### PR TITLE
Add optional id field to widgets

### DIFF
--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -518,6 +518,7 @@ func vnodeToRow(n *vnode) Row {
 
 func vnodeToWidget(n *vnode) Widget {
 	w := Widget{
+		ID:          asString(n.Props["id"]),
 		Name:        asString(n.Props["name"]),
 		Description: asString(n.Props["description"]),
 		Type:        widgetType(n.Tag),

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -131,9 +131,10 @@ type Row struct {
 // Widget represents a single dashboard widget.
 // Query resolution priority: query (named ref) > sql (inline) > file (external).
 type Widget struct {
+	ID          string `yaml:"id,omitempty" json:"id,omitempty"`
 	Name        string `yaml:"name" json:"name"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
-	Type        string `yaml:"type" json:"type"` // metric, chart, table, text
+	Type        string `yaml:"type" json:"type"`
 	Col         int    `yaml:"col,omitempty" json:"col,omitempty"`
 
 	// Query source (pick one)

--- a/pkg/dashboard/widget_id_test.go
+++ b/pkg/dashboard/widget_id_test.go
@@ -1,0 +1,81 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestWidgetID_YAML(t *testing.T) {
+	yamlBody := `
+name: w
+type: metric
+id: kpi_rev
+sql: SELECT 1 AS value
+column: value
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if w.ID != "kpi_rev" {
+		t.Errorf("expected ID = %q, got %q", "kpi_rev", w.ID)
+	}
+}
+
+func TestWidgetID_JSON(t *testing.T) {
+	body := []byte(`{"name":"w","type":"metric","id":"kpi_rev","sql":"SELECT 1","column":"value"}`)
+	var w Widget
+	if err := json.Unmarshal(body, &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if w.ID != "kpi_rev" {
+		t.Errorf("expected ID = %q, got %q", "kpi_rev", w.ID)
+	}
+}
+
+func TestWidgetID_OmittedWhenEmpty(t *testing.T) {
+	w := Widget{Name: "w", Type: "text", Content: "hi"}
+	out, err := json.Marshal(w)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(out); got == "" || containsKey(got, "id") {
+		t.Errorf("expected no id key when ID empty, got: %s", got)
+	}
+}
+
+func TestWidgetID_Roundtrip(t *testing.T) {
+	w := Widget{ID: "kpi_rev", Name: "w", Type: "metric"}
+	out, err := yaml.Marshal(&w)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back Widget
+	if err := yaml.Unmarshal(out, &back); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if back.ID != "kpi_rev" {
+		t.Errorf("roundtrip lost ID: got %q", back.ID)
+	}
+}
+
+func TestWidgetID_OptionalNotRequired(t *testing.T) {
+	d := &Dashboard{
+		Name: "t",
+		Rows: []Row{{Widgets: []Widget{{Name: "w", Type: WidgetTypeText, Content: "hi"}}}},
+	}
+	if err := Validate(d); err != nil {
+		t.Fatalf("expected no error for widget without id, got: %v", err)
+	}
+}
+
+func containsKey(jsonStr, key string) bool {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
+}

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -213,6 +213,9 @@
       "type": "object",
       "required": ["name", "type"],
       "properties": {
+        "id": {
+          "type": "string"
+        },
         "name": {
           "type": "string",
           "minLength": 1


### PR DESCRIPTION
## Summary
- Adds optional `id` string field to `Widget` (model.go, json schema, TSX loader)
- Pure addition: no validator rules, no existing fields touched, no frontend changes
- Matches agent-runner's widget `id` (which is required there; we're keeping it optional in dac)
- Enables cloud's selection/deep-link/data-fetch flows that key off `widget.id`

## Test plan
- [x] \`make test\` green
- [x] \`make build\` green
- [x] All existing testdata/example dashboards still validate
- [x] 5 new test cases covering YAML/JSON round-trip + omitempty + optionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)