### PR TITLE
[codex] Add date and number filters

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -166,9 +166,19 @@ filters:
   - name: search
     type: text
     default: ""
+
+  # Plain date input
+  - name: as_of_date
+    type: date
+    default: "2025-01-01"
+
+  # Plain numeric input
+  - name: min_revenue
+    type: number
+    default: 1000
 ```
 
-**Filter types:** `select`, `date-range`, `text`
+**Filter types:** `select`, `date-range`, `date`, `number`, `text`
 
 **Date range presets:** `today`, `yesterday`, `last_7_days`, `last_30_days`, `last_90_days`, `this_month`, `last_month`, `this_quarter`, `this_year`, `year_to_date`, `all_time`. If `options.presets` is omitted, a default set is shown. Users can always pick "Custom range" for arbitrary dates.
 
@@ -780,9 +790,11 @@ WHERE created_at >= '{{ filters.date_range.start }}'
 {{ filters.date_range.end }}
 ```
 
-**Accessing simple values (select, text):**
+**Accessing simple values (select, date, number, text):**
 ```sql
 {{ filters.region }}
+{{ filters.as_of_date }}
+{{ filters.min_revenue }}
 {{ filters.search }}
 ```
 
@@ -1414,7 +1426,7 @@ rows:
 - `text` widgets require `content`.
 - `image` widgets require `src`.
 - `divider` widgets have no required fields.
-- Filter types must be one of: `select`, `date-range`, `text`.
+- Filter types must be one of: `select`, `date-range`, `date`, `number`, `text`.
 - Named query references (`query: name`) must exist in the `queries:` map.
 - `source` is required when `metrics` or `dimensions` are defined; `source.table` is required.
 - Each metric must have either `aggregate` or `expression` (not both).

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -109,6 +109,8 @@ Supported filter types:
 
 - `select`
 - `date-range`
+- `date`
+- `number`
 - `text`
 
 Date range presets include `today`, `yesterday`, `last_7_days`, `last_30_days`, `last_90_days`, `this_month`, `last_month`, `this_quarter`, `this_year`, `year_to_date`, and `all_time`.

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -37,7 +37,7 @@ dac validate --with-database
 - **Widgets**: `type` and `name` are required
 - **Grid**: column spans are 1-12, row totals don't exceed 12
 - **Query references**: named queries referenced by widgets exist in the `queries` map
-- **Filter types**: must be `select`, `date-range`, or `text`
+- **Filter types**: must be `select`, `date-range`, `date`, `number`, or `text`
 - **Chart types**: valid chart type names
 - **Semantic layer**:
   - model files under `semantic/` have a `name` and `source.table`

--- a/docs/dashboards/filters.md
+++ b/docs/dashboards/filters.md
@@ -4,7 +4,7 @@ Filters add interactive controls to dashboards. Users can change filter values i
 
 ## Filter Types
 
-DAC supports three filter types:
+DAC supports five filter types:
 
 ### Select
 
@@ -65,6 +65,26 @@ With specific presets:
         - this_year
 ```
 
+### Date
+
+A single plain date input. The current value is a `YYYY-MM-DD` string.
+
+```yaml
+  - name: as_of_date
+    type: date
+    default: "2025-01-31"
+```
+
+### Number
+
+A plain numerical input. Numeric values are sent to queries as numbers.
+
+```yaml
+  - name: min_order_value
+    type: number
+    default: 100
+```
+
 ### Text
 
 A free-form text input.
@@ -121,6 +141,20 @@ WHERE created_at >= '{{ filters.date_range.start }}'
   AND created_at <= '{{ filters.date_range.end }}'
 ```
 
