### PR TITLE
Honor row height for taller charts

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -281,6 +281,37 @@ rows:
         # ...
 ```
 
+### Row Height
+
+Each row accepts an optional `height` to override its rendered height. Useful when you want charts in a row to be taller (or shorter) than the default.
+
+- Number → pixels (e.g. `height: 480`). Charts inside the row expand to fill it.
+- String pixel value → e.g. `"480px"`. Same behavior as a number.
+- Other CSS strings → e.g. `"60vh"`, `"32rem"`. The row container takes that height, but charts fall back to their default 240px (use a pixel value if you want the chart to grow).
+- Omitted → default height; widgets use their built-in sizing.
+
+```yaml
+rows:
+  - height: 480               # Tall row — charts fill the extra vertical space
+    widgets:
+      - name: Revenue Trend
+        type: chart
+        chart: area
+        col: 8
+        # ...
+      - name: By Region
+        type: chart
+        chart: pie
+        col: 4
+        # ...
+
+  - widgets:                  # No height → default
+      - name: Recent Orders
+        type: table
+        col: 12
+        # ...
+```
+
 ---
 
 ## Widget Types

--- a/frontend/src/components/DashboardView.tsx
+++ b/frontend/src/components/DashboardView.tsx
@@ -385,7 +385,7 @@ export function DashboardView() {
                 className="animate-in"
                 style={{ animationDelay: `${50 + rowIdx * 30}ms` }}
               >
-                <Row>
+                <Row height={row.height}>
                   {row.widgets.map((widget, widgetIdx) =>
                     renderWidget(widget, rowIdx, widgetIdx, row.widgets.length),
                   )}
@@ -421,7 +421,7 @@ export function DashboardView() {
                     className="animate-in"
                     style={{ animationDelay: `${50 + rowIdx * 30}ms` }}
                   >
-                    <Row>
+                    <Row height={row.height}>
                       {row.widgets.map((widget, widgetIdx) =>
                         renderWidget(widget, rowIdx, widgetIdx, row.widgets.length),
                       )}

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import {
   LineChart, Line, BarChart, Bar, AreaChart, Area, PieChart, Pie, Cell,
   ScatterChart, Scatter, ZAxis,
@@ -7,6 +7,11 @@ import {
 } from "recharts";
 import type { Widget, WidgetData } from "../../types/dashboard";
 import { useTokens } from "../../themes/TemplateProvider";
+import { RowHeightContext } from "../../themes/RowContext";
+
+const DEFAULT_CHART_HEIGHT = 240;
+// Approx pixels consumed by the widget frame's title/padding above the chart.
+const FRAME_OVERHEAD = 60;
 
 interface Props {
   widget: Widget;
@@ -498,6 +503,10 @@ function DumbbellChart({
 
 export function ChartWidget({ widget, data }: Props) {
   const tokens = useTokens();
+  const rowHeight = useContext(RowHeightContext);
+  const chartHeight = rowHeight !== undefined
+    ? Math.max(80, rowHeight - FRAME_OVERHEAD)
+    : DEFAULT_CHART_HEIGHT;
 
   if (!data?.rows?.length) {
     return <div className="text-[var(--dac-text-muted)] text-xs py-6 text-center">No data</div>;
@@ -520,7 +529,7 @@ export function ChartWidget({ widget, data }: Props) {
   switch (widget.chart) {
     case "line":
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <LineChart data={chartData} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey={widget.x} {...commonAxisProps} dy={6} tickFormatter={formatAxisTick} />
@@ -546,7 +555,7 @@ export function ChartWidget({ widget, data }: Props) {
       const yFields = widget.y ?? [];
       const isStacked = widget.stacked && yFields.length > 1;
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <BarChart data={chartData} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey={widget.x} {...commonAxisProps} dy={6} tickFormatter={formatAxisTick} />
@@ -572,7 +581,7 @@ export function ChartWidget({ widget, data }: Props) {
       const yFields = widget.y ?? [];
       const isStacked = widget.stacked && yFields.length > 1;
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <AreaChart data={chartData} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey={widget.x} {...commonAxisProps} dy={6} tickFormatter={formatAxisTick} />
@@ -598,7 +607,7 @@ export function ChartWidget({ widget, data }: Props) {
 
     case "pie": {
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <PieChart>
             <Pie
               data={chartData}
@@ -631,7 +640,7 @@ export function ChartWidget({ widget, data }: Props) {
       const xIsNumeric = chartData.length > 0 && typeof chartData[0][widget.x!] === "number";
       const yIsNumeric = chartData.length > 0 && typeof chartData[0][widget.y?.[0] ?? ""] === "number";
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <ScatterChart margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey={widget.x} name={widget.x} {...commonAxisProps} dy={6}
@@ -650,7 +659,7 @@ export function ChartWidget({ widget, data }: Props) {
       const xIsNumeric = chartData.length > 0 && typeof chartData[0][widget.x!] === "number";
       const yIsNumeric = chartData.length > 0 && typeof chartData[0][widget.y?.[0] ?? ""] === "number";
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <ScatterChart margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey={widget.x} name={widget.x} {...commonAxisProps} dy={6}
@@ -670,7 +679,7 @@ export function ChartWidget({ widget, data }: Props) {
       const yFields = widget.y ?? [];
       const lineSet = new Set(widget.lines ?? []);
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <ComposedChart data={chartData} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey={widget.x} {...commonAxisProps} dy={6} tickFormatter={formatAxisTick} />
@@ -706,7 +715,7 @@ export function ChartWidget({ widget, data }: Props) {
     case "histogram": {
       const histData = buildHistogramData(chartData, widget.x!, widget.bins || 10);
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <BarChart data={histData} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey="bin" {...commonAxisProps} dy={6} angle={-30} textAnchor="end" height={50} />
@@ -722,7 +731,7 @@ export function ChartWidget({ widget, data }: Props) {
       const yField = widget.y?.[0] ?? "value";
       const boxData = buildBoxplotData(chartData, widget.x!, yField);
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <ComposedChart data={boxData} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey="category" {...commonAxisProps} dy={6} />
@@ -741,7 +750,7 @@ export function ChartWidget({ widget, data }: Props) {
 
     case "funnel":
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <FunnelChart>
             <Tooltip content={<CustomTooltip />} />
             <Funnel
@@ -772,7 +781,7 @@ export function ChartWidget({ widget, data }: Props) {
         widget.value || "value",
       );
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <Sankey
             data={sankeyData}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -834,7 +843,7 @@ export function ChartWidget({ widget, data }: Props) {
     case "waterfall": {
       const wfData = buildWaterfallData(chartData, widget.x!, widget.y?.[0] ?? "value");
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <BarChart data={wfData} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey="name" {...commonAxisProps} dy={6} tickFormatter={formatAxisTick} />
@@ -854,7 +863,7 @@ export function ChartWidget({ widget, data }: Props) {
     case "xmr": {
       const yField = widget.y?.[0] ?? "value";
       return (
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
           <LineChart data={chartData} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey={widget.x} {...commonAxisProps} dy={6} tickFormatter={formatAxisTick} />

--- a/frontend/src/themes/RowContext.ts
+++ b/frontend/src/themes/RowContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+export const RowHeightContext = createContext<number | undefined>(undefined);
+
+export function parseRowHeight(h: number | string | undefined): number | undefined {
+  if (h === undefined) return undefined;
+  if (typeof h === "number") return h;
+  const m = h.match(/^(\d+(?:\.\d+)?)(px)?$/);
+  if (m) return parseFloat(m[1]);
+  return undefined;
+}

--- a/frontend/src/themes/bruin/Row.tsx
+++ b/frontend/src/themes/bruin/Row.tsx
@@ -1,9 +1,15 @@
 import type { RowProps, WidgetContainerProps } from "../../types/template";
+import { RowHeightContext, parseRowHeight } from "../RowContext";
 
-export function BruinRow({ children }: RowProps) {
+export function BruinRow({ children, height }: RowProps) {
+  const style = height !== undefined
+    ? { height: typeof height === "number" ? `${height}px` : height }
+    : undefined;
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-12 gap-4">
-      {children}
+    <div className="grid grid-cols-1 sm:grid-cols-12 gap-4" style={style}>
+      <RowHeightContext.Provider value={parseRowHeight(height)}>
+        {children}
+      </RowHeightContext.Provider>
     </div>
   );
 }
@@ -11,7 +17,7 @@ export function BruinRow({ children }: RowProps) {
 export function BruinWidgetContainer({ col, children }: WidgetContainerProps) {
   return (
     <div
-      className="col-span-1"
+      className="col-span-1 min-h-0"
       style={{ gridColumn: `span ${col}` }}
     >
       {children}

--- a/frontend/src/themes/bruin/WidgetFrame.tsx
+++ b/frontend/src/themes/bruin/WidgetFrame.tsx
@@ -1,5 +1,7 @@
+import { useContext } from "react";
 import type { WidgetFrameProps } from "../../types/template";
 import { useTemplate } from "../TemplateProvider";
+import { RowHeightContext } from "../RowContext";
 import { QueryInfo } from "../../components/widgets/QueryInfo";
 
 const containerClass: Record<string, string> = {
@@ -13,6 +15,8 @@ const containerClass: Record<string, string> = {
 
 export function BruinWidgetFrame({ widget, data, isLoading }: WidgetFrameProps) {
   const { MetricWidget, ChartWidget, TableWidget, TextWidget } = useTemplate();
+  const rowHeight = useContext(RowHeightContext);
+  const chartSkeletonHeight = rowHeight !== undefined ? Math.max(80, rowHeight - 60) : 240;
 
   // Divider: just a horizontal line, no title or data.
   if (widget.type === "divider") {
@@ -65,7 +69,7 @@ export function BruinWidgetFrame({ widget, data, isLoading }: WidgetFrameProps) 
         <div className={`text-xs text-[var(--dac-error)] font-mono mt-1 ${isTable ? "px-4" : ""}`}>{data.error}</div>
       )}
 
-      {!data && isLoading && <LoadingSkeleton type={widget.type} />}
+      {!data && isLoading && <LoadingSkeleton type={widget.type} chartHeight={chartSkeletonHeight} />}
 
       {data && !data.error && (
         <>
@@ -82,12 +86,12 @@ export function BruinWidgetFrame({ widget, data, isLoading }: WidgetFrameProps) 
   );
 }
 
-function LoadingSkeleton({ type }: { type: string }) {
+function LoadingSkeleton({ type, chartHeight = 240 }: { type: string; chartHeight?: number }) {
   if (type === "metric") {
     return <div className="skeleton h-8 w-24 mt-1" />;
   }
   if (type === "chart") {
-    return <div className="skeleton h-[240px] w-full mt-2 rounded" />;
+    return <div className="skeleton w-full mt-2 rounded" style={{ height: `${chartHeight}px` }} />;
   }
   if (type === "table") {
     return (

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -35,6 +35,7 @@ export interface FilterBarProps {
  */
 export interface RowProps {
   children: ReactNode;
+  height?: number | string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Rows already accepted a `height` field in the Go model and TS types, but the frontend ignored it and the create-dashboard skill never documented it.
- Wires it up via a small `RowHeightContext`: `BruinRow` applies the height as inline CSS and provides numeric pixels to descendants; `ChartWidget` and the loading skeleton compute their chart height from that (defaulting to 240).
- Numeric / `"NNNpx"` values grow the chart inside the row. Other CSS units (`vh`, `rem`) still size the row container but charts fall back to the default — called out in the skill doc.
- Docs already had a Row Height section; only the create-dashboard skill needed a new subsection.

## Test plan
- [ ] `make dev`, open a dashboard and add `height: 480` to a row with a chart — chart fills the row.
- [ ] Omit `height` — chart still renders at 240px as before.
- [ ] `height: "60vh"` — row container takes 60vh; chart stays at 240px (documented behavior).
- [ ] Sparkline charts stay at 60px regardless of row height.
- [ ] Loading skeleton matches the chart's eventual height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)