### PR TITLE
docs: document multi-select filter SQL usage

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -708,6 +708,13 @@ WHERE created_at >= '{{ filters.date_range.start }}'
 {{ filters.search }}
 ```
 
+**Multi-select values (`multiple: true`)** — value is a list, render with `join` and guard the empty case:
+```sql
+{% if filters.status and filters.status | length > 0 %}
+  AND status IN ('{{ filters.status | join("','") }}')
+{% endif %}
+```
+
 ---
 
 ## TSX Dashboards (Code-Based)

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -113,6 +113,14 @@ Supported filter types:
 
 Date range presets include `today`, `yesterday`, `last_7_days`, `last_30_days`, `last_90_days`, `this_month`, `last_month`, `this_quarter`, `this_year`, `year_to_date`, and `all_time`.
 
+Select filters support `multiple: true` for multi-select. The value is a list — render with `join` in Jinja and guard the empty case:
+
+```sql
+{% if filters.status and filters.status | length > 0 %}
+  AND status IN ('{{ filters.status | join("','") }}')
+{% endif %}
+```
+
 ## Named Queries
 
 Use named queries when multiple widgets share the same SQL or semantic query.

--- a/docs/dashboards/filters.md
+++ b/docs/dashboards/filters.md
@@ -111,6 +111,15 @@ WHERE region = '{{ filters.region }}'
 {% endif %}
 ```
 
+Multi-select (`multiple: true`) — the value is a list, render it with `join`:
+
+```sql
+SELECT * FROM orders
+{% if filters.status and filters.status | length > 0 %}
+WHERE status IN ('{{ filters.status | join("','") }}')
+{% endif %}
+```
+
 ### Date Range Filters
 
 Date range filters provide `.start` and `.end` properties:


### PR DESCRIPTION
## Summary

The filters reference already documents the `multiple: true` filter spec, and `multiple` is accepted by the JSON schema, the Go `Filter` struct, and the TS type. But the "Using Filters in Queries" section in `docs/dashboards/filters.md` only shows single-value Jinja patterns — there was no example of how to interpolate a multi-select array into SQL. This PR adds the `IN (...)` + length-guard pattern alongside the existing single-value examples.

## Follow-up implementation ask (not in this PR)

The doc now describes how multi-select **should** work end-to-end, but the runtime doesn't honor `multiple: true` yet. To make the documented behavior real, a dev needs to:

1. **Frontend control** — `frontend/src/themes/bruin/FilterBar.tsx` currently renders all `type: select` filters as a single-select. When `filter.multiple === true`, render a multi-select control and store the value as an array in the filter state.
2. **Query-layer serialization** — filter values flow through `pkg/template.Render` as `map[string]any` (see `pkg/template/template.go:13`). The Jinja engine in use must accept a list value and support the `| join("','")` and `| length` filters used in the new doc example. Verify with a test in `pkg/template/template_test.go`; if `join`/`length` aren't supported, add them.
3. **Default value handling** — `pkg/dashboard/model.go:62` types `Default` as `any`, so an array default already round-trips through YAML. Confirm the frontend seeds initial state from an array default correctly.

No PRD — the spec is small enough to live in the doc + this PR description.

## Test plan

- [ ] `make build` succeeds (docs-only change, but sanity check)
- [ ] Render `docs/dashboards/filters.md` locally and confirm the new code block displays
- [ ] After follow-up implementation: a dashboard with `multiple: true` renders a multi-select control and the documented `IN (...)` Jinja pattern executes against a real connection