### PR TITLE
[codex] Add missing chart types

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -588,6 +588,65 @@ Positive values shown in one color, negative in another. Bars float to show cumu
 
 Horizontal chart showing range between two values per category.
 
+#### Gauge
+
+```yaml
+- name: Revenue vs Target
+  type: chart
+  chart: gauge
+  sql: SELECT current_revenue, revenue_target FROM kpi
+  value: current_revenue        # REQUIRED: current value column (first row)
+  target: revenue_target        # Optional: target/max column (default 100)
+  col: 3
+```
+
+Semi-circular progress gauge for KPI-vs-target. Reads the first row.
+
+#### Treemap
+
+```yaml
+- name: Revenue by Category
+  type: chart
+  chart: treemap
+  sql: SELECT category, revenue FROM sales
+  label: category               # REQUIRED: label column
+  value: revenue                # REQUIRED: size column
+  col: 6
+```
+
+Rectangular hierarchy showing part-to-whole proportions. Use instead of pie when slices exceed ~7.
+
+#### Radar
+
+```yaml
+- name: Product Scorecard
+  type: chart
+  chart: radar
+  sql: SELECT attribute, product_a, product_b FROM scorecard
+  x: attribute                  # REQUIRED: axis category column
+  y: [product_a, product_b]     # REQUIRED: one or more series to compare
+  col: 6
+```
+
+Multi-axis comparison across a small number of entities.
+
+#### Candlestick
+
+```yaml
+- name: Daily Price
+  type: chart
+  chart: candlestick
+  sql: SELECT date, open, high, low, close FROM ohlc ORDER BY date
+  x: date                       # REQUIRED: time column
+  open: open                    # REQUIRED
+  high: high                    # REQUIRED
+  low: low                      # REQUIRED
+  close: close                  # REQUIRED
+  col: 12
+```
+
+OHLC chart for financial/pricing data. Green when close ≥ open, red otherwise.
+
 ### Table Widget
 
 Data table with optional column configuration.
@@ -1289,7 +1348,7 @@ rows:
 | Type | Required Fields | Query Source | Description |
 |------|----------------|--------------|-------------|
 | `metric` | `metric:` ref OR `column` + query | Declarative or SQL | Single KPI number card |
-| `chart` | `dimension` + `metrics` OR `chart` + x/y + query | Declarative or SQL | Visualization (17 chart types) |
+| `chart` | `dimension` + `metrics` OR `chart` + x/y + query | Declarative or SQL | Visualization (21 chart types) |
 | `table` | — | SQL | Data table with optional column config |
 | `text` | `content` | None | Markdown/text content |
 | `divider` | — | None | Horizontal separator line |
@@ -1316,6 +1375,10 @@ rows:
 | `waterfall` | `x`, `y` | | Waterfall chart |
 | `xmr` | `x`, `y` | `yMin`, `yMax` | Control chart with limits |
 | `dumbbell` | `x`, `y` (2 fields) | | Horizontal range comparison |
+| `gauge` | `value` | `target` | Semi-circular KPI-vs-target gauge (uses first row) |
+| `treemap` | `label`, `value` | | Rectangular part-to-whole hierarchy |
+| `radar` | `x`, `y` | | Polar/spider chart for multi-metric comparison |
+| `candlestick` | `x`, `open`, `high`, `low`, `close` | | OHLC chart |
 
 ---
 

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -57,7 +57,7 @@ Metric-specific fields:
 
 ## Chart
 
-Charts visualize one or more series. DAC supports line, bar, area, pie, scatter, bubble, combo, histogram, boxplot, funnel, sankey, heatmap, calendar, sparkline, waterfall, XMR, and dumbbell charts.
+Charts visualize one or more series. DAC supports line, bar, area, pie, scatter, bubble, combo, histogram, boxplot, funnel, sankey, heatmap, calendar, sparkline, waterfall, XMR, dumbbell, gauge, treemap, radar, and candlestick charts.
 
 SQL-backed example:
 
@@ -97,8 +97,13 @@ Common chart fields:
 | `chart` | string | Chart type |
 | `x` | string | X-axis column for SQL-backed charts |
 | `y` | string[] | Y-axis columns for SQL-backed charts |