+### Date Filters
+
+```sql
+SELECT * FROM orders
+WHERE created_at::date = DATE '{{ filters.as_of_date }}'
+```
+
+### Number Filters
+
+```sql
+SELECT * FROM orders
+WHERE order_value >= {{ filters.min_order_value }}
+```
+
 ### Text Filters
 
 ```sql
@@ -133,9 +167,9 @@ WHERE customer_name LIKE '%{{ filters.search }}%'
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Filter identifier, used in `filters.<name>` |
-| `type` | string | Yes | `select`, `date-range`, or `text` |
+| `type` | string | Yes | `select`, `date-range`, `date`, `number`, or `text` |
 | `multiple` | bool | No | Allow multiple selections (select only) |
-| `default` | any | No | Initial value. String preset for date-range, array for multi-select |
+| `default` | any | No | Initial value. String preset for date-range, `YYYY-MM-DD` string for date, number for number, array for multi-select |
 | `options` | object | No | Filter options configuration |
 | `options.values` | string[] | No | Static list of options (select) |
 | `options.query` | string | No | SQL to populate options (select) |

--- a/docs/dashboards/queries.md
+++ b/docs/dashboards/queries.md
@@ -152,6 +152,13 @@ WHERE created_at >= '{{ filters.date_range.start }}'
   AND created_at < DATE '{{ filters.date_range.end }}' + INTERVAL 1 DAY
 ```
 
