### PR TITLE
[codex] Update DAC install curl

### DIFF
--- a/.github/workflows/edge-release.yml
+++ b/.github/workflows/edge-release.yml
@@ -56,7 +56,7 @@ jobs:
           Install with:
 
           \`\`\`bash
-          curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- --channel edge
+          curl -LsSf https://getbruin.com/install/dac | sh -s -- --channel edge
           \`\`\`
           EOF
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ rows:
 Install the latest stable DAC release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash
+curl -LsSf https://getbruin.com/install/dac | sh
 ```
 
 Install the latest edge build from `main`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- --channel edge
+curl -LsSf https://getbruin.com/install/dac | sh -s -- --channel edge
 ```
 
 DAC uses your existing Bruin connections and currently shells out to `bruin query` for query execution. The install script installs the Bruin CLI first when `bruin` is not already available on your `PATH`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ DAC is released as standalone binaries through GitHub Releases.
 ## Install Script
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash
+curl -LsSf https://getbruin.com/install/dac | sh
 ```
 
 The installer installs the Bruin CLI first if `bruin` is not already available on your `PATH`, then downloads the latest DAC GitHub release for your platform and installs `dac` into `~/.local/bin` by default.
@@ -15,19 +15,19 @@ DAC uses `.bruin.yml` connections and currently shells out to `bruin query` to e
 To install the latest edge build from `main`:
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- --channel edge
+curl -LsSf https://getbruin.com/install/dac | sh -s -- --channel edge
 ```
 
 To install into a different directory:
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- -b /usr/local/bin
+curl -LsSf https://getbruin.com/install/dac | sh -s -- -b /usr/local/bin
 ```
 
 To install a specific version:
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- v0.1.0
+curl -LsSf https://getbruin.com/install/dac | sh -s -- v0.1.0
 ```
 
 ## Upgrading


### PR DESCRIPTION
## Summary

Update DAC installation instructions to use the hosted `https://getbruin.com/install/dac` installer instead of the raw GitHub install script URL. This keeps the README, getting-started docs, and edge release notes aligned with the new curl command while preserving existing installer flag examples.

## Testing

- [ ] `make test`
- [ ] `make build`
- [ ] relevant example or manual smoke test

## Checklist

- [x] docs updated if behavior changed
- [ ] examples updated if the authoring model changed
- [ ] screenshots or recordings attached for UI changes