-| `label` | string | Label column for pie and funnel charts |
-| `value` | string | Value column for pie, funnel, heatmap, and calendar charts |
+| `label` | string | Label column for pie, funnel, and treemap charts |
+| `value` | string | Value column for pie, funnel, heatmap, calendar, treemap, and gauge charts |
+| `target` | string | Target/max column for gauge charts (also sankey target node) |
+| `open` | string | Open column for candlestick charts |
+| `high` | string | High column for candlestick charts |
+| `low` | string | Low column for candlestick charts |
+| `close` | string | Close column for candlestick charts |
 | `dimension` | string | Semantic dimension name |
 | `granularity` | string | Semantic time grain for `dimension` |
 | `metrics` | string[] | Semantic metric names |

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ rows:
 
 
 - **Two authoring formats.** YAML for declarative dashboards. [TSX](/dashboards/tsx) when you need loops, variables, conditionals, or queries that resolve at load time to drive layout.
-- **17 chart types.** Line, bar, area, pie, scatter, bubble, combo, histogram, boxplot, funnel, sankey, heatmap, calendar, sparkline, waterfall, XMR, dumbbell — plus metrics, tables, text, images, and dividers.
+- **21 chart types.** Line, bar, area, pie, scatter, bubble, combo, histogram, boxplot, funnel, sankey, heatmap, calendar, sparkline, waterfall, XMR, dumbbell, gauge, treemap, radar, candlestick — plus metrics, tables, text, images, and dividers.
 - **[Semantic layer](/dashboards/semantic-layer).** Define metrics and dimensions once in `semantic/`, reference them from any widget. DAC generates the SQL.
 - **Live reload.** Edit the file, save, see the change. No restart, no rebuild.
 - **Static export.** `dac build` produces self-contained HTML with query results baked in. Deploy to S3, GitHub Pages, anywhere — no runtime server needed.

--- a/examples/basic-yaml/.gitignore
+++ b/examples/basic-yaml/.gitignore
@@ -1,0 +1,1 @@
+.bruin.yml

--- a/examples/basic-yaml/dashboards/new-charts.yml
+++ b/examples/basic-yaml/dashboards/new-charts.yml
@@ -1,0 +1,89 @@
+schema: https://getbruin.com/schemas/dac/dashboard/v1
+name: New Charts Showcase
+description: Validates the four new chart types (gauge, treemap, radar, candlestick)
+connection: local_duckdb
+
+rows:
+  # Gauge + Treemap
+  - widgets:
+      - name: Revenue vs Target
+        type: chart
+        chart: gauge
+        col: 4
+        sql: |
+          SELECT
+            SUM(amount)::INTEGER AS current,
+            15000000 AS target
+          FROM sales
+        value: current
+        target: target
+
+      - name: Revenue by Region (Treemap)
+        type: chart
+        chart: treemap
+        col: 8
+        sql: |
+          SELECT region, SUM(amount)::INTEGER AS revenue
+          FROM sales
+          GROUP BY region
+          ORDER BY revenue DESC
+        label: region
+        value: revenue
+
+  # Radar
+  - widgets:
+      - name: Order Status — H1 vs H2
+        type: chart
+        chart: radar
+        col: 6
+        sql: |
+          SELECT
+            status,
+            COUNT(*) FILTER (WHERE created_at < '2025-07-01') AS h1,
+            COUNT(*) FILTER (WHERE created_at >= '2025-07-01') AS h2
+          FROM orders
+          WHERE status IS NOT NULL
+          GROUP BY status
+          ORDER BY status
+        x: status
+        y: [h1, h2]
+
+      - name: Channel Mix by Region
+        type: chart
+        chart: radar
+        col: 6
+        sql: |
+          SELECT
+            region,
+            SUM(amount) FILTER (WHERE channel = 'direct')::INTEGER AS direct,
+            SUM(amount) FILTER (WHERE channel = 'retail')::INTEGER AS retail,
+            SUM(amount) FILTER (WHERE channel = 'partner')::INTEGER AS partner
+          FROM sales
+          GROUP BY region
+          ORDER BY region
+        x: region
+        y: [direct, retail, partner]
+
+  # Candlestick
+  - widgets:
+      - name: Daily Order Amount (OHLC)
+        type: chart
+        chart: candlestick
+        col: 12
+        sql: |
+          SELECT
+            STRFTIME(created_at, '%Y-%m-%d') AS date,
+            FIRST(amount ORDER BY id)::DOUBLE AS open,
+            MAX(amount)::DOUBLE AS high,
+            MIN(amount)::DOUBLE AS low,
+            LAST(amount ORDER BY id)::DOUBLE AS close
+          FROM orders
+          WHERE created_at IS NOT NULL
+          GROUP BY 1
+          ORDER BY 1
+          LIMIT 30
+        x: date
+        open: open
+        high: high
+        low: low
+        close: close

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -3,8 +3,11 @@ import {
   LineChart, Line, BarChart, Bar, AreaChart, Area, PieChart, Pie, Cell,
   ScatterChart, Scatter, ZAxis,
   ComposedChart, FunnelChart, Funnel, LabelList, Sankey,
+  Treemap,
+  RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
   XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
 } from "recharts";