+Plain date filters expose a single `YYYY-MM-DD` string, while number filters expose a numeric value:
+
+```sql
+WHERE order_date = DATE '{{ filters.as_of_date }}'
+  AND order_value >= {{ filters.min_order_value }}
+```
+
 The same pattern works in semantic filters:
 
 ```yaml

--- a/docs/dashboards/semantic-layer.md
+++ b/docs/dashboards/semantic-layer.md
@@ -252,7 +252,7 @@ rows:
 
 DAC has two related filter concepts:
 
-- Dashboard filters define UI controls, such as `select`, `date-range`, and `text`.
+- Dashboard filters define UI controls, such as `select`, `date-range`, `date`, `number`, and `text`.
 - Semantic query filters define predicates applied to semantic dimensions before SQL execution.
 
 Dashboard filter values can be referenced in semantic filters with the same Jinja-style syntax used by SQL queries:

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ DAC (**D**ashboard-**a**s-**C**ode) is a tool for defining, validating, and serv
 - A single binary deployment that can run locally, on a server, or be exported as static HTML for hosting anywhere
 - Designed for use by both humans and AI agents, with a focus on reviewable, reproducible, and composable dashboard definitions
 - Supports all the major databases: Postgres, MySQL, Snowflake, BigQuery, Redshift, Databricks, and more via [Bruin](https://github.com/bruin-data/bruin)
-- Interactive [filters](/dashboards/filters). Date pickers, dropdowns, multiselects, and search inputs that inject into SQL via [Jinja templating](/dashboards/queries) and re-run affected widgets in place.
+- Interactive [filters](/dashboards/filters). Date pickers, numeric inputs, dropdowns, multiselects, and search inputs that inject into SQL via [Jinja templating](/dashboards/queries) and re-run affected widgets in place.
 - Dynamic charts, tabs, loops and conditionals with TSX
 - Built-in AI agent via Codex: chat with your dashboard live and get it updated
 

--- a/examples/basic-yaml/dashboards/date-number-filters.yml
+++ b/examples/basic-yaml/dashboards/date-number-filters.yml
@@ -1,0 +1,98 @@
+name: Date and Number Filters
+description: Minimal dashboard for validating plain date and number filters
+connection: local_duckdb
+
+filters:
+  - name: as_of_date
+    type: date
+    default: "2099-12-31"
+  - name: min_order_value
+    type: number
+    default: 100
+
+rows:
+  - widgets:
+      - name: Filtered Orders
+        type: metric
+        col: 3
+        sql: |
+          SELECT COUNT(*) AS value
+          FROM orders
+          WHERE created_at <= DATE '{{ filters.as_of_date }}'
+            AND amount >= {{ filters.min_order_value }}
+        column: value
+        format: number
+
+      - name: Filtered Revenue
+        type: metric
+        col: 3
+        sql: |
+          SELECT SUM(amount) AS value
+          FROM orders
+          WHERE created_at <= DATE '{{ filters.as_of_date }}'
+            AND amount >= {{ filters.min_order_value }}
+        column: value
+        prefix: "$"
+        format: number
+
+      - name: Average Order Value
+        type: metric
+        col: 3
+        sql: |
+          SELECT ROUND(AVG(amount), 2) AS value
+          FROM orders
+          WHERE created_at <= DATE '{{ filters.as_of_date }}'
+            AND amount >= {{ filters.min_order_value }}
+        column: value
+        prefix: "$"
+        format: number
+
+      - name: Max Order Value
+        type: metric
+        col: 3
+        sql: |
+          SELECT MAX(amount) AS value
+          FROM orders
+          WHERE created_at <= DATE '{{ filters.as_of_date }}'
+            AND amount >= {{ filters.min_order_value }}
+        column: value
+        prefix: "$"
+        format: number
+
+  - widgets:
+      - name: Orders by Status
+        type: chart
+        chart: bar
+        col: 5
+        sql: |
+          SELECT status, COUNT(*) AS orders
+          FROM orders
+          WHERE created_at <= DATE '{{ filters.as_of_date }}'
+            AND amount >= {{ filters.min_order_value }}
+          GROUP BY 1
+          ORDER BY 2 DESC
+        x: status
+        y: [orders]
+
+      - name: Recent Matching Orders
+        type: table
+        col: 7
+        sql: |
+          SELECT id, customer_name, amount, status, created_at
+          FROM orders
+          WHERE created_at <= DATE '{{ filters.as_of_date }}'
+            AND amount >= {{ filters.min_order_value }}
+          ORDER BY created_at DESC
+          LIMIT 20
+        columns:
+          - name: id
+            label: Order ID
+          - name: customer_name
+            label: Customer
+          - name: amount
+            label: Amount
+            format: currency
+          - name: status
+            label: Status
+          - name: created_at
+            label: Date

--- a/frontend/src/themes/bruin/FilterBar.tsx
+++ b/frontend/src/themes/bruin/FilterBar.tsx
@@ -217,6 +217,41 @@ function FilterControl({
     case "date-range":
       return <DateRangeFilter filter={filter} value={value} onChange={onChange} label={label} />;
 
+    case "date":
+      return (
+        <div className="flex flex-col gap-1">
+          <label className="text-[10px] font-medium uppercase tracking-wider text-[var(--dac-text-muted)]">
+            {label}
+          </label>
+          <input
+            type="date"
+            className={`${inputClass} min-w-[128px]`}
+            value={String(value ?? filter.default ?? "")}
+            onChange={(e) => onChange(e.target.value)}
+          />
+        </div>
+      );
+
+    case "number":
+      return (
+        <div className="flex flex-col gap-1">
+          <label className="text-[10px] font-medium uppercase tracking-wider text-[var(--dac-text-muted)]">
+            {label}
+          </label>
+          <input
+            type="number"
+            className={`${inputClass} w-[112px] tabular-nums`}
+            value={String(value ?? filter.default ?? "")}
+            onChange={(e) => {
+              const raw = e.target.value;
+              const next = e.target.valueAsNumber;
+              onChange(raw === "" || Number.isNaN(next) ? raw : next);
+            }}
+            placeholder={label}
+          />
+        </div>
+      );
+
     case "text":
       return (
         <div className="flex flex-col gap-1">

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -23,7 +23,7 @@ export interface Dashboard {
 
 export interface Filter {
   name: string;
-  type: "date-range" | "select" | "text";
+  type: "date" | "date-range" | "number" | "select" | "text";
   multiple?: boolean;
   default?: unknown;
   options?: {

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -163,7 +163,7 @@ func Validate(d *Dashboard) error {
 		if f.Type == "" {
 			errs = append(errs, fmt.Sprintf("%s: type is required", prefix))
 		}
-		validTypes := map[string]bool{"date-range": true, "date": true, "select": true, "text": true, "number": true}
+		validTypes := map[string]bool{"date": true, "date-range": true, "number": true, "select": true, "text": true}
 		if f.Type != "" && !validTypes[f.Type] {
 			errs = append(errs, fmt.Sprintf("%s: unknown filter type %q", prefix, f.Type))
 		}

--- a/pkg/dashboard/validator_test.go
+++ b/pkg/dashboard/validator_test.go
@@ -113,6 +113,28 @@ func TestValidate_ChartWidgetMissingChartType(t *testing.T) {
 	assertValidationContains(t, err, "chart type is required")
 }
 
+func TestValidate_FilterTypes(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Filters: []Filter{
+			{Name: "region", Type: "select"},
+			{Name: "date_range", Type: "date-range"},
+			{Name: "as_of_date", Type: "date"},
+			{Name: "min_revenue", Type: "number"},
+			{Name: "search", Type: "text"},
+		},
+		Rows: []Row{
+			{Widgets: []Widget{{Name: "w", Type: WidgetTypeText, Content: "hi"}}},
+		},
+	}
+	assertNoErr(t, Validate(d))
+
+	d.Filters = append(d.Filters, Filter{Name: "bad", Type: "boolean"})
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, `unknown filter type "boolean"`)
+}
+
 func TestValidate_ProjectSemanticDashboard(t *testing.T) {
 	d, err := LoadFile("../../testdata/project/dashboards/semantic-sales.yml")
 	assertNoErr(t, err)

--- a/pkg/server/agent.go
+++ b/pkg/server/agent.go
@@ -17,7 +17,7 @@ import (
 const dashboardSchemaRef = `Dashboard YAML structure:
 - schema: optional; v1 is assumed when omitted
 - name, description, connection (default DB connection)
