### PR TITLE
Add validation workflow guidance to create-dashboard skill

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -18,6 +18,25 @@ When invoked, use `$ARGUMENTS` as the description of what dashboard to create.
 
 ---
 
+## Validation Workflow — Read Before Editing
+
+`dac check` runs **every widget's query** against the live database and scales with total widget count. Running it after every edit is the single biggest waste of time when iterating on a dashboard. Pick the cheapest tool that proves the change is correct:
+
+| Change you just made | Run this | Why |
+|---|---|---|
+| UI-only — `chart` type, `col`, labels, `format`, `prefix`/`suffix`, colors, text/markdown, divider/image, theme, row order | **nothing** | No query changed. `dac serve` live-reloads instantly in the browser. |
+| One widget's SQL, `query:` ref, or column mapping | `dac query --dir ./dashboards --dashboard "X" --widget "Y"` | Executes only that one query, returns rows. ~1 query of latency. |
+| Filters, named queries, metrics/dimensions wiring, `col` sums, new widget skeletons | `dac validate --dir ./dashboards` | Structural check, no SQL executed. Sub-second. |
+| End-of-task sweep, or many widgets changed at once | `dac check --dir ./dashboards` | Full execution. Slow — only run once when you think you're done. |
+
+**Rules:**
+1. Default to **no command** for UI tweaks. The live reload in `dac serve` is the feedback loop, not the CLI.
+2. Never run `dac check` and then re-run individual widgets — pick one. Per-edit = `dac query --widget`; end-of-task = `dac check`.
+3. If you changed N widgets and N ≥ ~half the dashboard, `dac check` is fine. Otherwise `dac query --widget` per change is cheaper.
+4. `dac validate` is cheap (<1s) but only catches structure, never SQL errors. Don't rely on it for SQL edits.
+
+---
+
 ## Project Structure
 
 ```
@@ -1061,6 +1080,8 @@ dac check --dir ./dashboards
 ```
 
 Goes beyond `validate`: parses YAML, resolves all query references, applies default filter values, executes every query, and reports results with row/column counts and timing. Catches SQL errors, missing tables, bad column names.
+
+> **Cost warning:** runtime scales linearly with the total widget count across all dashboards in `--dir`. Reserve it for end-of-task sweeps. For per-edit checks, use `dac query --dashboard X --widget Y` to run a single widget instead. See the [Validation Workflow](#validation-workflow--read-before-editing) section at the top.
 
 ### `dac query` — Run a SQL query
 


### PR DESCRIPTION
## Summary
- Adds a prominent **Validation Workflow** section near the top of `.claude/skills/create-dashboard/SKILL.md` that maps each kind of edit to the cheapest CLI tool that proves it.
- Adds a **cost-warning callout** to the existing `dac check` CLI entry pointing back to the new section.

## What changed in the skill
The skill previously documented `dac validate` (cheap, structure-only) and `dac check` (expensive, executes every query) but gave **no guidance on when to use either**. The scoped command `dac query --dashboard X --widget Y` — which runs a single widget's query — was buried in the CLI reference and never recommended as a workflow tool. As a result, agents reached for `dac check` after every edit, including UI-only ones.

The new section pins the rules:

| Change | Run this |
|---|---|
| UI-only (chart type, `col`, labels, `format`, colors, text, theme, row order) | **nothing** — trust `dac serve` live reload |
| One widget's SQL/`query:` ref | `dac query --dashboard X --widget Y` |
| Structural (filters, named queries, metrics/dimensions wiring, `col` sums) | `dac validate` |
| End-of-task sweep / many widgets at once | `dac check` |

Plus four explicit rules: don't run anything for UI tweaks; never `dac check` *and* per-widget; only switch to `dac check` when ≥ ~half the widgets changed; `dac validate` never catches SQL errors.

## How it was tested
Created a temporary `tmp/` workspace with:
- `tmp/.bruin.yml` — DuckDB connection.
- `tmp/data/test.duckdb` seeded via `bruin query`: **customers** (500K rows), **products** (5K rows), **sales** (2M rows).
- `tmp/dashboards/sales.yml` — 9 widgets (4 metrics, 4 charts, 1 table) joining the three tables.

Built `bin/dac` from this branch and timed each command 3× back-to-back. Median real time:

### Old workflow (whole-dashboard validation per edit)
| Command | Median |
|---|---|
| `dac validate` | 0.59s |
| `dac check` (9 widgets) | **5.67s** |

### New workflow (scoped to the change)
| Command | Median |
|---|---|
| `dac validate` (structure only) | 0.59s |
| `dac query --widget "Total Revenue"` (simple SUM) | 1.19s |
| `dac query --widget "Daily Revenue Trend"` (2M-row agg, 501 buckets) | 1.26s |
| `dac query --widget "Top Products"` (join + group + LIMIT 20) | 1.23s |
| UI-only edit | **0s** (no command) |

Per-widget runtime is dominated by ~1s of CLI/DuckDB-open overhead, so it's roughly flat regardless of which widget is re-run.

## Expected performance improvement
Per-edit cost goes from `O(N × per-query latency)` to `O(1 query)` or `O(0)`:

- **UI-only edit:** 5.67s → 0s. Infinite speedup (the most common edit during iteration).
- **Single-SQL edit:** 5.67s → ~1.23s. **~4.6× faster, 4.4s saved per edit.**
- **Structural edit only:** 5.67s → 0.59s. **~9.6× faster.**

The gap widens with dashboard size. The user's reference dashboards (~90 widgets across 3 dashboards at ~2.1s/query against BigQuery) measured 3–4 minutes for `dac check` — the new workflow brings per-edit cost down to a single ~2s query.

## Test plan
- [x] Skill renders correctly (table + cross-reference link).
- [x] Old commands benchmarked on a representative DuckDB dataset.
- [x] New commands benchmarked on the same dataset.
- [x] `tmp/` cleaned up before commit (gitignored anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)