+import type { TreemapNode } from "recharts";
 import type { Widget, WidgetData } from "../../types/dashboard";
 import { useTokens } from "../../themes/TemplateProvider";
 
@@ -494,6 +497,256 @@ function DumbbellChart({
   );
 }
 
+// --- Treemap rendering ---
+
+function getHexLuminance(hex: string): number | null {
+  const match = hex.match(/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i);
+  if (!match) return null;
+
+  const [, r, g, b] = match;
+  const channels = [r, g, b].map((part) => {
+    const value = parseInt(part, 16) / 255;
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function getTreemapTextColor(fill: string): string {
+  const luminance = getHexLuminance(fill);
+  if (luminance === null) return "var(--dac-text-primary)";
+  return luminance > 0.32 ? "#0A0D14" : "#FFFFFF";
+}
+
+function truncateTreemapLabel(label: string, width: number, fontSize: number): string {
+  const maxChars = Math.floor((width - 16) / (fontSize * 0.58));
+  if (maxChars <= 1) return "";
+  if (label.length <= maxChars) return label;
+  return `${label.slice(0, Math.max(1, maxChars - 3))}...`;
+}
+
+function TreemapCell(node: TreemapNode) {
+  const fill = typeof node.fill === "string" ? node.fill : "var(--dac-accent)";
+  const textColor = getTreemapTextColor(fill);
+  const canShowLabel = node.width >= 42 && node.height >= 24;
+  const fontSize = node.width >= 150 && node.height >= 56 ? 12 : 11;
+  const label = canShowLabel ? truncateTreemapLabel(node.name, node.width, fontSize) : "";
+
+  return (
+    <g>
+      <rect
+        x={node.x}
+        y={node.y}
+        width={node.width}
+        height={node.height}
+        fill={fill}
+        stroke="var(--dac-surface)"
+        strokeWidth={1}
+      />
+      {label && (
+        <text
+          x={node.x + 8}
+          y={node.y + 16}
+          fill={textColor}
+          stroke="none"
+          fontFamily='"Geist", system-ui'
+          fontSize={fontSize}
+          fontWeight={500}
+          dominantBaseline="middle"
+          opacity={0.92}
+          style={{ pointerEvents: "none" }}
+        >
+          {label}
+        </text>
+      )}
+    </g>
+  );
+}
+
+// --- Gauge rendering ---
+
+function GaugeChart({
+  current,
+  target,
+  colors,
+  axisColor,
+  gridColor,
+}: {
+  current: number;
+  target: number;
+  colors: string[];
+  axisColor: string;
+  gridColor: string;
+}) {
+  const safeTarget = target > 0 ? target : 1;
+  const ratio = Math.max(0, Math.min(1, current / safeTarget));
+
+  const width = 240;
+  const height = 150;
+  const cx = width / 2;
+  const cy = height - 16;
+  const r = 90;
+  const stroke = 14;
+
+  // Semi-circle from 180° (left) to 0° (right)
+  const polarToCart = (deg: number) => {
+    const rad = (deg * Math.PI) / 180;
+    return { x: cx + r * Math.cos(rad), y: cy - r * Math.sin(rad) };
+  };
+
+  const bgPath = (() => {
+    const a = polarToCart(180);
+    const b = polarToCart(0);
+    return `M ${a.x} ${a.y} A ${r} ${r} 0 0 1 ${b.x} ${b.y}`;
+  })();
+
+  const fgPath = (() => {
+    const endDeg = 180 - ratio * 180;
+    const a = polarToCart(180);
+    const b = polarToCart(endDeg);
+    return `M ${a.x} ${a.y} A ${r} ${r} 0 0 1 ${b.x} ${b.y}`;
+  })();
+
+  const pct = Math.round(ratio * 100);
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${width} ${height}`} style={{ maxHeight: 240 }}>
+      <path d={bgPath} stroke={gridColor} strokeWidth={stroke} strokeLinecap="round" fill="none" opacity={0.4} />
+      {ratio > 0 && (
+        <path d={fgPath} stroke={colors[0]} strokeWidth={stroke} strokeLinecap="round" fill="none" />
+      )}
+      <text x={cx} y={cy - 18} textAnchor="middle"
+        fill="var(--dac-text-primary)" fontSize={26} fontWeight={600} fontFamily='"Geist", system-ui'>
+        {formatTooltipValue(current)}
+      </text>
+      <text x={cx} y={cy + 2} textAnchor="middle"
+        fill={axisColor} fontSize={11} fontFamily='"Geist", system-ui'>
+        {pct}% of {formatTooltipValue(safeTarget)}
+      </text>
+    </svg>
+  );
+}
+
+// --- Candlestick rendering ---
+
+function CandlestickChart({
+  data,
+  xKey,
+  openKey,
+  highKey,
+  lowKey,
+  closeKey,
+  colors,
+  axisColor,
+  gridColor,
+}: {
+  data: Record<string, unknown>[];
+  xKey: string;
+  openKey: string;
+  highKey: string;
+  lowKey: string;
+  closeKey: string;
+  colors: string[];
+  axisColor: string;
+  gridColor: string;
+}) {
+  const [hover, setHover] = useState<{
+    x: number; y: number; label: string;
+    open: number; high: number; low: number; close: number;
+  } | null>(null);
+
+  const items = useMemo(() => data.map((d) => ({
+    label: String(d[xKey]),
+    open: Number(d[openKey]) || 0,
+    high: Number(d[highKey]) || 0,
+    low: Number(d[lowKey]) || 0,
+    close: Number(d[closeKey]) || 0,
+  })), [data, xKey, openKey, highKey, lowKey, closeKey]);
+
+  if (items.length === 0) return null;
+
+  const allVals = items.flatMap((i) => [i.high, i.low, i.open, i.close]);
+  const dataMin = Math.min(...allVals);
+  const dataMax = Math.max(...allVals);
+  const pad = (dataMax - dataMin) * 0.05 || 1;
+  const yMin = dataMin - pad;
+  const yMax = dataMax + pad;
+
+  const width = 600;
+  const height = 240;
+  const padL = 44;
+  const padR = 8;
+  const padT = 8;
+  const padB = 28;
+  const plotW = width - padL - padR;
+  const plotH = height - padT - padB;
+
+  const yToPx = (v: number) => padT + plotH - ((v - yMin) / (yMax - yMin)) * plotH;
+  const step = plotW / items.length;
+  const bodyW = Math.max(2, Math.min(16, step * 0.6));
+
+  const upColor = colors[0];
+  const downColor = colors[3] ?? "#DC2626";
+
+  const tickCount = 4;
+  const yTicks = Array.from({ length: tickCount + 1 }, (_, i) => yMin + (i / tickCount) * (yMax - yMin));
+
+  const labelStride = Math.max(1, Math.ceil(items.length / 8));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${width} ${height}`} style={{ maxHeight: 240 }}
+      onMouseLeave={() => setHover(null)}>
+      {yTicks.map((v, i) => {
+        const y = yToPx(v);
+        return (
+          <g key={i}>
+            <line x1={padL} x2={width - padR} y1={y} y2={y}
+              stroke={gridColor} strokeOpacity={0.5} strokeDasharray="3 3" />
+            <text x={padL - 6} y={y + 3} textAnchor="end"
+              fill={axisColor} fontSize={11} fontFamily='"Geist", system-ui'>
+              {formatYTick(v)}
+            </text>
+          </g>
+        );
+      })}
+      {items.map((item, i) => {
+        const cx = padL + i * step + step / 2;
+        const yH = yToPx(item.high);
+        const yL = yToPx(item.low);
+        const yO = yToPx(item.open);
+        const yC = yToPx(item.close);
+        const up = item.close >= item.open;
+        const color = up ? upColor : downColor;
+        const top = Math.min(yO, yC);
+        const h = Math.max(1, Math.abs(yC - yO));
+        return (
+          <g key={i}
+            onMouseEnter={() => setHover({ x: cx, y: (yH + yL) / 2, ...item })}
+            onMouseLeave={() => setHover(null)}>
+            <line x1={cx} x2={cx} y1={yH} y2={yL} stroke={color} strokeWidth={1} />
+            <rect x={cx - bodyW / 2} y={top} width={bodyW} height={h}
+              fill={color} stroke={color} />
+            {i % labelStride === 0 && (
+              <text x={cx} y={height - padB + 14} textAnchor="middle"
+                fill={axisColor} fontSize={10} fontFamily='"Geist", system-ui'>
+                {formatAxisTick(item.label)}
+              </text>
+            )}
+          </g>
+        );
+      })}
+      {hover && (
+        <SvgTooltip x={hover.x + bodyW / 2} y={hover.y}
+          lines={[
+            formatAxisTick(hover.label),
+            `O ${formatTooltipValue(hover.open)}  H ${formatTooltipValue(hover.high)}`,
+            `L ${formatTooltipValue(hover.low)}  C ${formatTooltipValue(hover.close)}`,
+          ]} />
+      )}
+    </svg>
+  );
+}
+
 // --- Main chart component ---
 
 export function ChartWidget({ widget, data }: Props) {
@@ -881,6 +1134,89 @@ export function ChartWidget({ widget, data }: Props) {
           data={chartData}
           xKey={widget.x!}
           yFields={widget.y ?? []}
+          colors={colors}
+          axisColor={axisColor}
+          gridColor={gridColor}
+        />
+      );
+
+    case "gauge": {
+      const valueKey = widget.value || "value";
+      const targetKey = widget.target;
+      const first = chartData[0] ?? {};
+      const current = Number(first[valueKey]) || 0;
+      const target = targetKey ? Number(first[targetKey]) || 0 : 100;
+      return (
+        <GaugeChart
+          current={current}
+          target={target}
+          colors={colors}
+          axisColor={axisColor}
+          gridColor={gridColor}
+        />
+      );
+    }
+
+    case "treemap": {
+      const labelKey = widget.label || "label";
+      const valueKey = widget.value || "value";
+      const tmData = chartData.map((d, i) => ({
+        name: String(d[labelKey]),
+        size: Number(d[valueKey]) || 0,
+        fill: colors[i % colors.length],
+      }));
+      return (
+        <ResponsiveContainer width="100%" height={240}>
+          <Treemap
+            data={tmData}
+            dataKey="size"
+            nameKey="name"
+            stroke="var(--dac-surface)"
+            content={TreemapCell}
+            isAnimationActive={false}
+          >
+            <Tooltip content={<CustomTooltip />} />
+          </Treemap>
+        </ResponsiveContainer>
+      );
+    }
+
+    case "radar": {
+      const yFields = widget.y ?? [];
+      return (
+        <ResponsiveContainer width="100%" height={240}>
+          <RadarChart data={chartData} margin={{ top: 8, right: 24, bottom: 8, left: 24 }}>
+            <PolarGrid stroke={gridColor} strokeOpacity={0.5} />
+            <PolarAngleAxis dataKey={widget.x} tick={{ ...AXIS_STYLE, fill: axisColor }} />
+            <PolarRadiusAxis tick={{ ...AXIS_STYLE, fill: axisColor }} axisLine={false} tickFormatter={formatYTick} />
+            <Tooltip content={<CustomTooltip />} />
+            {yFields.length > 1 && <Legend wrapperStyle={AXIS_STYLE} iconSize={7} />}
+            {yFields.map((field, i) => (
+              <Radar
+                key={field}
+                name={field}
+                dataKey={field}
+                stroke={colors[i % colors.length]}
+                fill={colors[i % colors.length]}
+                fillOpacity={0.15}
+                strokeWidth={1.5}
+                isAnimationActive={false}
+              />
+            ))}
+          </RadarChart>
+        </ResponsiveContainer>
+      );
+    }
+
+    case "candlestick":
+      return (
+        <CandlestickChart
+          data={chartData}
+          xKey={widget.x!}
+          openKey={widget.open || "open"}
+          highKey={widget.high || "high"}
+          lowKey={widget.low || "low"}
+          closeKey={widget.close || "close"}
           colors={colors}
           axisColor={axisColor}
           gridColor={gridColor}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -83,7 +83,7 @@ export interface Widget {
   format?: string;
 
   // Chart
-  chart?: "line" | "bar" | "area" | "pie" | "scatter" | "bubble" | "combo" | "histogram" | "boxplot" | "funnel" | "sankey" | "heatmap" | "calendar" | "sparkline" | "waterfall" | "xmr" | "dumbbell";
+  chart?: "line" | "bar" | "area" | "pie" | "scatter" | "bubble" | "combo" | "histogram" | "boxplot" | "funnel" | "sankey" | "heatmap" | "calendar" | "sparkline" | "waterfall" | "xmr" | "dumbbell" | "gauge" | "treemap" | "radar" | "candlestick";
   x?: string;
   y?: string[];
   label?: string;
@@ -91,11 +91,15 @@ export interface Widget {
   stacked?: boolean;
   size?: string;       // bubble: size dimension
   source?: string;     // sankey: source column
-  target?: string;     // sankey: target column
+  target?: string;     // sankey: target column / gauge: target (max) column
   bins?: number;       // histogram: number of bins
   lines?: string[];    // combo: which y series are lines
   yMin?: string;       // xmr: min control limit column
   yMax?: string;       // xmr: max control limit column
+  open?: string;       // candlestick: open column
+  high?: string;       // candlestick: high column
+  low?: string;        // candlestick: low column
+  close?: string;      // candlestick: close column
 
   // Table
   columns?: TableColumn[];

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -159,19 +159,23 @@ type Widget struct {
 	Limit       int                    `yaml:"limit,omitempty" json:"limit,omitempty"` // LIMIT for dimensional queries
 
 	// Chart fields
-	Chart   string   `yaml:"chart,omitempty" json:"chart,omitempty"` // line, bar, area, pie, scatter, bubble, combo, histogram, boxplot, funnel, sankey, heatmap, calendar, sparkline, waterfall, xmr, dumbbell
+	Chart   string   `yaml:"chart,omitempty" json:"chart,omitempty"` // line, bar, area, pie, scatter, bubble, combo, histogram, boxplot, funnel, sankey, heatmap, calendar, sparkline, waterfall, xmr, dumbbell, gauge, treemap, radar, candlestick
 	X       string   `yaml:"x,omitempty" json:"x,omitempty"`
 	Y       []string `yaml:"y,omitempty" json:"y,omitempty"`
-	Label   string   `yaml:"label,omitempty" json:"label,omitempty"`     // for pie/funnel
-	Value   string   `yaml:"value,omitempty" json:"value,omitempty"`     // for pie/funnel/heatmap/calendar
+	Label   string   `yaml:"label,omitempty" json:"label,omitempty"`     // for pie/funnel/treemap
+	Value   string   `yaml:"value,omitempty" json:"value,omitempty"`     // for pie/funnel/heatmap/calendar/treemap/gauge
 	Stacked bool     `yaml:"stacked,omitempty" json:"stacked,omitempty"` // for bar/area charts
 	Size    string   `yaml:"size,omitempty" json:"size,omitempty"`       // bubble: size dimension column
 	Source  string   `yaml:"source,omitempty" json:"source,omitempty"`   // sankey: source column
-	Target  string   `yaml:"target,omitempty" json:"target,omitempty"`   // sankey: target column
+	Target  string   `yaml:"target,omitempty" json:"target,omitempty"`   // sankey: target column, gauge: target (max) column
 	Bins    int      `yaml:"bins,omitempty" json:"bins,omitempty"`       // histogram: number of bins
 	Lines   []string `yaml:"lines,omitempty" json:"lines,omitempty"`     // combo: which y series render as lines
 	YMin    string   `yaml:"yMin,omitempty" json:"yMin,omitempty"`       // xmr: min control limit column
 	YMax    string   `yaml:"yMax,omitempty" json:"yMax,omitempty"`       // xmr: max control limit column
+	Open    string   `yaml:"open,omitempty" json:"open,omitempty"`       // candlestick: open price column
+	High    string   `yaml:"high,omitempty" json:"high,omitempty"`       // candlestick: high price column
+	Low     string   `yaml:"low,omitempty" json:"low,omitempty"`         // candlestick: low price column
+	Close   string   `yaml:"close,omitempty" json:"close,omitempty"`     // candlestick: close price column
 
 	// Table fields
 	Columns []TableColumn `yaml:"columns,omitempty" json:"columns,omitempty"`

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -300,7 +300,8 @@ var validChartTypes = map[string]bool{
 	"scatter": true, "bubble": true, "combo": true, "histogram": true,
 	"boxplot": true, "funnel": true, "sankey": true, "heatmap": true,
 	"calendar": true, "sparkline": true, "waterfall": true, "xmr": true,
-	"dumbbell": true,
+	"dumbbell": true, "gauge": true, "treemap": true, "radar": true,
+	"candlestick": true,
 }
 
 func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
@@ -347,13 +348,37 @@ func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
 	}
 
 	switch w.Chart {
-	case "pie", "funnel":
+	case "pie", "funnel", "treemap":
 		// label + value columns
 		if w.Label == "" {
 			errs = append(errs, fmt.Sprintf("%s: label is required for %s charts", prefix, w.Chart))
 		}
 		if w.Value == "" {
 			errs = append(errs, fmt.Sprintf("%s: value is required for %s charts", prefix, w.Chart))
+		}
+
+	case "gauge":
+		// value column (current); target is optional
+		if w.Value == "" {
+			errs = append(errs, fmt.Sprintf("%s: value is required for gauge charts", prefix))
+		}
+
+	case "candlestick":
+		// x + open/high/low/close
+		if w.X == "" {
+			errs = append(errs, fmt.Sprintf("%s: x is required for candlestick charts", prefix))
+		}
+		if w.Open == "" {
+			errs = append(errs, fmt.Sprintf("%s: open is required for candlestick charts", prefix))
+		}
+		if w.High == "" {
+			errs = append(errs, fmt.Sprintf("%s: high is required for candlestick charts", prefix))
+		}
+		if w.Low == "" {
+			errs = append(errs, fmt.Sprintf("%s: low is required for candlestick charts", prefix))
+		}
+		if w.Close == "" {
+			errs = append(errs, fmt.Sprintf("%s: close is required for candlestick charts", prefix))
 		}
 
 	case "sankey":
@@ -408,7 +433,7 @@ func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
 		}
 
 	default:
-		// line, bar, area, scatter, combo, sparkline, waterfall, xmr, dumbbell, boxplot
+		// line, bar, area, scatter, combo, sparkline, waterfall, xmr, dumbbell, boxplot, radar
 		// all need x + y
 		if w.X == "" {
 			errs = append(errs, fmt.Sprintf("%s: x is required for %s charts", prefix, w.Chart))

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -294,7 +294,11 @@
             "sparkline",
             "waterfall",
             "xmr",
-            "dumbbell"
+            "dumbbell",
+            "gauge",
+            "treemap",
+            "radar",
+            "candlestick"
           ]
         },
         "x": {
@@ -332,6 +336,18 @@
           "type": "string"
         },
         "yMax": {
+          "type": "string"
+        },
+        "open": {
+          "type": "string"
+        },
+        "high": {
+          "type": "string"
+        },
+        "low": {
+          "type": "string"
+        },
+        "close": {
           "type": "string"
         },
         "columns": {


### PR DESCRIPTION
## Summary

Adds gauge, treemap, radar, and candlestick chart support across validation, schema, frontend rendering, docs, and the YAML example suite. The treemap renderer uses an explicit cell renderer to avoid Recharts' default outlined SVG label style.

## Testing

- [x] `make test`
- [x] `make build`
- [x] relevant example or manual smoke test: served `examples/basic-yaml` and verified the dashboard API/root page responded

## Checklist

- [x] docs updated if behavior changed
- [x] examples updated if the authoring model changed
- [ ] screenshots or recordings attached for UI changes