### PR TITLE
Use canonical install URL for `dac upgrade`

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -11,22 +11,10 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// installScriptURLFmt is the canonical installer used by `dac upgrade`. The
-// ref is pinned to the running binary's version (a known-good release commit)
-// so a broken `main` cannot break every user's upgrade path. Dev/test builds
-// fall back to `main`.
-const installScriptURLFmt = "https://raw.githubusercontent.com/bruin-data/dac/%s/install.sh"
-
-// installScriptURL returns the install.sh URL pinned to the version of the
-// running binary, or to `main` for dev/test builds where no release commit
-// exists.
-func installScriptURL(version string) string {
-	ref := version
-	if ref == "" || ref == "dev" || strings.HasPrefix(ref, "test-") {
-		ref = "main"
-	}
-	return fmt.Sprintf(installScriptURLFmt, ref)
-}
+// installScriptURL is the canonical installer used by `dac upgrade`. It is
+// the same URL we publish in the README, and resolves to the latest install.sh
+// on the stable channel.
+const installScriptURL = "https://getbruin.com/install/dac"
 
 func upgradeCmd(build BuildInfo) *cli.Command {
 	return &cli.Command{
@@ -79,7 +67,7 @@ func runUpgrade(ctx context.Context, cmd *cli.Command, build BuildInfo) error {
 
 	fmt.Fprintf(os.Stderr, "Upgrading dac (%s channel) into %s...\n", channel, bindir)
 
-	args := []string{"-fsSL", installScriptURL(build.Version)}
+	args := []string{"-fsSL", installScriptURL}
 	curl := exec.CommandContext(ctx, "curl", args...)
 	curlOut, err := curl.StdoutPipe()
 	if err != nil {

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -20,29 +19,6 @@ func TestInferChannel(t *testing.T) {
 	for _, c := range cases {
 		if got := inferChannel(c.version); got != c.want {
 			t.Errorf("inferChannel(%q) = %q, want %q", c.version, got, c.want)
-		}
-	}
-}
-
-func TestInstallScriptURL(t *testing.T) {
-	cases := []struct {
-		version  string
-		wantRef  string
-		wantPath string
-	}{
-		{"v1.2.3", "v1.2.3", "/bruin-data/dac/v1.2.3/install.sh"},
-		{"v0.0.0-edge.42.abc", "v0.0.0-edge.42.abc", "/bruin-data/dac/v0.0.0-edge.42.abc/install.sh"},
-		{"dev", "main", "/bruin-data/dac/main/install.sh"},
-		{"test-debug", "main", "/bruin-data/dac/main/install.sh"},
-		{"", "main", "/bruin-data/dac/main/install.sh"},
-	}
-	for _, c := range cases {
-		got := installScriptURL(c.version)
-		if !strings.Contains(got, c.wantPath) {
-			t.Errorf("installScriptURL(%q) = %q, want path containing %q", c.version, got, c.wantPath)
-		}
-		if !strings.HasPrefix(got, "https://raw.githubusercontent.com/") {
-			t.Errorf("installScriptURL(%q) = %q, want raw.githubusercontent.com prefix", c.version, got)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `dac upgrade` was 404ing because goreleaser stamps `main.version` as `0.2.0` (no `v`) while the git tag is `v0.2.0`, so the version-pinned `raw.githubusercontent.com/bruin-data/dac/<ref>/install.sh` URL didn't resolve.
- Replace the version-pinned URL with the canonical `https://getbruin.com/install/dac` — the same one we ship in the README — and drop the now-unused `installScriptURL(version)` helper plus its test.

## Test plan
- [x] `go test ./cmd/...` passes
- [x] `go vet ./cmd/...` clean
- [ ] Manual: build a binary, run `dac upgrade`, confirm it reinstalls successfully on stable and edge channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)