-- filters: [{name, type (select|date-range), default, options}]
+- filters: [{name, type (select|date-range|date|number|text), default, options}]
 - queries: named reusable SQL queries (sql: inline | file: path.sql)
 - rows: [{widgets: [...]}]
 

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -84,7 +84,7 @@
           "minLength": 1
         },
         "type": {
-          "enum": ["select", "date-range", "date", "text", "number"]
+          "enum": ["select", "date-range", "date", "number", "text"]
         },
         "multiple": {
           "type": "boolean"

--- a/schemas/schema_test.go
+++ b/schemas/schema_test.go
@@ -26,6 +26,26 @@ rows:
 `,
 		},
 		{
+			name:     "dashboard filter types",
+			schemaID: DashboardV1ID,
+			yaml: `schema: https://getbruin.com/schemas/dac/dashboard/v1
+name: Filter Types
+filters:
+  - name: as_of_date
+    type: date
+    default: "2025-01-31"
+  - name: min_value
+    type: number
+    default: 100
+rows:
+  - widgets:
+      - name: One
+        type: metric
+        sql: SELECT 1 AS value
+        column: value
+`,
+		},
+		{
 			name:     "semantic model",
 			schemaID: SemanticModelV1ID,
 			yaml: `schema: https://getbruin.com/schemas/dac/semantic-model/v1


### PR DESCRIPTION
## Summary

Adds plain `date` and `number` dashboard filter support across the frontend controls, TypeScript types, Go validation, JSON schema, docs, and agent/skill guidance. Includes a basic YAML example dashboard that uses both new filter types in metric, chart, and table SQL so authors can validate the behavior against the sample DuckDB data.

## Testing

- [x] `make test`
- [x] `make build`
- [x] `./bin/dac validate --dir examples/basic-yaml`
- [x] `./bin/dac check --dir examples/basic-yaml`

## Checklist

- [x] scanned `docs/` and updated (or added) the relevant pages
- [x] examples updated if the authoring model changed
- [ ] screenshots or recordings attached for UI changes
