### PR TITLE
[codex] Add npm minimum release age

### DIFF
--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## Summary
- Add project-level `.npmrc` files for the docs and frontend npm package roots.
- Configure `min-release-age=7` so npm waits at least 7 days before installing newly published dependency versions.

## Validation
- Verified both npm package roots read back `min-release-age=7` with `npm config get min-release-age --location=project`.
- Confirmed only `docs/.npmrc` and `frontend/.npmrc` are included in this PR.