### PR TITLE
Add anonymous RudderStack telemetry

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }}
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }} -X main.telemetryKey={{ if index .Env "TELEMETRY_KEY" }}{{ .Env.TELEMETRY_KEY }}{{ end }}
 
 archives:
   - id: dac-archives

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ BUILD_DIR ?= bin
 BUILD_SRC=.
 VERSION ?= dev
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "")
-GO_LDFLAGS=-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT)
+TELEMETRY_KEY ?=
+GO_LDFLAGS=-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.telemetryKey=$(TELEMETRY_KEY)
 
 NO_COLOR=\033[0m
 OK_COLOR=\033[32;01m

--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ make dev
 
 The main development commands are defined in the [`Makefile`](Makefile). Use `make` targets rather than ad-hoc `go build` or `npm run build` commands so frontend embedding and build flags stay consistent.
 
+## Telemetry
+
+DAC sends anonymous usage events to help us understand which commands are used and where they fail. Each event includes the command name, run duration, OS/architecture, DAC version, and an anonymous install ID stored at `~/.dac/telemetry.json`.
+
+We do not collect:
+
+- SQL queries, query results, or row counts
+- Dashboard or widget contents, names, or file paths
+- Connection names, hosts, credentials, project IDs, or dataset names
+- Any environment variables or shell history
+
+To disable telemetry, set either of these environment variables:
+
+```bash
+export TELEMETRY_OPTOUT=1
+# or the industry-standard:
+export DO_NOT_TRACK=1
+```
+
+Builds without a telemetry write key (the default for `make build`) are silent and send nothing.
+
 ## Documentation
 
 - Docs source: [`docs/`](docs)

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -9,6 +9,8 @@ import (
 	"github.com/bruin-data/dac/pkg/dashboard"
 	"github.com/bruin-data/dac/pkg/query"
 	"github.com/bruin-data/dac/pkg/server"
+	"github.com/bruin-data/dac/pkg/telemetry"
+	analytics "github.com/rudderlabs/analytics-go/v4"
 	"github.com/urfave/cli/v3"
 )
 
@@ -43,6 +45,9 @@ func checkCmd() *cli.Command {
 			if err != nil {
 				return err
 			}
+			telemetry.SendEvent("dashboards_loaded", analytics.Properties{
+				"count": len(dashboards),
+			})
 			if dashboards == nil {
 				fmt.Println("No dashboard files found in", dir)
 				return nil

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bruin-data/dac/pkg/telemetry"
+	analytics "github.com/rudderlabs/analytics-go/v4"
 	"github.com/urfave/cli/v3"
 )
 
@@ -50,6 +52,10 @@ func initCmd() *cli.Command {
 
 func runInit(target, template string, force bool) error {
 	template = normalizeInitTemplate(template)
+	telemetry.SetTemplateName(template)
+	telemetry.SendEvent("template_selected", analytics.Properties{
+		"template": template,
+	})
 	files, err := initTemplateFiles(template)
 	if err != nil {
 		return err

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/bruin-data/dac/pkg/telemetry"
+	analytics "github.com/rudderlabs/analytics-go/v4"
 	"github.com/urfave/cli/v3"
 )
 
@@ -19,6 +21,11 @@ func lsCmd() *cli.Command {
 			if err != nil {
 				return err
 			}
+			telemetry.SendEvent("dashboards_loaded", analytics.Properties{
+				"count":         len(dashboards),
+				"valid_count":   len(dashboards),
+				"invalid_count": 0,
+			})
 			if dashboards == nil {
 				fmt.Println("No dashboard files found in", cmd.String("dir"))
 				return nil

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -9,9 +9,12 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/bruin-data/dac/pkg/config"
 	"github.com/bruin-data/dac/pkg/dashboard"
 	"github.com/bruin-data/dac/pkg/query"
 	"github.com/bruin-data/dac/pkg/server"
+	"github.com/bruin-data/dac/pkg/telemetry"
+	analytics "github.com/rudderlabs/analytics-go/v4"
 	"github.com/urfave/cli/v3"
 )
 
@@ -50,24 +53,26 @@ func queryCmd() *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			dir := cmd.String("dir")
 
-			configFile, _, err := resolveConfig(cmd, dir)
+			configFile, cfg, err := resolveConfig(cmd, dir)
 			if err != nil {
 				return fmt.Errorf("config error: %w", err)
 			}
 
 			backend := newBackend(cmd, configFile)
 
-			var sql, connection string
+			var sql, connection, source string
 
 			dashboardName := cmd.String("dashboard")
 			widgetName := cmd.String("widget")
 
 			if dashboardName != "" && widgetName != "" {
+				source = "dashboard"
 				sql, connection, err = resolveWidgetQuery(dir, dashboardName, widgetName)
 				if err != nil {
 					return err
 				}
 			} else if cmd.String("file") != "" {
+				source = "file"
 				data, err := os.ReadFile(cmd.String("file"))
 				if err != nil {
 					return fmt.Errorf("reading SQL file: %w", err)
@@ -75,6 +80,7 @@ func queryCmd() *cli.Command {
 				sql = string(data)
 				connection = cmd.String("connection")
 			} else if cmd.Args().Len() > 0 {
+				source = "inline"
 				sql = strings.Join(cmd.Args().Slice(), " ")
 				connection = cmd.String("connection")
 			} else {
@@ -85,14 +91,41 @@ func queryCmd() *cli.Command {
 				return fmt.Errorf("no connection specified: use --connection or run against a dashboard widget")
 			}
 
-			result, err := backend.Execute(ctx, connection, sql)
-			if err != nil {
-				return fmt.Errorf("query failed: %w", err)
+			result, execErr := backend.Execute(ctx, connection, sql)
+			telemetry.SendEvent("query_executed", analytics.Properties{
+				"source":          source,
+				"output":          cmd.String("output"),
+				"connection_type": connectionType(cfg, cmd.Root().String("environment"), connection),
+				"success":         execErr == nil,
+			})
+			if execErr != nil {
+				return fmt.Errorf("query failed: %w", execErr)
 			}
 
 			return printResult(result, cmd.String("output"))
 		},
 	}
+}
+
+// connectionType resolves a connection name to its type bucket (e.g. "duckdb",
+// "bigquery") for telemetry. Returns empty string if not found — telemetry is
+// best-effort and never blocks the user's query.
+func connectionType(cfg *config.Config, environment, name string) string {
+	if cfg == nil {
+		return ""
+	}
+	env, err := cfg.GetEnvironment(environment)
+	if err != nil || env == nil {
+		return ""
+	}
+	for connType, conns := range env.Connections {
+		for _, c := range conns {
+			if c.Name == name {
+				return connType
+			}
+		}
+	}
+	return ""
 }
 
 // resolveWidgetQuery finds a widget in a dashboard and returns its resolved, templated SQL.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/fs"
 
+	"github.com/bruin-data/dac/pkg/telemetry"
 	"github.com/urfave/cli/v3"
 )
 
@@ -13,6 +14,15 @@ var frontendFS fs.FS
 type BuildInfo struct {
 	Version string
 	Commit  string
+}
+
+// withTelemetry attaches telemetry Before/After hooks to a command. Hooks are
+// attached per-subcommand (matching Bruin CLI) so they only fire when a real
+// command runs, not on `dac --help` or `dac --version`.
+func withTelemetry(c *cli.Command) *cli.Command {
+	c.Before = telemetry.BeforeCommand
+	c.After = telemetry.AfterCommand
+	return c
 }
 
 func NewApp(build BuildInfo) *cli.Command {
@@ -37,16 +47,16 @@ func NewApp(build BuildInfo) *cli.Command {
 			},
 		},
 		Commands: []*cli.Command{
-			initCmd(),
-			serveCmd(),
-			buildCmd(),
-			validateCmd(),
-			checkCmd(),
-			queryCmd(),
-			lsCmd(),
-			connectionsCmd(),
-			skillsCmd(),
-			exportCmd(),
+			withTelemetry(initCmd()),
+			withTelemetry(serveCmd()),
+			withTelemetry(buildCmd()),
+			withTelemetry(validateCmd()),
+			withTelemetry(checkCmd()),
+			withTelemetry(queryCmd()),
+			withTelemetry(lsCmd()),
+			withTelemetry(connectionsCmd()),
+			withTelemetry(skillsCmd()),
+			withTelemetry(exportCmd()),
 			versionCmd(build),
 		},
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -3,7 +3,10 @@ package cmd
 import (
 	"context"
 
+	"github.com/bruin-data/dac/pkg/dashboard"
 	"github.com/bruin-data/dac/pkg/server"
+	"github.com/bruin-data/dac/pkg/telemetry"
+	analytics "github.com/rudderlabs/analytics-go/v4"
 	"github.com/urfave/cli/v3"
 )
 
@@ -62,6 +65,16 @@ func serveCmd() *cli.Command {
 			if err != nil {
 				return err
 			}
+
+			dashboardCount := -1
+			if dashboards, err := dashboard.LoadDir(dir); err == nil {
+				dashboardCount = len(dashboards)
+			}
+			telemetry.SendEvent("serve_started", analytics.Properties{
+				"port":            int(cmd.Int("port")),
+				"template":        cmd.String("template"),
+				"dashboard_count": dashboardCount,
+			})
 
 			return srv.Start()
 		},

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/bruin-data/dac/pkg/dashboard"
+	"github.com/bruin-data/dac/pkg/telemetry"
+	analytics "github.com/rudderlabs/analytics-go/v4"
 	"github.com/urfave/cli/v3"
 )
 
@@ -19,21 +21,34 @@ func validateCmd() *cli.Command {
 				return err
 			}
 			if dashboards == nil {
+				telemetry.SendEvent("dashboards_loaded", analytics.Properties{
+					"count":         0,
+					"valid_count":   0,
+					"invalid_count": 0,
+				})
 				fmt.Println("No dashboard files found in", cmd.String("dir"))
 				return nil
 			}
 
-			hasErrors := false
+			validCount := 0
+			invalidCount := 0
 			for _, d := range dashboards {
 				if err := dashboard.Validate(d); err != nil {
 					fmt.Println(err)
-					hasErrors = true
+					invalidCount++
 				} else {
 					fmt.Printf("  %s: OK\n", d.Name)
+					validCount++
 				}
 			}
 
-			if hasErrors {
+			telemetry.SendEvent("dashboards_loaded", analytics.Properties{
+				"count":         len(dashboards),
+				"valid_count":   validCount,
+				"invalid_count": invalidCount,
+			})
+
+			if invalidCount > 0 {
 				return fmt.Errorf("validation failed")
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,16 @@ module github.com/bruin-data/dac
 go 1.25.0
 
 require (
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dop251/goja v0.0.0-20260305124333-6a7976c22267
 	github.com/dustin/go-humanize v1.0.1
 	github.com/evanw/esbuild v0.27.3
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/google/uuid v1.6.0
 	github.com/nikolalohinski/gonja/v2 v2.7.0
+	github.com/rudderlabs/analytics-go/v4 v4.2.3
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	github.com/spf13/afero v1.15.0
 	github.com/urfave/cli/v3 v3.7.0
 	github.com/wcharczuk/go-chart/v2 v2.1.2
 	golang.org/x/oauth2 v0.36.0
@@ -29,13 +33,14 @@ require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
+	github.com/grafana/jsonparser v0.0.0-20250908162026-5c2524e07b4c // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/segmentio/backo-go v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dop251/goja v0.0.0-20260305124333-6a7976c22267 h1:Kfmq11A6DLHD8XoOeljWjzWg/rrujeaLHWSb8u7+2qQ=
@@ -52,6 +54,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.14 h1:yh8ncqsbUY4shRD5dA
 github.com/googleapis/enterprise-certificate-proxy v0.3.14/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
 github.com/googleapis/gax-go/v2 v2.17.0 h1:RksgfBpxqff0EZkDWYuz9q/uWsTVz+kf43LsZ1J6SMc=
 github.com/googleapis/gax-go/v2 v2.17.0/go.mod h1:mzaqghpQp4JDh3HvADwrat+6M3MOIDp5YKHhb9PAgDY=
+github.com/grafana/jsonparser v0.0.0-20250908162026-5c2524e07b4c h1:qEltnsNJ0ZXbsvFbCNstFwMheGxpogecPAB5dvbbf00=
+github.com/grafana/jsonparser v0.0.0-20250908162026-5c2524e07b4c/go.mod h1:796sq+UcONnSlzA3RtlBZ+b/hrerkZXiEmO8oMjyRwY=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -75,10 +79,16 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rudderlabs/analytics-go/v4 v4.2.3 h1:klZCka0yVuLkQ+tnb3/OEwC2B9XuFaW+yf0RmQLSr4I=
+github.com/rudderlabs/analytics-go/v4 v4.2.3/go.mod h1:84tpNtjazdbgJ9hIx3A0JXP5ld0czi90yrsVTBh2RzM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/segmentio/backo-go v1.1.0 h1:cJIfHQUdmLsd8t9IXqf5J8SdrOMn9vMa7cIvOavHAhc=
+github.com/segmentio/backo-go v1.1.0/go.mod h1:ckenwdf+v/qbyhVdNPWHnqh2YdJBED1O9cidYyM5J18=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
+github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/main.go
+++ b/main.go
@@ -6,20 +6,33 @@ import (
 	"os"
 
 	"github.com/bruin-data/dac/cmd"
+	"github.com/bruin-data/dac/pkg/telemetry"
 )
 
 var (
-	version = "dev"
-	commit  = ""
+	version      = "dev"
+	commit       = ""
+	telemetryKey = ""
 )
 
 func main() {
+	if telemetryKey == "" {
+		telemetryKey = os.Getenv("TELEMETRY_KEY")
+	}
+	telemetry.TelemetryKey = telemetryKey
+	telemetry.OptOut = os.Getenv("TELEMETRY_OPTOUT") != "" || os.Getenv("DO_NOT_TRACK") != ""
+	telemetry.AppVersion = version
+	client := telemetry.Init()
+	defer client.Close()
+
 	buildInfo := cmd.BuildInfo{
 		Version: version,
 		Commit:  commit,
 	}
 
 	if err := cmd.Run(context.Background(), os.Args, frontendDistFS(), buildInfo); err != nil {
+		// Close manually since defer doesn't run on os.Exit.
+		client.Close()
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/pkg/telemetry/state.go
+++ b/pkg/telemetry/state.go
@@ -1,0 +1,78 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/afero"
+)
+
+const (
+	dacHomeDir             = ".dac"
+	telemetryStateFileName = "telemetry.json"
+)
+
+type installState struct {
+	InstallID      string `json:"install_id"`
+	InstallAt      string `json:"install_at"`
+	InstallVersion string `json:"install_version"`
+}
+
+func loadOrCreateInstallState(appVersion string) (installState, bool, error) {
+	fs := afero.NewOsFs()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return installState{}, false, err
+	}
+	return loadOrCreateInstallStateWithFS(fs, filepath.Join(home, dacHomeDir), appVersion, time.Now)
+}
+
+func loadOrCreateInstallStateWithFS(fs afero.Fs, homeDir string, appVersion string, now func() time.Time) (installState, bool, error) {
+	if err := fs.MkdirAll(homeDir, 0o755); err != nil {
+		return installState{}, false, err
+	}
+
+	statePath := filepath.Join(homeDir, telemetryStateFileName)
+	state, err := readInstallState(fs, statePath)
+	if err == nil && state.InstallID != "" {
+		return state, false, nil
+	}
+
+	newState := installState{
+		InstallID:      uuid.NewString(),
+		InstallAt:      now().UTC().Format(time.RFC3339),
+		InstallVersion: appVersion,
+	}
+
+	if err := writeInstallState(fs, statePath, newState); err != nil {
+		return newState, true, err
+	}
+
+	return newState, true, nil
+}
+
+func readInstallState(fs afero.Fs, path string) (installState, error) {
+	buf, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return installState{}, err
+	}
+
+	var state installState
+	if err := json.Unmarshal(buf, &state); err != nil {
+		return installState{}, err
+	}
+
+	return state, nil
+}
+
+func writeInstallState(fs afero.Fs, path string, state installState) error {
+	buf, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+
+	return afero.WriteFile(fs, path, buf, 0o600)
+}

--- a/pkg/telemetry/state_test.go
+++ b/pkg/telemetry/state_test.go
@@ -1,0 +1,52 @@
+package telemetry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+)
+
+func TestLoadOrCreateInstallStateWithFS_CreatesAndPersists(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	homeDir := "/home/test/.dac"
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	state, isNew, err := loadOrCreateInstallStateWithFS(fs, homeDir, "1.2.3", func() time.Time {
+		return now
+	})
+	if err != nil {
+		t.Fatalf("first load returned error: %v", err)
+	}
+	if !isNew {
+		t.Fatal("expected isNew=true on first load")
+	}
+	if state.InstallID == "" {
+		t.Fatal("expected non-empty install id")
+	}
+	if state.InstallVersion != "1.2.3" {
+		t.Fatalf("install version: got %q want %q", state.InstallVersion, "1.2.3")
+	}
+	if got, want := state.InstallAt, now.Format(time.RFC3339); got != want {
+		t.Fatalf("install at: got %q want %q", got, want)
+	}
+
+	state2, isNew2, err := loadOrCreateInstallStateWithFS(fs, homeDir, "9.9.9", time.Now)
+	if err != nil {
+		t.Fatalf("second load returned error: %v", err)
+	}
+	if isNew2 {
+		t.Fatal("expected isNew=false on second load")
+	}
+	if state2.InstallID != state.InstallID {
+		t.Fatalf("install id changed across loads: got %q want %q", state2.InstallID, state.InstallID)
+	}
+	if state2.InstallAt != state.InstallAt {
+		t.Fatalf("install at changed across loads: got %q want %q", state2.InstallAt, state.InstallAt)
+	}
+	if state2.InstallVersion != state.InstallVersion {
+		t.Fatalf("install version changed across loads: got %q want %q", state2.InstallVersion, state.InstallVersion)
+	}
+}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,0 +1,194 @@
+// Package telemetry sends anonymous usage events to RudderStack.
+//
+// Mirrors the architecture of bruin-data/bruin's pkg/telemetry so improvements
+// stay portable between the two CLIs. No PII is captured: only command names,
+// durations, OS/arch, version, and an anonymous install ID stored at
+// ~/.dac/telemetry.json. Disable with TELEMETRY_OPTOUT=1 or DO_NOT_TRACK=1.
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/denisbrodbeck/machineid"
+	"github.com/google/uuid"
+	analytics "github.com/rudderlabs/analytics-go/v4"
+	"github.com/urfave/cli/v3"
+)
+
+// silentLogger swallows all RudderStack client output so misconfigured builds
+// never leak "rudder INFO/ERROR" lines into a user's terminal.
+type silentLogger struct{}
+
+func (silentLogger) Logf(string, ...interface{})    {}
+func (silentLogger) Errorf(string, ...interface{}) {}
+
+const (
+	url          = "https://getbruinbumlky.dataplane.rudderstack.com"
+	startTimeKey = "telemetry_start"
+)
+
+type contextKey string
+
+var TelemetryKey string
+var (
+	OptOut       = false
+	AppVersion   = ""
+	RunID        = ""
+	TemplateName = "" // Stores template name for init command (protected by lock)
+	client       analytics.Client
+	lock         sync.Mutex
+	installID    string
+)
+
+// SetTemplateName stores the template name picked during `dac init` so the
+// AfterCommand hook can attach it to the command_end event.
+func SetTemplateName(name string) {
+	lock.Lock()
+	defer lock.Unlock()
+	TemplateName = name
+}
+
+func Init() io.Closer {
+	c, err := analytics.NewWithConfig(TelemetryKey, analytics.Config{
+		DataPlaneUrl: url,
+		Logger:       silentLogger{},
+	})
+	if err != nil {
+		// Fall back to a no-op closer; we never want telemetry init to break the CLI.
+		return io.NopCloser(nil)
+	}
+	client = c
+
+	if OptOut || TelemetryKey == "" {
+		return client
+	}
+
+	state, isNew, err := loadOrCreateInstallState(AppVersion)
+	if err != nil {
+		log.Printf("telemetry: failed to load install state: %v", err)
+		return client
+	}
+
+	lock.Lock()
+	installID = state.InstallID
+	lock.Unlock()
+
+	if isNew {
+		SendEvent("install", analytics.Properties{
+			"install_id":      state.InstallID,
+			"install_at":      state.InstallAt,
+			"install_version": state.InstallVersion,
+		})
+		SendEvent("first_run", analytics.Properties{
+			"install_id":      state.InstallID,
+			"install_at":      state.InstallAt,
+			"install_version": state.InstallVersion,
+		})
+	}
+
+	return client
+}
+
+func SendEvent(event string, properties analytics.Properties) {
+	lock.Lock()
+	defer lock.Unlock()
+	if RunID == "" {
+		RunID = uuid.New().String()
+	}
+	if OptOut || TelemetryKey == "" {
+		return
+	}
+
+	if properties == nil {
+		properties = analytics.Properties{}
+	}
+	if installID != "" {
+		if _, ok := properties["install_id"]; !ok {
+			properties["install_id"] = installID
+		}
+	}
+	properties["run_id"] = RunID
+
+	id := installID
+	if id == "" {
+		id, _ = machineid.ID()
+	}
+	if id == "" {
+		id = RunID
+	}
+
+	if client == nil {
+		return
+	}
+
+	_ = client.Enqueue(analytics.Track{
+		AnonymousId:       id,
+		Event:             event,
+		OriginalTimestamp: time.Now().In(time.UTC),
+		Context: &analytics.Context{
+			App: analytics.AppInfo{
+				Name:    "DAC CLI",
+				Version: AppVersion,
+			},
+			OS: analytics.OSInfo{
+				Name: runtime.GOOS + " " + runtime.GOARCH,
+			},
+		},
+		Properties: properties,
+	})
+}
+
+func BeforeCommand(ctx context.Context, c *cli.Command) (context.Context, error) {
+	start := time.Now()
+	ctx = context.WithValue(ctx, contextKey(startTimeKey), start)
+	SendEvent("command_start", analytics.Properties{
+		"command": c.Name,
+	})
+	return ctx, nil
+}
+
+func AfterCommand(ctx context.Context, cmd *cli.Command) error {
+	start := ctx.Value(contextKey(startTimeKey))
+	durationMs := int64(-1)
+	if start != nil {
+		durationMs = time.Since(start.(time.Time)).Milliseconds()
+	}
+	properties := analytics.Properties{
+		"command":     cmd.Name,
+		"duration_ms": durationMs,
+	}
+
+	lock.Lock()
+	if TemplateName != "" && cmd.Name == "init" {
+		properties["template_name"] = TemplateName
+		TemplateName = ""
+	}
+	lock.Unlock()
+
+	SendEvent("command_end", properties)
+	return nil
+}
+
+func ErrorCommand(ctx context.Context, cmd *cli.Command, err error) error {
+	if err == nil {
+		return nil
+	}
+	fmt.Println(err)
+	start := ctx.Value(contextKey(startTimeKey))
+	startTime, ok := start.(time.Time)
+	if !ok {
+		return nil
+	}
+
+	SendEvent("command_error", analytics.Properties{
+		"command":     cmd.Name,
+		"duration_ms": time.Since(startTime).Milliseconds(),
+	})
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds anonymous, opt-out usage telemetry mirroring the bruin-data/bruin `pkg/telemetry` implementation so events from both CLIs land in the same RudderStack workspace and improvements stay portable. State persists at `~/.dac/telemetry.json`. Tracks command lifecycle (`install`, `first_run`, `command_start`/`end`/`error`, `template_selected`) plus DAC-specific events (`serve_started`, `query_executed`, `dashboards_loaded`) — metadata only, never SQL, results, file paths, dashboard names, or connection details. Disable with `TELEMETRY_OPTOUT=1` or `DO_NOT_TRACK=1`; the write key is injected at build time via `-X main.telemetryKey=…` and `Makefile`/`.goreleaser.yaml` are wired to read `TELEMETRY_KEY` from the environment.

## Testing

- [x] `make test` (telemetry package + full suite green)
- [x] `make build`
- [x] Manual smoke test: built with real key, confirmed `install`, `first_run`, `command_start`, `dashboards_loaded`, `command_end` events arrive in RudderStack live events feed; second run reuses install_id; `TELEMETRY_OPTOUT=1` and `DO_NOT_TRACK=1` silence all sends; no-key dev builds are silent

## Checklist

- [x] docs updated (README telemetry section)
- [ ] examples updated if the authoring model changed (n/a)
- [ ] screenshots or recordings attached for UI changes (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)