### PR TITLE
Add dac upgrade command and update-available nudge

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ func NewApp(build BuildInfo) *cli.Command {
 			withTelemetry(connectionsCmd()),
 			withTelemetry(skillsCmd()),
 			withTelemetry(exportCmd()),
+			withTelemetry(upgradeCmd(build)),
 			versionCmd(build),
 		},
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+)
+
+// installScriptURLFmt is the canonical installer used by `dac upgrade`. The
+// ref is pinned to the running binary's version (a known-good release commit)
+// so a broken `main` cannot break every user's upgrade path. Dev/test builds
+// fall back to `main`.
+const installScriptURLFmt = "https://raw.githubusercontent.com/bruin-data/dac/%s/install.sh"
+
+// installScriptURL returns the install.sh URL pinned to the version of the
+// running binary, or to `main` for dev/test builds where no release commit
+// exists.
+func installScriptURL(version string) string {
+	ref := version
+	if ref == "" || ref == "dev" || strings.HasPrefix(ref, "test-") {
+		ref = "main"
+	}
+	return fmt.Sprintf(installScriptURLFmt, ref)
+}
+
+func upgradeCmd(build BuildInfo) *cli.Command {
+	return &cli.Command{
+		Name:    "upgrade",
+		Aliases: []string{"update"},
+		Usage:   "Upgrade the dac CLI in place to the latest release",
+		Description: "Re-runs the official install script to replace the current binary " +
+			"with the latest release on the same channel. Pass --channel edge to track " +
+			"the edge stream, or a tag like v1.2.3 as an argument to pin to a specific version.",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "channel",
+				Usage: "Release channel to install from (stable or edge)",
+			},
+			&cli.StringFlag{
+				Name:  "bindir",
+				Usage: "Directory to install into (default: directory of the current binary)",
+			},
+		},
+		ArgsUsage: "[tag]",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			return runUpgrade(ctx, cmd, build)
+		},
+	}
+}
+
+func runUpgrade(ctx context.Context, cmd *cli.Command, build BuildInfo) error {
+	channel := strings.TrimSpace(cmd.String("channel"))
+	if channel == "" {
+		channel = inferChannel(build.Version)
+	}
+	if channel != "stable" && channel != "edge" {
+		return fmt.Errorf("--channel must be 'stable' or 'edge', got %q", channel)
+	}
+
+	bindir := strings.TrimSpace(cmd.String("bindir"))
+	if bindir == "" {
+		exe, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("could not locate current binary: %w", err)
+		}
+		resolved, err := filepath.EvalSymlinks(exe)
+		if err == nil {
+			exe = resolved
+		}
+		bindir = filepath.Dir(exe)
+	}
+
+	tag := strings.TrimSpace(cmd.Args().First())
+
+	fmt.Fprintf(os.Stderr, "Upgrading dac (%s channel) into %s...\n", channel, bindir)
+
+	args := []string{"-fsSL", installScriptURL(build.Version)}
+	curl := exec.CommandContext(ctx, "curl", args...)
+	curlOut, err := curl.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	curl.Stderr = os.Stderr
+
+	bashArgs := []string{"-s", "--", "-b", bindir, "--channel", channel}
+	if tag != "" {
+		bashArgs = append(bashArgs, tag)
+	}
+	bash := exec.CommandContext(ctx, "bash", bashArgs...)
+	bash.Stdin = curlOut
+	bash.Stdout = os.Stderr // installer logs to stdout; route to stderr so CLI output stays clean
+	bash.Stderr = os.Stderr
+	// The official installer would otherwise reinstall the bruin CLI on every
+	// dac upgrade — skip it; users who want bruin can run that installer
+	// themselves.
+	bash.Env = append(os.Environ(), "DAC_SKIP_BRUIN_INSTALL=1")
+
+	if err := bash.Start(); err != nil {
+		return fmt.Errorf("could not start install script: %w", err)
+	}
+	if err := curl.Start(); err != nil {
+		_ = bash.Process.Kill()
+		return fmt.Errorf("could not start curl: %w", err)
+	}
+	if err := curl.Wait(); err != nil {
+		_ = bash.Process.Kill()
+		return fmt.Errorf("curl failed: %w", err)
+	}
+	if err := bash.Wait(); err != nil {
+		return fmt.Errorf("installer failed: %w", err)
+	}
+	return nil
+}
+
+// inferChannel picks a default channel from the running binary's version
+// string. Edge tags look like v0.0.0-edge.NNN.SHA1234.
+func inferChannel(version string) string {
+	if strings.Contains(version, "-edge.") {
+		return "edge"
+	}
+	return "stable"
+}

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInferChannel(t *testing.T) {
+	cases := []struct {
+		version string
+		want    string
+	}{
+		{"v1.2.3", "stable"},
+		{"1.2.3", "stable"},
+		{"", "stable"},
+		{"dev", "stable"},
+		{"v0.0.0-edge.42.abc123", "edge"},
+		{"v0.0.0-edge.1.deadbe", "edge"},
+	}
+	for _, c := range cases {
+		if got := inferChannel(c.version); got != c.want {
+			t.Errorf("inferChannel(%q) = %q, want %q", c.version, got, c.want)
+		}
+	}
+}
+
+func TestInstallScriptURL(t *testing.T) {
+	cases := []struct {
+		version  string
+		wantRef  string
+		wantPath string
+	}{
+		{"v1.2.3", "v1.2.3", "/bruin-data/dac/v1.2.3/install.sh"},
+		{"v0.0.0-edge.42.abc", "v0.0.0-edge.42.abc", "/bruin-data/dac/v0.0.0-edge.42.abc/install.sh"},
+		{"dev", "main", "/bruin-data/dac/main/install.sh"},
+		{"test-debug", "main", "/bruin-data/dac/main/install.sh"},
+		{"", "main", "/bruin-data/dac/main/install.sh"},
+	}
+	for _, c := range cases {
+		got := installScriptURL(c.version)
+		if !strings.Contains(got, c.wantPath) {
+			t.Errorf("installScriptURL(%q) = %q, want path containing %q", c.version, got, c.wantPath)
+		}
+		if !strings.HasPrefix(got, "https://raw.githubusercontent.com/") {
+			t.Errorf("installScriptURL(%q) = %q, want raw.githubusercontent.com prefix", c.version, got)
+		}
+	}
+}

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -55,6 +55,7 @@ export default defineConfig({
           { text: "connections", link: "/commands/connections" },
           { text: "skills", link: "/commands/skills" },
           { text: "export", link: "/commands/export" },
+          { text: "upgrade", link: "/commands/upgrade" },
         ],
       },
       {

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -26,3 +26,4 @@ These flags apply to all commands:
 | [`connections`](/commands/connections) | Test database connections |
 | [`skills`](/commands/skills) | List and install DAC agent skills |
 | [`export`](/commands/export) | Export dashboards to external formats |
+| [`upgrade`](/commands/upgrade) | Upgrade the DAC CLI in place (alias: `update`) |

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -1,0 +1,54 @@
+# dac upgrade
+
+Upgrade the DAC CLI in place to the latest release.
+
+```shell
+dac upgrade [tag] [flags]
+```
+
+`dac upgrade` re-runs the official install script to replace the current binary with the latest release on the same channel. The channel is inferred from the running binary's version, so stable installs stay on stable and edge installs stay on edge.
+
+`dac update` is an alias.
+
+## Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--channel` | string | inferred from current version | Release channel to install from (`stable` or `edge`) |
+| `--bindir` | string | directory of the current binary | Directory to install into |
+
+## Examples
+
+```shell
+# Upgrade to the latest release on the current channel
+dac upgrade
+
+# Switch to the edge channel
+dac upgrade --channel edge
+
+# Pin to a specific version
+dac upgrade v0.1.0
+
+# Install into a different directory (may require sudo)
+dac upgrade --bindir /usr/local/bin
+```
+
+## Update Notifications
+
+DAC checks GitHub once per day for newer releases on the channel you installed from. When one is available, a one-line notice is printed to stderr after the command finishes:
+
+```text
+dac v0.2.0 available (current: v0.1.0). Run `dac upgrade`.
+```
+
+The notice is skipped when stderr is not a terminal, so scripts and CI logs stay clean. The check itself runs in the background and never blocks the command path.
+
+To disable the check entirely:
+
+```shell
+export DAC_NO_UPDATE_CHECK=1
+# or the industry-standard:
+export DO_NOT_TRACK=1
+```
+
+The check is also disabled for `dev` and `test-*` builds.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,6 +30,18 @@ To install a specific version:
 curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- v0.1.0
 ```
 
+## Upgrading
+
+Once `dac` is on your `PATH`, upgrade in place with:
+
+```shell
+dac upgrade
+```
+
+This re-runs the official installer to replace the current binary with the latest release on the same channel. See [`dac upgrade`](/commands/upgrade) for flags, channel switching, and pinning a specific version.
+
+DAC also checks GitHub once a day for newer releases on your channel and prints a one-line notice to stderr when one is available. Set `DAC_NO_UPDATE_CHECK=1` or `DO_NOT_TRACK=1` to disable.
+
 ## Build from Source
 
 If you are developing DAC itself:

--- a/main.go
+++ b/main.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/bruin-data/dac/cmd"
 	"github.com/bruin-data/dac/pkg/telemetry"
+	"github.com/bruin-data/dac/pkg/update"
 )
+
+// updateWaitOnExit is how long we'll wait for the update check goroutine to
+// finish before printing the nudge. The check itself caps HTTP at 3s, but at
+// process exit we'd rather skip the nudge than make `dac ls` feel slow.
+const updateWaitOnExit = 1 * time.Second
 
 var (
 	version      = "dev"
@@ -25,15 +32,69 @@ func main() {
 	client := telemetry.Init()
 	defer client.Close()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Kick off the update check in the background. The receive is gated on a
+	// short timeout below so a slow GitHub round-trip never blocks the user.
+	var updateCh <-chan update.Result
+	if checker := update.NewChecker(version); checker != nil {
+		updateCh = checker.Start(ctx)
+	}
+
 	buildInfo := cmd.BuildInfo{
 		Version: version,
 		Commit:  commit,
 	}
 
-	if err := cmd.Run(context.Background(), os.Args, frontendDistFS(), buildInfo); err != nil {
-		// Close manually since defer doesn't run on os.Exit.
-		client.Close()
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+	args := os.Args
+	err := cmd.Run(ctx, args, frontendDistFS(), buildInfo)
+	if err == nil {
+		printUpdateNudge(args, updateCh)
+		return
 	}
+
+	// Close manually since defer doesn't run on os.Exit.
+	client.Close()
+	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	os.Exit(1)
+}
+
+// printUpdateNudge surfaces the cached/fresh update check result if it
+// arrived in time, but only for commands where the nudge is appropriate.
+func printUpdateNudge(args []string, ch <-chan update.Result) {
+	if ch == nil {
+		return
+	}
+	if shouldSkipNudge(args) {
+		return
+	}
+	select {
+	case res, ok := <-ch:
+		if !ok {
+			return
+		}
+		update.Nudge(os.Stderr, res)
+	case <-time.After(updateWaitOnExit):
+		// Check still in flight; skip rather than make the CLI feel slow.
+		// The goroutine will keep running until the process exits, which
+		// is fine — its only side effect is writing ~/.dac/update-check.json.
+	}
+}
+
+// shouldSkipNudge suppresses the nudge for commands whose output should stay
+// clean (version, help) or where the nudge would be redundant (upgrade,
+// update).
+func shouldSkipNudge(args []string) bool {
+	for _, a := range args[1:] {
+		if len(a) > 0 && a[0] == '-' {
+			continue // skip flags
+		}
+		switch a {
+		case "version", "upgrade", "update", "help", "h":
+			return true
+		}
+		return false
+	}
+	return true // no subcommand → don't nudge
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestShouldSkipNudge(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"bare invocation", []string{"dac"}, true},
+		{"version subcommand", []string{"dac", "version"}, true},
+		{"upgrade subcommand", []string{"dac", "upgrade"}, true},
+		{"update alias", []string{"dac", "update"}, true},
+		{"help subcommand", []string{"dac", "help"}, true},
+		{"h alias", []string{"dac", "h"}, true},
+		{"--version flag", []string{"dac", "--version"}, true},
+		{"--help flag", []string{"dac", "--help"}, true},
+		{"-v short flag", []string{"dac", "-v"}, true},
+		{"serve subcommand", []string{"dac", "serve"}, false},
+		{"validate subcommand", []string{"dac", "validate"}, false},
+		{"global flag then serve", []string{"dac", "--debug", "serve"}, false},
+		{"help with target", []string{"dac", "help", "serve"}, true},
+		{"upgrade with tag", []string{"dac", "upgrade", "v1.2.3"}, true},
+	}
+	for _, c := range cases {
+		if got := shouldSkipNudge(c.args); got != c.want {
+			t.Errorf("%s: shouldSkipNudge(%v) = %v, want %v", c.name, c.args, got, c.want)
+		}
+	}
+}

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -1,0 +1,248 @@
+// Package update fetches the latest dac release tag from GitHub and caches
+// it under ~/.dac/update-check.json so subsequent runs avoid the network
+// round-trip. The result drives a one-line "update available" nudge printed
+// at the end of a command.
+//
+// Disable with DAC_NO_UPDATE_CHECK=1 or DO_NOT_TRACK=1.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/afero"
+)
+
+const (
+	owner          = "bruin-data"
+	repo           = "dac"
+	dacHomeDir     = ".dac"
+	cacheFileName  = "update-check.json"
+	defaultTTL     = 24 * time.Hour
+	defaultTimeout = 3 * time.Second
+)
+
+// Channel describes which release stream the current binary tracks.
+type Channel string
+
+const (
+	ChannelStable Channel = "stable"
+	ChannelEdge   Channel = "edge"
+)
+
+// Result is what the asynchronous check returns.
+type Result struct {
+	LatestVersion  string
+	CurrentVersion string
+	Channel        Channel
+	HasUpdate      bool
+}
+
+type cacheEntry struct {
+	LatestVersion string    `json:"latest_version"`
+	Channel       Channel   `json:"channel"`
+	CheckedAt     time.Time `json:"checked_at"`
+}
+
+// Checker drives an asynchronous update check. Construct with NewChecker.
+type Checker struct {
+	currentVersion string
+	channel        Channel
+	httpClient     *http.Client
+	fs             afero.Fs
+	homeDir        string
+	now            func() time.Time
+	apiBase        string
+	ttl            time.Duration
+}
+
+// NewChecker returns a Checker configured for real-world use. Returns nil if
+// the current version is not eligible for nudging (dev/test builds, opt-out).
+func NewChecker(currentVersion string) *Checker {
+	if !Enabled(currentVersion) {
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return &Checker{
+		currentVersion: currentVersion,
+		channel:        detectChannel(currentVersion),
+		httpClient:     &http.Client{Timeout: defaultTimeout},
+		fs:             afero.NewOsFs(),
+		homeDir:        filepath.Join(home, dacHomeDir),
+		now:            time.Now,
+		apiBase:        "https://api.github.com",
+		ttl:            defaultTTL,
+	}
+}
+
+// Enabled reports whether update checks should run for this build.
+func Enabled(currentVersion string) bool {
+	if os.Getenv("DAC_NO_UPDATE_CHECK") != "" || os.Getenv("DO_NOT_TRACK") != "" {
+		return false
+	}
+	if currentVersion == "" || currentVersion == "dev" {
+		return false
+	}
+	if strings.HasPrefix(currentVersion, "test-") {
+		return false
+	}
+	return true
+}
+
+// Start kicks off the check in a goroutine and returns a channel that yields
+// a single Result on success. The channel is closed without a value when the
+// check is skipped, fails, or times out — receivers should use a select with
+// a deadline so they never block the main flow.
+func (c *Checker) Start(ctx context.Context) <-chan Result {
+	out := make(chan Result, 1)
+	go func() {
+		defer close(out)
+		res, ok := c.run(ctx)
+		if ok {
+			out <- res
+		}
+	}()
+	return out
+}
+
+func (c *Checker) run(ctx context.Context) (Result, bool) {
+	cached, fresh := c.readCache()
+	var latest string
+	var channel Channel
+	switch {
+	case fresh:
+		latest = cached.LatestVersion
+		channel = cached.Channel
+	default:
+		v, ch, err := c.fetchLatest(ctx)
+		if err != nil {
+			return Result{}, false
+		}
+		latest, channel = v, ch
+		c.writeCache(cacheEntry{LatestVersion: latest, Channel: channel, CheckedAt: c.now().UTC()})
+	}
+
+	if latest == "" {
+		return Result{}, false
+	}
+	return Result{
+		LatestVersion:  latest,
+		CurrentVersion: c.currentVersion,
+		Channel:        channel,
+		HasUpdate:      isNewer(latest, c.currentVersion),
+	}, true
+}
+
+func (c *Checker) readCache() (cacheEntry, bool) {
+	path := filepath.Join(c.homeDir, cacheFileName)
+	buf, err := afero.ReadFile(c.fs, path)
+	if err != nil {
+		return cacheEntry{}, false
+	}
+	var entry cacheEntry
+	if err := json.Unmarshal(buf, &entry); err != nil {
+		return cacheEntry{}, false
+	}
+	if entry.Channel != c.channel {
+		return cacheEntry{}, false
+	}
+	if c.now().Sub(entry.CheckedAt) > c.ttl {
+		return cacheEntry{}, false
+	}
+	return entry, true
+}
+
+func (c *Checker) writeCache(entry cacheEntry) {
+	if err := c.fs.MkdirAll(c.homeDir, 0o755); err != nil {
+		return
+	}
+	buf, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	_ = afero.WriteFile(c.fs, filepath.Join(c.homeDir, cacheFileName), buf, 0o600)
+}
+
+func (c *Checker) fetchLatest(ctx context.Context) (string, Channel, error) {
+	switch c.channel {
+	case ChannelEdge:
+		v, err := c.fetchLatestEdge(ctx)
+		return v, ChannelEdge, err
+	default:
+		v, err := c.fetchLatestStable(ctx)
+		return v, ChannelStable, err
+	}
+}
+
+func (c *Checker) fetchLatestStable(ctx context.Context) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", c.apiBase, owner, repo)
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := c.getJSON(ctx, url, &payload); err != nil {
+		return "", err
+	}
+	return payload.TagName, nil
+}
+
+func (c *Checker) fetchLatestEdge(ctx context.Context) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=30", c.apiBase, owner, repo)
+	var releases []struct {
+		TagName    string `json:"tag_name"`
+		Prerelease bool   `json:"prerelease"`
+	}
+	if err := c.getJSON(ctx, url, &releases); err != nil {
+		return "", err
+	}
+	for _, r := range releases {
+		if r.Prerelease && strings.HasPrefix(r.TagName, "v0.0.0-edge.") {
+			return r.TagName, nil
+		}
+	}
+	return "", nil
+}
+
+func (c *Checker) getJSON(ctx context.Context, url string, into any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return fmt.Errorf("github api: %s", resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(into)
+}
+
+func detectChannel(version string) Channel {
+	if strings.Contains(version, "-edge.") {
+		return ChannelEdge
+	}
+	return ChannelStable
+}
+
+// isNewer reports whether latest is a different tag than current. We do not
+// parse semver — GitHub already tells us the latest tag, so any mismatch
+// means there's something newer to install. A bare equality check avoids
+// edge-tag quirks like "v0.0.0-edge.42.abc123".
+func isNewer(latest, current string) bool {
+	l := strings.TrimPrefix(latest, "v")
+	c := strings.TrimPrefix(current, "v")
+	return l != "" && c != "" && l != c
+}

--- a/pkg/update/check_test.go
+++ b/pkg/update/check_test.go
@@ -1,0 +1,235 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+)
+
+func newTestChecker(t *testing.T, version string, server *httptest.Server) *Checker {
+	t.Helper()
+	return &Checker{
+		currentVersion: version,
+		channel:        detectChannel(version),
+		httpClient:     server.Client(),
+		fs:             afero.NewMemMapFs(),
+		homeDir:        filepath.Join("/test", dacHomeDir),
+		now:            time.Now,
+		apiBase:        server.URL,
+		ttl:            defaultTTL,
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	t.Setenv("DAC_NO_UPDATE_CHECK", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"v1.2.3", true},
+		{"1.2.3", true},
+		{"v0.0.0-edge.42.abc123", true},
+		{"dev", false},
+		{"", false},
+		{"test-local", false},
+		{"test-debug-fix", false},
+	}
+	for _, c := range cases {
+		if got := Enabled(c.version); got != c.want {
+			t.Errorf("Enabled(%q) = %v, want %v", c.version, got, c.want)
+		}
+	}
+
+	t.Setenv("DAC_NO_UPDATE_CHECK", "1")
+	if Enabled("v1.2.3") {
+		t.Error("DAC_NO_UPDATE_CHECK=1 should disable check")
+	}
+	t.Setenv("DAC_NO_UPDATE_CHECK", "")
+	t.Setenv("DO_NOT_TRACK", "1")
+	if Enabled("v1.2.3") {
+		t.Error("DO_NOT_TRACK=1 should disable check")
+	}
+}
+
+func TestDetectChannel(t *testing.T) {
+	if detectChannel("v1.2.3") != ChannelStable {
+		t.Error("stable tag should map to ChannelStable")
+	}
+	if detectChannel("v0.0.0-edge.42.abc123") != ChannelEdge {
+		t.Error("edge tag should map to ChannelEdge")
+	}
+}
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"v1.2.3", "v1.2.3", false},
+		{"v1.2.4", "v1.2.3", true},
+		{"1.2.3", "v1.2.3", false},
+		{"", "v1.2.3", false},
+		{"v1.2.3", "", false},
+		{"v0.0.0-edge.42.a", "v0.0.0-edge.41.b", true},
+	}
+	for _, c := range cases {
+		if got := isNewer(c.latest, c.current); got != c.want {
+			t.Errorf("isNewer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
+		}
+	}
+}
+
+func TestRunStableFetchAndCache(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		if !strings.HasSuffix(r.URL.Path, "/releases/latest") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v2.0.0"})
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(t, "v1.0.0", srv)
+
+	res, ok := c.run(context.Background())
+	if !ok {
+		t.Fatal("expected ok=true on first run")
+	}
+	if res.LatestVersion != "v2.0.0" || !res.HasUpdate || res.Channel != ChannelStable {
+		t.Errorf("unexpected result: %+v", res)
+	}
+	if atomic.LoadInt32(&hits) != 1 {
+		t.Errorf("expected 1 HTTP hit, got %d", hits)
+	}
+
+	// Second run should be served from cache, no HTTP.
+	res2, ok := c.run(context.Background())
+	if !ok || res2.LatestVersion != "v2.0.0" {
+		t.Errorf("second run should hit cache, got %+v ok=%v", res2, ok)
+	}
+	if atomic.LoadInt32(&hits) != 1 {
+		t.Errorf("expected still 1 HTTP hit, got %d", hits)
+	}
+}
+
+func TestRunCacheExpires(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v2.0.0"})
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(t, "v1.0.0", srv)
+	now := time.Now()
+	c.now = func() time.Time { return now }
+
+	if _, ok := c.run(context.Background()); !ok {
+		t.Fatal("first run failed")
+	}
+
+	// Advance past TTL.
+	now = now.Add(defaultTTL + time.Minute)
+	if _, ok := c.run(context.Background()); !ok {
+		t.Fatal("post-expiry run failed")
+	}
+	if atomic.LoadInt32(&hits) != 2 {
+		t.Errorf("expected cache to expire and refetch, got %d hits", hits)
+	}
+}
+
+func TestRunEdgeChannel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/releases") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"tag_name": "v1.5.0", "prerelease": false},
+			{"tag_name": "v0.0.0-edge.50.abc", "prerelease": true},
+			{"tag_name": "v0.0.0-edge.49.def", "prerelease": true},
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(t, "v0.0.0-edge.42.aaa", srv)
+	if c.channel != ChannelEdge {
+		t.Fatalf("channel = %s, want edge", c.channel)
+	}
+
+	res, ok := c.run(context.Background())
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if res.LatestVersion != "v0.0.0-edge.50.abc" {
+		t.Errorf("LatestVersion = %s, want v0.0.0-edge.50.abc", res.LatestVersion)
+	}
+	if !res.HasUpdate {
+		t.Error("expected HasUpdate=true")
+	}
+}
+
+func TestRunNetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(t, "v1.0.0", srv)
+	if _, ok := c.run(context.Background()); ok {
+		t.Error("expected ok=false on 5xx")
+	}
+}
+
+func TestNudgeSkipsWhenNoUpdate(t *testing.T) {
+	var sb strings.Builder
+	if Nudge(&sb, Result{HasUpdate: false}) {
+		t.Error("Nudge should return false when HasUpdate=false")
+	}
+	if sb.Len() != 0 {
+		t.Errorf("Nudge wrote unexpected output: %q", sb.String())
+	}
+}
+
+func TestNudgeWritesToWriter(t *testing.T) {
+	var sb strings.Builder
+	res := Result{
+		LatestVersion:  "v2.0.0",
+		CurrentVersion: "v1.0.0",
+		Channel:        ChannelStable,
+		HasUpdate:      true,
+	}
+	if !Nudge(&sb, res) {
+		t.Fatal("Nudge returned false")
+	}
+	out := sb.String()
+	if !strings.Contains(out, "v2.0.0") || !strings.Contains(out, "v1.0.0") {
+		t.Errorf("nudge missing versions: %q", out)
+	}
+	if !strings.Contains(out, "dac upgrade") {
+		t.Errorf("nudge missing upgrade hint: %q", out)
+	}
+}
+
+func TestNudgeEdgeChannelHint(t *testing.T) {
+	var sb strings.Builder
+	Nudge(&sb, Result{
+		LatestVersion:  "v0.0.0-edge.50.abc",
+		CurrentVersion: "v0.0.0-edge.42.aaa",
+		Channel:        ChannelEdge,
+		HasUpdate:      true,
+	})
+	if !strings.Contains(sb.String(), "--channel edge") {
+		t.Errorf("edge nudge missing channel flag hint: %q", sb.String())
+	}
+}

--- a/pkg/update/nudge.go
+++ b/pkg/update/nudge.go
@@ -1,0 +1,30 @@
+package update
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Nudge prints a one-line "update available" notice to w if res indicates a
+// newer version. Returns true if it printed anything.
+//
+// Skips when w is a non-terminal *os.File so scripts and CI logs stay clean.
+func Nudge(w io.Writer, res Result) bool {
+	if !res.HasUpdate {
+		return false
+	}
+	if f, ok := w.(*os.File); ok {
+		fi, err := f.Stat()
+		if err != nil || fi.Mode()&os.ModeCharDevice == 0 {
+			return false
+		}
+	}
+	cmd := "dac upgrade"
+	if res.Channel == ChannelEdge {
+		cmd = "dac upgrade --channel edge"
+	}
+	fmt.Fprintf(w, "dac %s available (current: %s). Run `%s`.\n",
+		res.LatestVersion, res.CurrentVersion, cmd)
+	return true
+}


### PR DESCRIPTION
## Summary

Without an update path, users stay pinned on whatever version they first installed — including versions that shipped with bugs. The CLI now checks for newer releases on the same channel, prints a single-line stderr notice when one exists, and offers `dac upgrade` (alias `dac update`) to re-run the official installer in place.

The telemetry release-config fix has been split off into #9, which this PR depends on. This PR stays focused on the upgrade path.

## Changes

- **`pkg/update/check.go`** — asynchronously hits the GitHub releases API for the latest tag on the matching channel (stable or edge), caches the result at `~/.dac/update-check.json` for 24 h, and never blocks the command path. The HTTP client caps at 3 s; process exit caps at 1 s, then skips the nudge if not yet ready.
- **`pkg/update/nudge.go`** — terse one-line stderr notice (`dac v2.0.0 available (current: v1.0.0). Run \`dac upgrade\`.`). Skipped when stderr isn't a TTY so scripts and CI stay clean.
- **`cmd/upgrade.go`** — new `dac upgrade` (alias `update`). Detects the channel from the running binary's version, lets users override with `--channel stable|edge`, accepts an optional pinned tag, installs into the directory of the current binary by default (override with `--bindir`). Shells the install script for parity with first-time installs. The install script URL is **pinned to the running binary's tag** so a broken `main` cannot break every user's upgrade path. Forces `DAC_SKIP_BRUIN_INSTALL=1` so the bruin CLI isn't reinstalled on every upgrade.
- **`main.go`** — kicks off the check at process start, prints the nudge after the command finishes. Suppresses the nudge for `version`, `upgrade`, `update`, `help`, and when no subcommand is given.

Opt-out: `DAC_NO_UPDATE_CHECK=1` or `DO_NOT_TRACK=1`. Disabled for `dev` and `test-*` builds so local iterations don't spam.

## Test plan

- [x] `make test` passes — `pkg/update` lands at ~75% coverage with HTTP-server-mocked checks
- [x] `go build ./...` clean
- [x] `inferChannel`, `installScriptURL`, and `shouldSkipNudge` covered by table tests
- [x] Update nudge prints to stderr on TTY, skipped under redirect
- [x] Skip-list works (no nudge for `version`, `upgrade`, `update`, help, or bare invocation)
- [x] Cached run does not refetch from GitHub (verified by mock server hit counter)
- [ ] After #9 merges and edge-release runs: install via the edge channel, run a few commands, confirm the cache populates and nudge fires on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)