### PR TITLE
[codex] Fix production telemetry release config

### DIFF
--- a/.github/workflows/edge-release.yml
+++ b/.github/workflows/edge-release.yml
@@ -60,6 +60,16 @@ jobs:
           \`\`\`
           EOF
 
+      - name: Verify telemetry key
+        shell: bash
+        env:
+          TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}
+        run: |
+          if [ -z "$TELEMETRY_KEY" ]; then
+            echo "TELEMETRY_KEY repository secret must be configured for edge releases." >&2
+            exit 1
+          fi
+
       - name: Release edge build
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -68,3 +78,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GORELEASER_CURRENT_TAG: ${{ steps.edge.outputs.tag }}
+          TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,16 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
+      - name: Verify telemetry key
+        shell: bash
+        env:
+          TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}
+        run: |
+          if [ -z "$TELEMETRY_KEY" ]; then
+            echo "TELEMETRY_KEY repository secret must be configured for production releases." >&2
+            exit 1
+          fi
+
       - name: Release
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -36,3 +46,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}


### PR DESCRIPTION
## Summary

Production and edge release workflows now pass the `TELEMETRY_KEY` repository secret into GoReleaser and fail early when it is missing. This fixes the release path where published binaries were compiled with an empty RudderStack write key, disabling telemetry events in production builds.

## Testing

- [x] `make test`
- [x] `make build TELEMETRY_KEY=dac_dummy_telemetry_key_for_build_check VERSION=telemetry-check`
- [x] `goreleaser check` and verified the dummy key was linked into `bin/dac`

## Checklist

- [ ] docs updated if behavior changed (not applicable)
- [ ] examples updated if the authoring model changed (not applicable)
- [ ] screenshots or recordings attached for UI changes (not applicable)