### PR TITLE
Replace metric widget flat fields with value encoding; drop dead theme/refresh fields

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -102,11 +102,6 @@ rows: []                              # At least one row required
 # Optional
 description: A description            # Shown on the dashboard list page
 connection: my_duckdb                 # Default connection for all queries
-theme: bruin                          # Template name (bruin, bruin-dark, or custom)
-
-# Optional: refresh config
-refresh:
-  interval: 5m                        # Cache TTL for query results
 
 # Optional: interactive filters
 filters: []

--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -24,7 +24,7 @@ When invoked, use `$ARGUMENTS` as the description of what dashboard to create.
 
 | Change you just made | Run this | Why |
 |---|---|---|
-| UI-only — `chart` type, `col`, labels, `format`, `prefix`/`suffix`, colors, text/markdown, divider/image, theme, row order | **nothing** | No query changed. `dac serve` live-reloads instantly in the browser. |
+| UI-only — `chart` type, `col`, labels, `value` formatting, colors, text/markdown, divider/image, theme, row order | **nothing** | No query changed. `dac serve` live-reloads instantly in the browser. |
 | One widget's SQL, `query:` ref, or column mapping | `dac query --dir ./dashboards --dashboard "X" --widget "Y"` | Executes only that one query, returns rows. ~1 query of latency. |
 | Filters, named queries, metrics/dimensions wiring, `col` sums, new widget skeletons | `dac validate --dir ./dashboards` | Structural check, no SQL executed. Sub-second. |
 | End-of-task sweep, or many widgets changed at once | `dac check --dir ./dashboards` | Full execution. Slow — only run once when you think you're done. |
@@ -360,11 +360,22 @@ Single KPI number card. Two modes: **declarative** (using top-level metrics) or 
 - name: Page Views
   type: metric
   metric: page_views              # References a metric from the metrics: map
-  format: number                  # Optional: "number" for locale formatting
+  value:
+    field: value                  # Result column (auto-aliased to "value" for metric refs)
+    type: number
+    format: ",.0f"                # Optional: d3-format string
   col: 3
 ```
 
 All metric-ref widgets sharing the same dashboard are merged into a **single SQL query** for efficiency. Expression metrics (e.g. `pages_per_session`) are evaluated client-side from the query results.
+
+The `value` encoding controls how the number is displayed:
+
+- `value.field` — REQUIRED: which result column holds the number.
+- `value.type` — `number`, `date`, or `category`.
+- `value.format` — optional [d3-format](https://github.com/d3/d3-format) string. Currency and percent are expressed in the format string itself — there are no `prefix`/`suffix` fields. Examples: `",.0f"` (integer with thousands separators), `"$,.2f"` (currency), `".1%"` (percent).
+
+When no formatting is needed, `value` can be a bare column name string (shorthand for `{ field: "<col>" }`).
 
 **Query-based mode** — provide SQL directly:
 
@@ -372,14 +383,24 @@ All metric-ref widgets sharing the same dashboard are merged into a **single SQL
 - name: Total Revenue
   type: metric
   query: total_revenue          # or sql: / file:
-  column: value                 # REQUIRED: which result column to display
-  prefix: "$"                   # Optional: shown before the number
-  suffix: "%"                   # Optional: shown after the number
-  format: number                # Optional: "number" for locale formatting
+  value:
+    field: value                # REQUIRED: which result column to display
+    type: number                # number | date | category
+    format: "$,.2f"             # Optional: d3-format string (currency, percent, etc.)
   col: 3
 ```
 
-The SQL must return at least one row. The value from `column` in the first row is displayed.
+Shorthand — when no formatting is needed, set `value` to the column name directly:
+
+```yaml
+- name: Total Orders
+  type: metric
+  sql: SELECT COUNT(*) as total FROM orders
+  value: total                  # Shorthand: just the result column
+  col: 3
+```
+
+The SQL must return at least one row. The value from `value.field` in the first row is displayed.
 
 ### Chart Widget
 
@@ -855,10 +876,10 @@ export default (
     <Row>
       <Metric name="Revenue" col={3}
         sql="SELECT SUM(amount) as value FROM sales"
-        column="value" prefix="$" format="number" />
+        value={{ field: "value", type: "number", format: "$,.2f" }} />
       <Metric name="Orders" col={3}
         sql="SELECT COUNT(*) as value FROM orders"
-        column="value" format="number" />
+        value={{ field: "value", type: "number", format: ",.0f" }} />
     </Row>
 
     <Row>
@@ -889,7 +910,7 @@ Every YAML widget type has a corresponding JSX tag. Props map directly to YAML f
 | `<Filter>` | (filter) | `name`, `type`, `default`, `multiple`, `options` |
 | `<Query>` | (named query) | `name`, `sql`, `file`, `connection` |
 | `<Semantic>` | (semantic layer) | `source`, `metrics`, `dimensions` |
-| `<Metric>` | `metric` | `name`, `col`, `sql`, `query`, `column`, `prefix`, `suffix`, `format`, `metric` |
+| `<Metric>` | `metric` | `name`, `col`, `sql`, `query`, `value`, `metric` |
 | `<Chart>` | `chart` | `name`, `col`, `chart`, `sql`, `x`, `y`, `label`, `value`, `stacked`, `dimension`, `metrics`, `limit`, etc. |
 | `<Table>` | `table` | `name`, `col`, `sql`, `query`, `columns` |
 | `<Text>` | `text` | `name`, `col`, `content` |
@@ -901,14 +922,14 @@ Every YAML widget type has a corresponding JSX tag. Props map directly to YAML f
 Define reusable widget patterns as functions — impossible in YAML:
 
 ```tsx
-function KPI({ name, sql, prefix, ...rest }) {
-  return <Metric name={name} sql={sql} column="value" format="number" prefix={prefix} {...rest} />
+function KPI({ name, sql, format = ",.0f", ...rest }) {
+  return <Metric name={name} sql={sql} value={{ field: "value", type: "number", format }} {...rest} />
 }
 
 export default (
   <Dashboard name="Sales" connection="duckdb">
     <Row>
-      <KPI name="Revenue" sql="SELECT SUM(amount) as value FROM sales" prefix="$" col={4} />
+      <KPI name="Revenue" sql="SELECT SUM(amount) as value FROM sales" format="$,.0f" col={4} />
       <KPI name="Orders" sql="SELECT COUNT(*) as value FROM orders" col={4} />
     </Row>
   </Dashboard>
@@ -926,9 +947,9 @@ export default (
   <Dashboard name="Sales" connection="duckdb">
     <Row>
       {regions.map(r =>
-        <Metric name={`${r} Revenue`} col={4} prefix="$"
+        <Metric name={`${r} Revenue`} col={4}
           sql={`SELECT SUM(amount) as value FROM sales WHERE region = '${r}'`}
-          column="value" format="number" />
+          value={{ field: "value", type: "number", format: "$,.2f" }} />
       )}
     </Row>
   </Dashboard>
@@ -947,8 +968,8 @@ const tables = query("duckdb",
   "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main' ORDER BY 1"
 )
 
-function KPI({ name, sql, prefix, ...rest }) {
-  return <Metric name={name} sql={sql} column="value" format="number" prefix={prefix} {...rest} />
+function KPI({ name, sql, format = ",.0f", ...rest }) {
+  return <Metric name={name} sql={sql} value={{ field: "value", type: "number", format }} {...rest} />
 }
 
 export default (
@@ -960,7 +981,7 @@ export default (
     {/* Auto-generated per-region KPIs — adapts when data changes */}
     <Row>
       {regions.rows.map(([region]) => (
-        <KPI name={region} prefix="$"
+        <KPI name={region} format="$,.0f"
           col={Math.floor(12 / regions.rows.length)}
           sql={`SELECT SUM(amount) as value FROM sales WHERE region = '${region}'`} />
       ))}
@@ -1030,8 +1051,8 @@ Import shared `.tsx`, `.js`, or `.json` files using CommonJS `require()`:
 
 ```tsx
 // lib/kpi.tsx
-function KPI({ name, sql, ...rest }) {
-  return <Metric name={name} sql={sql} column="value" format="number" {...rest} />
+function KPI({ name, sql, format = ",.0f", ...rest }) {
+  return <Metric name={name} sql={sql} value={{ field: "value", type: "number", format }} {...rest} />
 }
 module.exports = { KPI }
 
@@ -1041,7 +1062,7 @@ const { KPI } = require("./lib/kpi")
 export default (
   <Dashboard name="Sales" connection="duckdb">
     <Row>
-      <KPI name="Revenue" sql="..." prefix="$" col={4} />
+      <KPI name="Revenue" sql="..." format="$,.0f" col={4} />
     </Row>
   </Dashboard>
 )
@@ -1262,21 +1283,34 @@ rows:
       - name: Page Views
         type: metric
         metric: page_views
-        format: number
+        value:
+          field: value
+          type: number
+          format: ",.0f"
         col: 3
       - name: Users
         type: metric
         metric: users
-        format: number
+        value:
+          field: value
+          type: number
+          format: ",.0f"
         col: 3
       - name: Sessions
         type: metric
         metric: sessions
-        format: number
+        value:
+          field: value
+          type: number
+          format: ",.0f"
         col: 3
       - name: Pages / Session
         type: metric
         metric: pages_per_session
+        value:
+          field: value
+          type: number
+          format: ".2f"
         col: 3
 
   # Dimensional charts — SQL auto-generated from source + metrics + dimensions
@@ -1355,23 +1389,27 @@ rows:
       - name: Total Revenue
         type: metric
         query: total_revenue
-        column: value
-        prefix: "$"
-        format: number
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
         col: 4
       - name: Total Orders
         type: metric
         col: 4
         sql: SELECT COUNT(*) as total FROM orders
-        column: total
-        format: number
+        value:
+          field: total
+          type: number
+          format: ",.0f"
       - name: Avg Order
         type: metric
         col: 4
         sql: SELECT ROUND(AVG(amount), 2) as avg FROM orders
-        column: avg
-        prefix: "$"
-        format: number
+        value:
+          field: avg
+          type: number
+          format: "$,.2f"
 
   - widgets:
       - name: Revenue Trend
@@ -1418,7 +1456,7 @@ rows:
 
 | Type | Required Fields | Query Source | Description |
 |------|----------------|--------------|-------------|
-| `metric` | `metric:` ref OR `column` + query | Declarative or SQL | Single KPI number card |
+| `metric` | `metric:` ref OR `value` + query | Declarative or SQL | Single KPI number card |
 | `chart` | `dimension` + `metrics` OR `chart` + x/y + query | Declarative or SQL | Visualization (21 chart types) |
 | `table` | — | SQL | Data table with optional column config |
 | `text` | `content` | None | Markdown/text content |
@@ -1459,7 +1497,7 @@ rows:
 - At least one row is required; each row needs at least one widget.
 - `col` must be 1-12; total per row must not exceed 12.
 - Every widget that requires data needs a query source (`query`, `sql`, `file`) OR a declarative reference (`metric:` for metric widgets, `dimension:` + `metrics:` for chart widgets).
-- `metric` widgets require either `metric: <name>` (declarative) or `column` + query source (SQL mode).
+- `metric` widgets require either `metric: <name>` (declarative) or `value` + query source (SQL mode).
 - `chart` widgets require `chart` type plus either `dimension` + `metrics` (declarative) or chart-specific fields (SQL mode).
 - `text` widgets require `content`.
 - `image` widgets require `src`.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ It is built for AI agents to build dashboards in a reliable and reviewable way.
         name="Total Revenue"
         col={4}
         sql="SELECT SUM(amount) AS value FROM sales"
-        column="value"
-        prefix="$"
-        format="number"
+        value={{ field: "value", type: "number", format: "$,.2f" }}
       /&gt;
     &lt;/Row&gt;
   &lt;/Dashboard&gt;
@@ -46,8 +44,10 @@ rows:
       - name: Revenue
         type: metric
         sql: SELECT SUM(amount) AS value FROM sales
-        column: value
-        prefix: "$"
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
         col: 4</code></pre>
 
 </td>

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -331,9 +331,10 @@ rows:
   - widgets:
       - name: Total Revenue
         type: metric
-        column: value
-        prefix: "$"
-        format: number
+        value:
+          field: value
+          type: number
+          format: "$,.0f"
         col: 3
         sql: |
 __INIT_CTE_WIDGET__
@@ -357,8 +358,10 @@ __INIT_CTE_WIDGET__
           {% if filters.region != 'All' %}
             AND region = '{{ filters.region }}'
           {% endif %}
-        column: value
-        format: number
+        value:
+          field: value
+          type: number
+          format: ",.0f"
 
       - name: Unique Customers
         type: metric
@@ -372,8 +375,10 @@ __INIT_CTE_WIDGET__
           {% if filters.region != 'All' %}
             AND region = '{{ filters.region }}'
           {% endif %}
-        column: value
-        format: number
+        value:
+          field: value
+          type: number
+          format: ",.0f"
 
       - name: Average Sale Value
         type: metric
@@ -387,9 +392,10 @@ __INIT_CTE_WIDGET__
           {% if filters.region != 'All' %}
             AND region = '{{ filters.region }}'
           {% endif %}
-        column: value
-        prefix: "$"
-        format: number
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
 
   - widgets:
       - name: Revenue Trend
@@ -529,8 +535,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        prefix: "$"
-        format: number
+        value:
+          field: revenue
+          type: number
+          format: "$,.0f"
         col: 3
 
       - name: Sales Count
@@ -545,7 +553,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        format: number
+        value:
+          field: sales_count
+          type: number
+          format: ",.0f"
         col: 3
 
       - name: Unique Customers
@@ -560,7 +571,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        format: number
+        value:
+          field: unique_customers
+          type: number
+          format: ",.0f"
         col: 3
 
       - name: Average Sale Value
@@ -575,8 +589,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        prefix: "$"
-        format: number
+        value:
+          field: avg_sale_value
+          type: number
+          format: "$,.2f"
         col: 3
 
   - widgets:
@@ -661,8 +677,7 @@ const initSemanticTSXDashboard = `export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        prefix="$"
-        format="number"
+        value={{ field: "revenue", type: "number", format: "$,.0f" }}
         col={3}
       />
       <Metric
@@ -672,7 +687,7 @@ const initSemanticTSXDashboard = `export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        format="number"
+        value={{ field: "sales_count", type: "number", format: ",.0f" }}
         col={3}
       />
       <Metric
@@ -682,7 +697,7 @@ const initSemanticTSXDashboard = `export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        format="number"
+        value={{ field: "unique_customers", type: "number", format: ",.0f" }}
         col={3}
       />
       <Metric
@@ -692,8 +707,7 @@ const initSemanticTSXDashboard = `export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        prefix="$"
-        format="number"
+        value={{ field: "avg_sale_value", type: "number", format: "$,.2f" }}
         col={3}
       />
     </Row>

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -93,9 +93,10 @@ rows:
           {% if filters.region != 'All' %}
             AND region = '{{ filters.region }}'
           {% endif %}
-        column: value
-        prefix: "$"
-        format: number
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
         col: 3
 ```
 
@@ -210,8 +211,10 @@ rows:
           - dimension: region
             operator: equals
             value: "{{ filters.region }}"
-        prefix: "$"
-        format: number
+        value:
+          field: revenue
+          type: number
+          format: "$,.0f"
         col: 3
 
       - name: Revenue by Month
@@ -251,8 +254,7 @@ export default (
         filters={[
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
         ]}
-        prefix="$"
-        format="number"
+        value={{ field: "revenue", type: "number", format: "$,.0f" }}
         col={3}
       />
       <Chart

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -59,7 +59,7 @@ func TestValidateDashboardWithDatabaseDryRunsWidgetQueries(t *testing.T) {
 				Name:     "Total Revenue",
 				Type:     dashboard.WidgetTypeMetric,
 				QueryRef: "total_revenue",
-				Column:   "value",
+				Value:    &dashboard.ValueEncoding{Field: "value", Type: "number", Format: "$,.0f"},
 			}},
 		}},
 	}
@@ -182,7 +182,7 @@ rows:
       - name: Total
         type: metric
         query: total
-        column: value
+        value: value
 `), 0o644); err != nil {
 		t.Fatalf("write dashboard: %v", err)
 	}

--- a/docs/dashboards/layout.md
+++ b/docs/dashboards/layout.md
@@ -106,7 +106,7 @@ In TSX, use the `<Tabs>` and `<Tab>` components:
 ```tsx
 <Dashboard name="Analytics" connection="my_db">
   <Row>
-    <Metric name="Revenue" col={4} sql="..." column="value" />
+    <Metric name="Revenue" col={4} sql="..." value={{ field: "value", type: "number", format: "$,.2f" }} />
   </Row>
 
   <Tabs>

--- a/docs/dashboards/overview.md
+++ b/docs/dashboards/overview.md
@@ -33,8 +33,10 @@ rows:
       - name: Revenue
         type: metric
         sql: SELECT SUM(amount) AS value FROM sales
-        column: value
-        prefix: "$"
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
         col: 4
 ```
 
@@ -57,7 +59,7 @@ export default (
               name="Row Count"
               col={4}
               sql={`SELECT COUNT(*) AS value FROM "${table}"`}
-              column="value"
+              value={{ field: "value", type: "number", format: ",.0f" }}
             />
           </Row>
         </Tab>

--- a/docs/dashboards/queries.md
+++ b/docs/dashboards/queries.md
@@ -20,7 +20,7 @@ rows:
       - name: Revenue
         type: metric
         query: total_revenue
-        column: value
+        value: value
 ```
 
 ## Named Semantic Queries
@@ -91,19 +91,19 @@ Examples:
 - name: Revenue
   type: metric
   query: total_revenue
-  column: value
+  value: value
 
 # Inline SQL
 - name: Revenue
   type: metric
   sql: SELECT SUM(amount) AS value FROM sales
-  column: value
+  value: value
 
 # External file
 - name: Revenue
   type: metric
   file: queries/revenue.sql
-  column: value
+  value: value
 
 # Semantic metric widget
 - name: Revenue

--- a/docs/dashboards/schemas.md
+++ b/docs/dashboards/schemas.md
@@ -19,7 +19,7 @@ rows:
       - name: Revenue
         type: metric
         sql: SELECT SUM(amount) AS value FROM sales
-        column: value
+        value: value
 ```
 
 Semantic model example:

--- a/docs/dashboards/semantic-layer.md
+++ b/docs/dashboards/semantic-layer.md
@@ -186,8 +186,10 @@ In this example, dashboard widgets can use `model: sales_model`, and DAC resolve
     - dimension: region
       operator: equals
       value: "{{ filters.region }}"
-  prefix: "$"
-  format: number
+  value:
+    field: revenue
+    type: number
+    format: "$,.0f"
   col: 3
 ```
 

--- a/docs/dashboards/themes.md
+++ b/docs/dashboards/themes.md
@@ -9,20 +9,11 @@ DAC includes a theme system based on design tokens. Choose a built-in theme or d
 | `bruin` | Light theme (default) |
 | `bruin-dark` | Dark theme |
 
-Set the theme in your dashboard:
-
-```yaml
-name: My Dashboard
-theme: bruin-dark
-```
-
-Or via the CLI:
+Select the theme with the `--template` flag, which applies to all dashboards:
 
 ```shell
 dac serve --template bruin-dark
 ```
-
-The `--template` flag overrides the theme for all dashboards.
 
 ## Custom Themes
 
@@ -45,13 +36,6 @@ Use it:
 
 ```shell
 dac serve --template ./themes/corporate.yml
-```
-
-Or reference it in your dashboard:
-
-```yaml
-name: My Dashboard
-theme: ./themes/corporate.yml
 ```
 
 ### Token Reference

--- a/docs/dashboards/tsx.md
+++ b/docs/dashboards/tsx.md
@@ -77,8 +77,6 @@ interface QueryResult {
   description="Description"
   connection="my_db"
   model="sales"
-  theme="bruin-dark"
-  refresh={{ interval: "5m" }}
 >
   {children}
 </Dashboard>

--- a/docs/dashboards/tsx.md
+++ b/docs/dashboards/tsx.md
@@ -20,9 +20,7 @@ export default (
         name="Total Revenue"
         col={4}
         sql="SELECT SUM(amount) AS value FROM sales"
-        column="value"
-        prefix="$"
-        format="number"
+        value={{ field: "value", type: "number", format: "$,.2f" }}
       />
       <Chart
         name="Revenue Over Time"
@@ -184,7 +182,7 @@ For a complete runnable project, see `examples/semantic-tsx`.
 All widget components accept the same props as their YAML equivalents.
 
 ```tsx
-<Metric name="Revenue" col={4} sql="..." column="value" />
+<Metric name="Revenue" col={4} sql="..." value={{ field: "value", type: "number", format: "$,.2f" }} />
 <Chart name="Trend" chart="area" col={8} sql="..." x="month" y={["revenue"]} />
 <Table name="Orders" col={12} sql="..." />
 <Text name="Note" col={6} content="**Important:** This data updates daily." />

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -15,17 +15,24 @@ Data-backed widgets (`metric`, `chart`, `table`) also need a query source: `quer
 
 ## Metric
 
-Metric widgets display a single value.
+Metric widgets display a single value. The value is configured with a `value`
+encoding — which column to read, its type, and a [d3-format](https://d3js.org/d3-format)
+string for display.
 
 ```yaml
 - name: Total Revenue
   type: metric
   sql: SELECT SUM(amount) AS value FROM sales
-  column: value
-  prefix: "$"
-  format: number
+  value:
+    field: value
+    type: number
+    format: "$,.2f"
   col: 3
 ```
+
+`value` also accepts a bare string as shorthand for the field name (`value: revenue`
+is the same as `value: { field: revenue }`), in which case the number is rendered
+with an auto-compact fallback (e.g. `1.2M`).
 
 Metric widgets can also use semantic models:
 
@@ -40,8 +47,10 @@ Metric widgets can also use semantic models:
       value:
         start: "{{ filters.date_range.start }}"
         end: "{{ filters.date_range.end }}"
-  prefix: "$"
-  format: number
+  value:
+    field: revenue
+    type: number
+    format: "$,.0f"
   col: 3
 ```
 
@@ -51,11 +60,15 @@ Metric-specific fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `column` | string | Result column to display for SQL-backed metrics |
+| `value` | string \| object | Value encoding. String form is the field name; object form takes `field`, `type`, and `format` |
+| `value.field` | string | Result column to display |
+| `value.type` | string | `number`, `date`, or `category` |
+| `value.format` | string | [d3-format](https://d3js.org/d3-format) string (numbers, e.g. `"$,.2f"`, `".0%"`) or d3-time-format string (dates, e.g. `"%b %Y"`) |
 | `metric` | string | Semantic metric name |
-| `prefix` | string | Text before the value |
-| `suffix` | string | Text after the value |
-| `format` | string | `number`, `currency`, or `percent` |
+
+> **Note:** Currency and unit affixes live in the format string — `$` is a d3-format
+> prefix (`"$,.2f"`) and `%` comes from the percent type (`".0%"` renders `0.12` as
+> `12%`). There are no separate `prefix`/`suffix` fields.
 
 ## Chart
 

--- a/docs/dashboards/yaml.md
+++ b/docs/dashboards/yaml.md
@@ -48,7 +48,10 @@ rows:
       - name: Row Count
         type: metric
         sql: SELECT COUNT(*) AS value FROM my_table
-        column: value
+        value:
+          field: value
+          type: number
+          format: ",.0f"
 ```
 
 ## Semantic Example
@@ -95,8 +98,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        prefix: "$"
-        format: number
+        value:
+          field: revenue
+          type: number
+          format: "$,.0f"
         col: 3
 
       - name: Revenue Trend
@@ -162,7 +167,7 @@ rows:
       - name: Revenue
         type: metric
         query: total_revenue
-        column: value
+        value: value
 ```
 
 ### Inline SQL
@@ -171,7 +176,7 @@ rows:
 - name: Revenue
   type: metric
   sql: SELECT SUM(amount) AS value FROM sales
-  column: value
+  value: value
 ```
 
 ### External SQL File
@@ -180,7 +185,7 @@ rows:
 - name: Revenue
   type: metric
   file: queries/revenue.sql
-  column: value
+  value: value
 ```
 
 ### Direct Semantic Query

--- a/docs/dashboards/yaml.md
+++ b/docs/dashboards/yaml.md
@@ -13,10 +13,6 @@ name: Sales Analytics              # required
 description: Revenue tracking      # optional
 connection: local_duckdb           # optional default connection
 model: sales                       # optional default semantic model
-theme: bruin-dark                  # optional
-
-refresh:
-  interval: 5m
 
 filters:
   - name: region
@@ -139,8 +135,6 @@ For a complete runnable project, see `examples/semantic-yaml`.
 | `connection` | string | No | Default connection for widgets and named queries |
 | `model` | string | No | Default semantic model for semantic widgets and named semantic queries |
 | `models` | map | No | Optional aliases that map dashboard names to semantic model names |
-| `theme` | string | No | Theme name or theme file path |
-| `refresh` | object | No | Auto-refresh configuration |
 | `filters` | array | No | Interactive filter controls |
 | `queries` | map | No | Named SQL or semantic queries |
 | `rows` | array | Yes | Dashboard layout rows |

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,7 @@ export default (
         name="Total Revenue"
         col={4}
         sql="SELECT SUM(amount) AS value FROM sales"
-        column="value"
-        prefix="$"
-        format="number"
+        value={{ field: "value", type: "number", format: "$,.2f" }}
       />
       <Chart
         name="Revenue Over Time"
@@ -62,8 +60,10 @@ rows:
       - name: Revenue
         type: metric
         sql: SELECT SUM(amount) AS value FROM sales
-        column: value
-        prefix: "$"
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
         col: 4
 ```
 

--- a/examples/basic-tsx/dashboards/sales.dashboard.tsx
+++ b/examples/basic-tsx/dashboards/sales.dashboard.tsx
@@ -12,8 +12,8 @@ const tables = query("local_duckdb",
 const regionSeries = regions.rows.length ? regions.rows.map(([r]) => r) : ["placeholder"]
 
 // Reusable KPI component
-function KPI({ name, sql, prefix, ...rest }) {
-  return <Metric name={name} sql={sql} column="value" format="number" prefix={prefix} {...rest} />
+function KPI({ name, sql, format = ",.0f", ...rest }) {
+  return <Metric name={name} sql={sql} value={{ field: "value", type: "number", format }} {...rest} />
 }
 
 export default (
@@ -33,7 +33,7 @@ export default (
       {regions.rows.map(([region]) => (
         <KPI
           name={`${region}`}
-          prefix="$"
+          format="$,.0f"
           col={Math.floor(12 / regions.rows.length)}
           sql={`SELECT SUM(amount) as value FROM sales WHERE region = '${region}'`}
         />

--- a/examples/basic-yaml/dashboards/date-number-filters.yml
+++ b/examples/basic-yaml/dashboards/date-number-filters.yml
@@ -20,8 +20,10 @@ rows:
           FROM orders
           WHERE created_at <= DATE '{{ filters.as_of_date }}'
             AND amount >= {{ filters.min_order_value }}
-        column: value
-        format: number
+        value:
+          field: value
+          type: number
+          format: ",.0f"
 
       - name: Filtered Revenue
         type: metric
@@ -31,9 +33,10 @@ rows:
           FROM orders
           WHERE created_at <= DATE '{{ filters.as_of_date }}'
             AND amount >= {{ filters.min_order_value }}
-        column: value
-        prefix: "$"
-        format: number
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
 
       - name: Average Order Value
         type: metric
@@ -43,9 +46,10 @@ rows:
           FROM orders
           WHERE created_at <= DATE '{{ filters.as_of_date }}'
             AND amount >= {{ filters.min_order_value }}
-        column: value
-        prefix: "$"
-        format: number
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
 
       - name: Max Order Value
         type: metric
@@ -55,9 +59,10 @@ rows:
           FROM orders
           WHERE created_at <= DATE '{{ filters.as_of_date }}'
             AND amount >= {{ filters.min_order_value }}
-        column: value
-        prefix: "$"
-        format: number
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
 
   - widgets:
       - name: Orders by Status

--- a/examples/basic-yaml/dashboards/sales.yml
+++ b/examples/basic-yaml/dashboards/sales.yml
@@ -31,9 +31,10 @@ rows:
       - name: Total Revenue
         type: metric
         query: total_revenue
-        column: value
-        prefix: "$"
-        format: number
+        value:
+          field: value
+          type: number
+          format: "$,.0f"
         col: 3
       - name: Total Orders
         type: metric
@@ -42,8 +43,10 @@ rows:
           SELECT COUNT(*) as total FROM orders
           WHERE created_at >= '{{ filters.date_range.start }}'
             AND created_at <= '{{ filters.date_range.end }}'
-        column: total
-        format: number
+        value:
+          field: total
+          type: number
+          format: ",.0f"
       - name: Average Order Value
         type: metric
         col: 3
@@ -51,9 +54,10 @@ rows:
           SELECT ROUND(AVG(amount), 2) as avg_value FROM orders
           WHERE created_at >= '{{ filters.date_range.start }}'
             AND created_at <= '{{ filters.date_range.end }}'
-        column: avg_value
-        prefix: "$"
-        format: number
+        value:
+          field: avg_value
+          type: number
+          format: "$,.2f"
       - name: P90 Order Value
         type: metric
         col: 3
@@ -61,9 +65,10 @@ rows:
           SELECT ROUND(quantile_cont(amount, 0.9), 2) as p90_value FROM orders
           WHERE created_at >= '{{ filters.date_range.start }}'
             AND created_at <= '{{ filters.date_range.end }}'
-        column: p90_value
-        prefix: "$"
-        format: number
+        value:
+          field: p90_value
+          type: number
+          format: "$,.2f"
 
   # Revenue trend + region breakdown
   - widgets:

--- a/examples/semantic-tsx/dashboards/semantic.dashboard.tsx
+++ b/examples/semantic-tsx/dashboards/semantic.dashboard.tsx
@@ -31,8 +31,7 @@ export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        prefix="$"
-        format="number"
+        value={{ field: "revenue", type: "number", format: "$,.0f" }}
         col={3}
       />
       <Metric
@@ -42,7 +41,7 @@ export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        format="number"
+        value={{ field: "sales_count", type: "number", format: ",.0f" }}
         col={3}
       />
       <Metric
@@ -52,7 +51,7 @@ export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        format="number"
+        value={{ field: "unique_customers", type: "number", format: ",.0f" }}
         col={3}
       />
       <Metric
@@ -62,8 +61,7 @@ export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        prefix="$"
-        format="number"
+        value={{ field: "avg_sale_value", type: "number", format: "$,.2f" }}
         col={3}
       />
     </Row>

--- a/examples/semantic-yaml/dashboards/semantic-sales.yml
+++ b/examples/semantic-yaml/dashboards/semantic-sales.yml
@@ -39,8 +39,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        prefix: "$"
-        format: number
+        value:
+          field: revenue
+          type: number
+          format: "$,.0f"
         col: 3
 
       - name: Sales Count
@@ -55,7 +57,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        format: number
+        value:
+          field: sales_count
+          type: number
+          format: ",.0f"
         col: 3
 
       - name: Unique Customers
@@ -70,7 +75,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        format: number
+        value:
+          field: unique_customers
+          type: number
+          format: ",.0f"
         col: 3
 
       - name: Average Sale Value
@@ -85,8 +93,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        prefix: "$"
-        format: number
+        value:
+          field: avg_sale_value
+          type: number
+          format: "$,.2f"
         col: 3
 
   - widgets:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.90.21",
+        "d3-format": "^3.1.2",
+        "d3-time-format": "^4.1.0",
         "react": "^19.2.4",
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.4",
@@ -22,6 +24,8 @@
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@tailwindcss/vite": "^4.2.1",
+        "@types/d3-format": "^3.0.4",
+        "@types/d3-time-format": "^4.0.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -1497,6 +1501,13 @@
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -1534,6 +1545,13 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-timer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.21",
+    "d3-format": "^3.1.2",
+    "d3-time-format": "^4.1.0",
     "react": "^19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.4",
@@ -25,6 +27,8 @@
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@tailwindcss/vite": "^4.2.1",
+    "@types/d3-format": "^3.0.4",
+    "@types/d3-time-format": "^4.0.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -9,6 +9,7 @@ import {
 } from "recharts";
 import type { TreemapNode } from "recharts";
 import type { Widget, WidgetData } from "../../types/dashboard";
+import { valueField } from "../../lib/format";
 import { useTokens } from "../../themes/TemplateProvider";
 import { RowHeightContext } from "../../themes/RowContext";
 
@@ -864,7 +865,7 @@ export function ChartWidget({ widget, data }: Props) {
           <PieChart>
             <Pie
               data={chartData}
-              dataKey={widget.value || "value"}
+              dataKey={valueField(widget.value) || "value"}
               nameKey={widget.label || "label"}
               cx="50%"
               cy="45%"
@@ -1011,7 +1012,7 @@ export function ChartWidget({ widget, data }: Props) {
                 ...d,
                 fill: colors[i % colors.length],
               }))}
-              dataKey={widget.value || "value"}
+              dataKey={valueField(widget.value) || "value"}
               nameKey={widget.label || "label"}
               isAnimationActive={false}
             >
@@ -1031,7 +1032,7 @@ export function ChartWidget({ widget, data }: Props) {
         chartData,
         widget.source || "source",
         widget.target || "target",
-        widget.value || "value",
+        valueField(widget.value) || "value",
       );
       return (
         <ResponsiveContainer width="100%" height={chartHeight}>
@@ -1056,7 +1057,7 @@ export function ChartWidget({ widget, data }: Props) {
           data={chartData}
           xKey={widget.x!}
           yKey={widget.y?.[0] ?? "y"}
-          valueKey={widget.value || "value"}
+          valueKey={valueField(widget.value) || "value"}
           colors={colors}
           axisColor={axisColor}
         />
@@ -1067,7 +1068,7 @@ export function ChartWidget({ widget, data }: Props) {
         <CalendarHeatmap
           data={chartData}
           dateKey={widget.x!}
-          valueKey={widget.value || "value"}
+          valueKey={valueField(widget.value) || "value"}
           colors={colors}
           axisColor={axisColor}
         />
@@ -1150,7 +1151,7 @@ export function ChartWidget({ widget, data }: Props) {
       );
 
     case "gauge": {
-      const valueKey = widget.value || "value";
+      const valueKey = valueField(widget.value) || "value";
       const targetKey = widget.target;
       const first = chartData[0] ?? {};
       const current = Number(first[valueKey]) || 0;
@@ -1168,7 +1169,7 @@ export function ChartWidget({ widget, data }: Props) {
 
     case "treemap": {
       const labelKey = widget.label || "label";
-      const valueKey = widget.value || "value";
+      const valueKey = valueField(widget.value) || "value";
       const tmData = chartData.map((d, i) => ({
         name: String(d[labelKey]),
         size: Number(d[valueKey]) || 0,

--- a/frontend/src/components/widgets/MetricWidget.tsx
+++ b/frontend/src/components/widgets/MetricWidget.tsx
@@ -1,28 +1,10 @@
 import { useRef, useEffect, useState } from "react";
 import type { Widget, WidgetData } from "../../types/dashboard";
+import { buildFormatter, valueEncoding } from "../../lib/format";
 
 interface Props {
   widget: Widget;
   data?: WidgetData;
-}
-
-function formatValue(value: unknown, format?: string): string {
-  if (value === null || value === undefined) return "—";
-  const num = Number(value);
-  if (isNaN(num)) return String(value);
-
-  switch (format) {
-    case "number":
-      return num.toLocaleString();
-    case "currency":
-      return num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-    case "percent":
-      return num.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
-    case "compact":
-      return Intl.NumberFormat(undefined, { notation: "compact", maximumFractionDigits: 1 }).format(num);
-    default:
-      return num.toLocaleString();
-  }
 }
 
 /** Pick the right font size so the value fits its container. */
@@ -55,14 +37,13 @@ function useAutoFit(text: string) {
 export function MetricWidget({ widget, data }: Props) {
   const hasData = !!data?.rows?.length && !!data.columns?.length;
 
-  const colIdx = hasData ? data.columns.findIndex((c) => c.name === widget.column) : -1;
+  const enc = valueEncoding(widget.value);
+  const colIdx = hasData && enc?.field ? data.columns.findIndex((c) => c.name === enc.field) : -1;
   const rawValue = hasData ? (colIdx >= 0 ? data.rows[0][colIdx] : data.rows[0][0]) : null;
-  const formatted = hasData ? formatValue(rawValue, widget.format) : "";
+  const formatted = hasData ? buildFormatter(enc)(rawValue) : "";
 
   // Hook must be called unconditionally (Rules of Hooks).
-  const { containerRef, fontSize } = useAutoFit(
-    `${widget.prefix ?? ""}${formatted}${widget.suffix ?? ""}`
-  );
+  const { containerRef, fontSize } = useAutoFit(formatted);
 
   if (!hasData) {
     return (
@@ -75,15 +56,9 @@ export function MetricWidget({ widget, data }: Props) {
   return (
     <div className="tabular-nums overflow-hidden">
       <div ref={containerRef} className="flex items-baseline gap-1 whitespace-nowrap" style={{ fontSize, lineHeight: 1.1 }}>
-        {widget.prefix && (
-          <span className="font-normal text-[var(--dac-text-muted)]" style={{ fontSize: "0.65em" }}>{widget.prefix}</span>
-        )}
         <span className="font-semibold tracking-tight text-[var(--dac-text-primary)]">
           {formatted}
         </span>
-        {widget.suffix && (
-          <span className="font-normal text-[var(--dac-text-muted)]" style={{ fontSize: "0.65em" }}>{widget.suffix}</span>
-        )}
       </div>
     </div>
   );

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,64 @@
+import { format as d3Format } from "d3-format";
+import { timeFormat as d3TimeFormat } from "d3-time-format";
+import type { ValueEncoding } from "../types/dashboard";
+
+/** Resolve the column name from a value channel that may be a bare string or an encoding object. */
+export function valueField(value?: string | ValueEncoding): string | undefined {
+  if (value == null) return undefined;
+  return typeof value === "string" ? value : value.field;
+}
+
+/** Normalize a value channel into a ValueEncoding (bare strings become `{ field }`). */
+export function valueEncoding(value?: string | ValueEncoding): ValueEncoding | undefined {
+  if (value == null) return undefined;
+  return typeof value === "string" ? { field: value } : value;
+}
+
+/** Auto-compact fallback for numbers that have no explicit format. */
+export function formatNumber(val: number): string {
+  if (!Number.isFinite(val)) return String(val);
+  const abs = Math.abs(val);
+  if (abs >= 1_000_000_000) return `${trimZero(val / 1_000_000_000)}B`;
+  if (abs >= 1_000_000) return `${trimZero(val / 1_000_000)}M`;
+  if (abs >= 10_000) return `${trimZero(val / 1_000)}k`;
+  if (Number.isInteger(val)) return val.toLocaleString();
+  return String(parseFloat(val.toFixed(2)));
+}
+
+function trimZero(n: number): string {
+  return n.toFixed(1).replace(/\.0$/, "");
+}
+
+/**
+ * Build a value formatter from an encoding, mirroring the cloud renderer:
+ * d3-format for numbers, d3-time-format for dates, and an auto-compact
+ * fallback when no format string is supplied.
+ */
+export function buildFormatter(enc?: ValueEncoding): (val: unknown) => string {
+  const fmt = enc?.format;
+
+  if (!fmt) {
+    return (val) => {
+      const num = Number(val);
+      return val !== null && val !== "" && Number.isFinite(num) ? formatNumber(num) : String(val ?? "");
+    };
+  }
+
+  if (enc?.type === "date") {
+    const tf = d3TimeFormat(fmt);
+    return (val) => {
+      const d = val instanceof Date ? val : new Date(val as string);
+      return isNaN(d.getTime()) ? String(val ?? "") : tf(d);
+    };
+  }
+
+  try {
+    const nf = d3Format(fmt);
+    return (val) => {
+      const num = Number(val);
+      return Number.isFinite(num) ? nf(num) : String(val ?? "");
+    };
+  } catch {
+    return (val) => String(val ?? "");
+  }
+}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -13,8 +13,6 @@ export interface Dashboard {
   connection?: string;
   model?: string;
   models?: Record<string, string>;
-  theme?: string;
-  refresh?: { interval: string };
   filters?: Filter[];
   queries?: Record<string, Query>;
   rows: Row[];

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -76,18 +76,13 @@ export interface Widget {
   segments?: string[];
   sort?: SemanticSort[];
 
-  // Metric
-  column?: string;
-  prefix?: string;
-  suffix?: string;
-  format?: string;
-
   // Chart
   chart?: "line" | "bar" | "area" | "pie" | "scatter" | "bubble" | "combo" | "histogram" | "boxplot" | "funnel" | "sankey" | "heatmap" | "calendar" | "sparkline" | "waterfall" | "xmr" | "dumbbell" | "gauge" | "treemap" | "radar" | "candlestick";
   x?: string;
   y?: string[];
   label?: string;
-  value?: string;
+  // metric: the value + formatting; pie/funnel/heatmap/calendar/treemap/gauge: value column
+  value?: string | ValueEncoding;
   stacked?: boolean;
   size?: string;       // bubble: size dimension
   source?: string;     // sankey: source column
@@ -116,6 +111,13 @@ export interface TableColumn {
   name: string;
   label?: string;
   format?: string;
+}
+
+/** Structured encoding for a widget's value channel (metric value, pie/funnel/gauge value column). */
+export interface ValueEncoding {
+  field: string;
+  type?: "number" | "date" | "category";
+  format?: string; // d3-format / d3-time-format string, e.g. "$,.2f", ".0%", "%b %Y"
 }
 
 export interface SemanticDimensionRef {

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -397,15 +397,6 @@ func vnodeToDashboard(root *vnode) (*Dashboard, error) {
 		Connection:  asString(root.Props["connection"]),
 		Model:       asString(root.Props["model"]),
 		Models:      asStringMap(root.Props["models"]),
-		Theme:       asString(root.Props["theme"]),
-	}
-
-	if v := root.Props["refresh"]; v != nil {
-		if m, ok := v.(map[string]interface{}); ok {
-			d.Refresh = &RefreshConfig{
-				Interval: asString(m["interval"]),
-			}
-		}
 	}
 
 	for _, child := range root.Children {

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -532,12 +532,6 @@ func vnodeToWidget(n *vnode) Widget {
 		Model:      asString(n.Props["model"]),
 		Connection: asString(n.Props["connection"]),
 
-		// Metric fields
-		Column: asString(n.Props["column"]),
-		Prefix: asString(n.Props["prefix"]),
-		Suffix: asString(n.Props["suffix"]),
-		Format: asString(n.Props["format"]),
-
 		// Declarative chart fields
 		Dimension:   asString(n.Props["dimension"]),
 		Granularity: asString(n.Props["granularity"]),

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -118,9 +118,9 @@ export default (
   <Dashboard name="Loop Test" connection="duckdb">
     <Row>
       {regions.map(r =>
-        <Metric name={r + " Revenue"} col={4} prefix="$"
+        <Metric name={r + " Revenue"} col={4}
           sql={"SELECT SUM(amount) as value FROM sales WHERE region = '" + r + "'"}
-          column="value" format="number" />
+          value={{ field: "value", type: "number", format: "$,.0f" }} />
       )}
     </Row>
   </Dashboard>
@@ -144,8 +144,11 @@ export default (
 		if w.Name != names[i] {
 			t.Errorf("widget %d: expected name %q, got %q", i, names[i], w.Name)
 		}
-		if w.Prefix != "$" {
-			t.Errorf("widget %d: expected prefix %q, got %q", i, "$", w.Prefix)
+		if w.Value == nil || w.Value.Field != "value" {
+			t.Errorf("widget %d: expected value field %q, got %+v", i, "value", w.Value)
+		}
+		if w.Value == nil || w.Value.Format != "$,.0f" {
+			t.Errorf("widget %d: expected format %q, got %+v", i, "$,.0f", w.Value)
 		}
 		if !strings.Contains(w.SQL, "WHERE region") {
 			t.Errorf("widget %d: expected SQL with region filter", i)
@@ -155,14 +158,14 @@ export default (
 
 func TestEvalTSX_CustomComponent(t *testing.T) {
 	source := `
-function KPI({ name, sql, ...rest }) {
-  return <Metric name={name} sql={sql} column="value" format="number" {...rest} />
+function KPI({ name, sql, format = ",.0f", ...rest }) {
+  return <Metric name={name} sql={sql} value={{ field: "value", type: "number", format }} {...rest} />
 }
 
 export default (
   <Dashboard name="Custom Component" connection="duckdb">
     <Row>
-      <KPI name="Revenue" sql="SELECT 100 as value" prefix="$" col={4} />
+      <KPI name="Revenue" sql="SELECT 100 as value" format="$,.0f" col={4} />
       <KPI name="Orders" sql="SELECT 42 as value" col={4} />
     </Row>
   </Dashboard>
@@ -182,11 +185,11 @@ export default (
 	if w0.Type != WidgetTypeMetric {
 		t.Errorf("expected metric, got %q", w0.Type)
 	}
-	if w0.Column != "value" {
-		t.Errorf("expected column %q, got %q", "value", w0.Column)
+	if w0.Value == nil || w0.Value.Field != "value" {
+		t.Errorf("expected value field %q, got %+v", "value", w0.Value)
 	}
-	if w0.Prefix != "$" {
-		t.Errorf("expected prefix %q, got %q", "$", w0.Prefix)
+	if w0.Value == nil || w0.Value.Format != "$,.0f" {
+		t.Errorf("expected format %q, got %+v", "$,.0f", w0.Value)
 	}
 }
 
@@ -335,7 +338,7 @@ export default (
   <Dashboard name="Named Query" connection="db">
     <Query name="total_revenue" sql="SELECT SUM(amount) as value FROM sales" />
     <Row>
-      <Metric name="Revenue" query="total_revenue" column="value" col={6} />
+      <Metric name="Revenue" query="total_revenue" value="value" col={6} />
     </Row>
   </Dashboard>
 )
@@ -587,7 +590,7 @@ func TestEvalTSX_RequireModule(t *testing.T) {
 	// Write the shared module.
 	helperCode := `
 function KPI({ name, sql }) {
-  return h("Metric", { name: name, sql: sql, column: "value", format: "number" })
+  return h("Metric", { name: name, sql: sql, value: { field: "value", type: "number", format: ",.0f" } })
 }
 module.exports = { KPI }
 `
@@ -641,7 +644,7 @@ func TestEvalTSX_RequireTSXModule(t *testing.T) {
 	// Write a .tsx helper module.
 	helperCode := `
 function KPI({ name, sql, ...rest }) {
-  return <Metric name={name} sql={sql} column="value" format="number" {...rest} />
+  return <Metric name={name} sql={sql} value={{ field: "value", type: "number", format: ",.0f" }} {...rest} />
 }
 module.exports = { KPI }
 `
@@ -696,7 +699,7 @@ export default (
   <Dashboard name="JSON Require" connection="db">
     <Row>
       {config.regions.map(function(r) {
-        return <Metric name={r} sql={"SELECT 1 as value"} column="value" col={4} />
+        return <Metric name={r} sql={"SELECT 1 as value"} value="value" col={4} />
       })}
     </Row>
   </Dashboard>

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -416,27 +416,6 @@ export default (
 	}
 }
 
-func TestEvalTSX_RefreshConfig(t *testing.T) {
-	source := `
-export default (
-  <Dashboard name="Refresh Test" connection="db" refresh={{ interval: "30s" }}>
-    <Row>
-      <Text name="Note" content="test" col={12} />
-    </Row>
-  </Dashboard>
-)
-`
-	d, err := evalTSX(source, "test.tsx", &tsxConfig{})
-	assertNoErr(t, err)
-
-	if d.Refresh == nil {
-		t.Fatal("expected refresh config")
-	}
-	if d.Refresh.Interval != "30s" {
-		t.Errorf("expected interval %q, got %q", "30s", d.Refresh.Interval)
-	}
-}
-
 func TestEvalTSX_TableWithColumns(t *testing.T) {
 	source := `
 export default (

--- a/pkg/dashboard/loader_test.go
+++ b/pkg/dashboard/loader_test.go
@@ -135,18 +135,18 @@ func TestLoadFile_DoesNotOverrideExplicitXY(t *testing.T) {
 	}
 }
 
-func TestLoadFile_MetricRefColumnNotForced(t *testing.T) {
+func TestLoadFile_MetricRefValueNotForced(t *testing.T) {
 	d, err := LoadFile("../../testdata/dashboards/google-analytics.yml")
 	assertNoErr(t, err)
 
-	// Row 0, widget 0: "Page Views" — metric ref, column should be empty
-	// (MetricWidget falls back to first column).
-	w := d.Rows[0].Widgets[0]
-	if w.Name != "Page Views" {
-		t.Fatalf("expected 'Page Views', got %q", w.Name)
+	// Row 0, widget 3: "Pages / Session" — metric ref with no value encoding;
+	// the loader must not synthesize one (MetricWidget falls back to first column).
+	w := d.Rows[0].Widgets[3]
+	if w.Name != "Pages / Session" {
+		t.Fatalf("expected 'Pages / Session', got %q", w.Name)
 	}
-	if w.Column != "" {
-		t.Errorf("expected empty column for metric-ref widget, got %q", w.Column)
+	if w.ValueField() != "" {
+		t.Errorf("expected empty value field for metric-ref widget, got %q", w.ValueField())
 	}
 }
 

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -30,8 +30,6 @@ type Dashboard struct {
 	Connection  string            `yaml:"connection,omitempty" json:"connection,omitempty"`
 	Model       string            `yaml:"model,omitempty" json:"model,omitempty"`
 	Models      map[string]string `yaml:"models,omitempty" json:"models,omitempty"`
-	Theme       string            `yaml:"theme,omitempty" json:"theme,omitempty"`
-	Refresh     *RefreshConfig    `yaml:"refresh,omitempty" json:"refresh,omitempty"`
 	Filters     []Filter          `yaml:"filters,omitempty" json:"filters,omitempty"`
 	Queries     map[string]Query  `yaml:"queries,omitempty" json:"queries,omitempty"`
 	Semantic    *SemanticLayer    `yaml:"semantic,omitempty" json:"semantic,omitempty"`
@@ -53,10 +51,6 @@ type SemanticLayer struct {
 	Source     *Source              `yaml:"source,omitempty" json:"source,omitempty"`
 	Metrics    map[string]Metric    `yaml:"metrics,omitempty" json:"metrics,omitempty"`
 	Dimensions map[string]Dimension `yaml:"dimensions,omitempty" json:"dimensions,omitempty"`
-}
-
-type RefreshConfig struct {
-	Interval string `yaml:"interval" json:"interval"`
 }
 
 type Filter struct {

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -147,12 +147,6 @@ type Widget struct {
 	// Connection override for inline queries
 	Connection string `yaml:"connection,omitempty" json:"connection,omitempty"`
 
-	// Metric fields
-	Column string `yaml:"column,omitempty" json:"column,omitempty"`
-	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
-	Suffix string `yaml:"suffix,omitempty" json:"suffix,omitempty"`
-	Format string `yaml:"format,omitempty" json:"format,omitempty"`
-
 	// Declarative chart fields (use with source + metrics)
 	Dimension   string                 `yaml:"dimension,omitempty" json:"dimension,omitempty"` // GROUP BY column
 	Granularity string                 `yaml:"granularity,omitempty" json:"granularity,omitempty"`
@@ -168,7 +162,7 @@ type Widget struct {
 	X          *AxisEncoding  `yaml:"x,omitempty" json:"x,omitempty"`
 	Y          *AxisEncoding  `yaml:"y,omitempty" json:"y,omitempty"`
 	Label      string         `yaml:"label,omitempty" json:"label,omitempty"` // for pie/funnel/treemap
-	Value      *ValueEncoding `yaml:"value,omitempty" json:"value,omitempty"`
+	Value      *ValueEncoding `yaml:"value,omitempty" json:"value,omitempty"` // metric: the value; pie/funnel/heatmap/calendar/treemap/gauge: value column
 	Color      *ColorEncoding `yaml:"color,omitempty" json:"color,omitempty"`
 	Stacked    bool           `yaml:"stacked,omitempty" json:"stacked,omitempty"`
 	Normalized bool           `yaml:"normalized,omitempty" json:"normalized,omitempty"`

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -301,8 +301,8 @@ func validateMetricWidget(prefix string, w *Widget, d *Dashboard) []string {
 		}
 		return errs
 	}
-	if w.Column == "" {
-		errs = append(errs, fmt.Sprintf("%s: column is required for metric widgets", prefix))
+	if w.ValueField() == "" {
+		errs = append(errs, fmt.Sprintf("%s: value is required for metric widgets", prefix))
 	}
 	return errs
 }

--- a/pkg/dashboard/widget_id_test.go
+++ b/pkg/dashboard/widget_id_test.go
@@ -13,7 +13,7 @@ name: w
 type: metric
 id: kpi_rev
 sql: SELECT 1 AS value
-column: value
+value: value
 `
 	var w Widget
 	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
@@ -25,7 +25,7 @@ column: value
 }
 
 func TestWidgetID_JSON(t *testing.T) {
-	body := []byte(`{"name":"w","type":"metric","id":"kpi_rev","sql":"SELECT 1","column":"value"}`)
+	body := []byte(`{"name":"w","type":"metric","id":"kpi_rev","sql":"SELECT 1","value":"value"}`)
 	var w Widget
 	if err := json.Unmarshal(body, &w); err != nil {
 		t.Fatalf("unmarshal: %v", err)

--- a/pkg/slides/export.go
+++ b/pkg/slides/export.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/dustin/go-humanize"
 
@@ -482,30 +485,192 @@ func formatMetricValue(w *dashboard.Widget, data *server.WidgetQueryResult) stri
 	}
 
 	ci := 0
-	if w.Column != "" {
+	if field := w.ValueField(); field != "" {
 		for i, c := range data.Columns {
-			if c.Name == w.Column {
+			if c.Name == field {
 				ci = i
 				break
 			}
 		}
 	}
 
-	val := toFloat64(data.Rows[0][ci])
+	raw := data.Rows[0][ci]
 
-	var s string
-	switch w.Format {
-	case "currency", "number":
-		if val == float64(int64(val)) {
-			s = humanize.Comma(int64(val))
-		} else {
-			s = humanize.CommafWithDigits(val, 2)
-		}
-	case "percent":
-		s = fmt.Sprintf("%.1f%%", val)
-	default:
-		s = fmt.Sprintf("%v", data.Rows[0][ci])
+	var format, typ string
+	if w.Value != nil {
+		format, typ = w.Value.Format, w.Value.Type
 	}
 
-	return w.Prefix + s + w.Suffix
+	// Date-typed values render with the d3-time-format string.
+	if typ == "date" {
+		if t, ok := parseMetricTime(raw); ok {
+			if layout := strftimeToGo(format); layout != "" {
+				return t.Format(layout)
+			}
+		}
+		return fmt.Sprintf("%v", raw)
+	}
+
+	num, ok := toFloat64OK(raw)
+	if !ok {
+		return fmt.Sprintf("%v", raw)
+	}
+
+	if format == "" {
+		// No explicit format: comma-group, trimming to whole numbers when exact.
+		if num == float64(int64(num)) {
+			return humanize.Comma(int64(num))
+		}
+		return humanize.CommafWithDigits(num, 2)
+	}
+
+	return formatD3Number(format, num)
+}
+
+// formatD3Number renders val using the subset of d3-format specifiers dac
+// dashboards rely on: an optional "$" currency prefix, "," group separators, a
+// ".N" precision, and a type of f (fixed), % (percent), or d/"," (integer).
+// Unrecognized specs fall back to a comma-grouped, two-decimal number.
+func formatD3Number(format string, val float64) string {
+	spec := format
+
+	prefix := ""
+	if strings.HasPrefix(spec, "$") {
+		prefix = "$"
+		spec = spec[1:]
+	}
+
+	group := strings.HasPrefix(spec, ",")
+	if group {
+		spec = spec[1:]
+	}
+
+	prec := -1
+	if strings.HasPrefix(spec, ".") {
+		rest := spec[1:]
+		j := 0
+		for j < len(rest) && rest[j] >= '0' && rest[j] <= '9' {
+			j++
+		}
+		if j > 0 {
+			prec, _ = strconv.Atoi(rest[:j])
+		}
+		spec = rest[j:]
+	}
+
+	var typ byte
+	if len(spec) > 0 {
+		typ = spec[len(spec)-1]
+	}
+
+	switch typ {
+	case '%':
+		if prec < 0 {
+			prec = 0
+		}
+		s := strconv.FormatFloat(val*100, 'f', prec, 64)
+		if group {
+			s = groupInteger(s)
+		}
+		return prefix + s + "%"
+	case 'd', ',':
+		return prefix + groupInteger(strconv.FormatFloat(val, 'f', 0, 64))
+	default: // 'f' and anything unrecognized
+		if prec < 0 {
+			prec = 2
+		}
+		s := strconv.FormatFloat(val, 'f', prec, 64)
+		if group {
+			s = groupInteger(s)
+		}
+		return prefix + s
+	}
+}
+
+// groupInteger inserts thousands separators into the integer part of a numeric
+// string, preserving any sign and fractional part.
+func groupInteger(s string) string {
+	neg := strings.HasPrefix(s, "-")
+	if neg {
+		s = s[1:]
+	}
+
+	intPart, frac := s, ""
+	if i := strings.IndexByte(s, '.'); i >= 0 {
+		intPart, frac = s[:i], s[i:]
+	}
+
+	n := len(intPart)
+	if n > 3 {
+		var b strings.Builder
+		pre := n % 3
+		if pre > 0 {
+			b.WriteString(intPart[:pre])
+			b.WriteByte(',')
+		}
+		for i := pre; i < n; i += 3 {
+			b.WriteString(intPart[i : i+3])
+			if i+3 < n {
+				b.WriteByte(',')
+			}
+		}
+		intPart = b.String()
+	}
+
+	out := intPart + frac
+	if neg {
+		out = "-" + out
+	}
+	return out
+}
+
+// strftimeToGo converts a d3-time-format (strftime-style) string into a Go
+// reference layout. Returns "" when nothing was converted.
+func strftimeToGo(f string) string {
+	out := strings.NewReplacer(
+		"%Y", "2006", "%y", "06",
+		"%m", "01", "%d", "02",
+		"%H", "15", "%M", "04", "%S", "05",
+		"%b", "Jan", "%B", "January",
+		"%a", "Mon", "%A", "Monday",
+		"%p", "PM",
+	).Replace(f)
+	if out == f {
+		return ""
+	}
+	return out
+}
+
+// parseMetricTime coerces a query value into a time.Time for date-typed metrics.
+func parseMetricTime(v any) (time.Time, bool) {
+	switch t := v.(type) {
+	case time.Time:
+		return t, true
+	case string:
+		for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05", "2006-01-02", "2006-01"} {
+			if parsed, err := time.Parse(layout, t); err == nil {
+				return parsed, true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+// toFloat64OK parses a query value as a float, reporting whether it is numeric.
+func toFloat64OK(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case string:
+		f, err := strconv.ParseFloat(n, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
 }

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -249,18 +249,6 @@
         "connection": {
           "type": "string"
         },
-        "column": {
-          "type": "string"
-        },
-        "prefix": {
-          "type": "string"
-        },
-        "suffix": {
-          "type": "string"
-        },
-        "format": {
-          "type": "string"
-        },
         "dimension": {
           "type": "string"
         },

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -27,12 +27,6 @@
         "type": "string"
       }
     },
-    "theme": {
-      "type": "string"
-    },
-    "refresh": {
-      "$ref": "#/$defs/refresh"
-    },
     "filters": {
       "type": "array",
       "items": {
@@ -61,20 +55,6 @@
   },
   "additionalProperties": false,
   "$defs": {
-    "refresh": {
-      "type": "object",
-      "required": ["interval"],
-      "properties": {
-        "interval": {
-          "type": "string",
-          "minLength": 1
-        }
-      },
-      "patternProperties": {
-        "^x-": true
-      },
-      "additionalProperties": false
-    },
     "filter": {
       "type": "object",
       "required": ["name", "type"],

--- a/schemas/schema_test.go
+++ b/schemas/schema_test.go
@@ -22,7 +22,7 @@ rows:
       - name: One
         type: metric
         sql: SELECT 1 AS value
-        column: value
+        value: value
 `,
 		},
 		{
@@ -42,7 +42,7 @@ rows:
       - name: One
         type: metric
         sql: SELECT 1 AS value
-        column: value
+        value: value
 `,
 		},
 		{
@@ -92,7 +92,7 @@ rows:
       - name: One
         type: metric
         sql: SELECT 1 AS value
-        column: value
+        value: value
 `,
 		},
 		{

--- a/testdata/dashboards/business-summary.yml
+++ b/testdata/dashboards/business-summary.yml
@@ -132,35 +132,42 @@ rows:
       - name: Revenue
         type: metric
         query: total_revenue
-        column: value
-        prefix: "$"
-        format: currency
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
         col: 3
       - name: Sales
         type: metric
         query: total_sales
-        column: value
-        format: number
+        value:
+          field: value
+          type: number
+          format: ",.0f"
         col: 2
       - name: Orders
         type: metric
         query: total_orders
-        column: value
-        format: number
+        value:
+          field: value
+          type: number
+          format: ",.0f"
         col: 2
       - name: Average Order Value
         type: metric
         query: average_order_value
-        column: value
-        prefix: "$"
-        format: currency
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
         col: 3
       - name: Revenue / Sale
         type: metric
         query: revenue_per_sale
-        column: value
-        prefix: "$"
-        format: currency
+        value:
+          field: value
+          type: number
+          format: "$,.2f"
         col: 2
 
   - widgets:

--- a/testdata/dashboards/google-analytics.yml
+++ b/testdata/dashboards/google-analytics.yml
@@ -59,19 +59,28 @@ rows:
       - name: Page Views
         type: metric
         metric: page_views
-        format: number
+        value:
+          field: page_views
+          type: number
+          format: ",.0f"
         col: 3
 
       - name: Users
         type: metric
         metric: users
-        format: number
+        value:
+          field: users
+          type: number
+          format: ",.0f"
         col: 3
 
       - name: Sessions
         type: metric
         metric: sessions
-        format: number
+        value:
+          field: sessions
+          type: number
+          format: ",.0f"
         col: 3
 
       - name: Pages / Session

--- a/testdata/dashboards/sales.yml
+++ b/testdata/dashboards/sales.yml
@@ -32,9 +32,10 @@ rows:
       - name: Total Revenue
         type: metric
         query: total_revenue
-        column: value
-        prefix: "$"
-        format: number
+        value:
+          field: value
+          type: number
+          format: "$,.0f"
         col: 3
       - name: Total Orders
         type: metric
@@ -43,8 +44,10 @@ rows:
           SELECT COUNT(*) as total FROM orders
           WHERE created_at >= '{{ filters.date_range.start }}'
             AND created_at <= '{{ filters.date_range.end }}'
-        column: total
-        format: number
+        value:
+          field: total
+          type: number
+          format: ",.0f"
       - name: Average Order Value
         type: metric
         col: 3
@@ -52,9 +55,10 @@ rows:
           SELECT ROUND(AVG(amount), 2) as avg_value FROM orders
           WHERE created_at >= '{{ filters.date_range.start }}'
             AND created_at <= '{{ filters.date_range.end }}'
-        column: avg_value
-        prefix: "$"
-        format: number
+        value:
+          field: avg_value
+          type: number
+          format: "$,.2f"
       - name: P90 Order Value
         type: metric
         col: 3
@@ -62,9 +66,10 @@ rows:
           SELECT ROUND(quantile_cont(amount, 0.9), 2) as p90_value FROM orders
           WHERE created_at >= '{{ filters.date_range.start }}'
             AND created_at <= '{{ filters.date_range.end }}'
-        column: p90_value
-        prefix: "$"
-        format: number
+        value:
+          field: p90_value
+          type: number
+          format: "$,.2f"
 
   # Revenue trend + region breakdown
   - widgets:

--- a/testdata/dashboards/semantic-sales.yml
+++ b/testdata/dashboards/semantic-sales.yml
@@ -40,8 +40,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        prefix: "$"
-        format: number
+        value:
+          field: revenue
+          type: number
+          format: "$,.0f"
         col: 3
 
       - name: Sales Count
@@ -56,7 +58,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        format: number
+        value:
+          field: sales_count
+          type: number
+          format: ",.0f"
         col: 3
 
       - name: Unique Customers
@@ -71,7 +76,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        format: number
+        value:
+          field: unique_customers
+          type: number
+          format: ",.0f"
         col: 3
 
       - name: Average Sale Value
@@ -86,8 +94,10 @@ rows:
             value:
               start: "{{ filters.date_range.start }}"
               end: "{{ filters.date_range.end }}"
-        prefix: "$"
-        format: number
+        value:
+          field: avg_sale_value
+          type: number
+          format: "$,.2f"
         col: 3
 
   - widgets:

--- a/testdata/dashboards/semantic.dashboard.tsx
+++ b/testdata/dashboards/semantic.dashboard.tsx
@@ -31,8 +31,7 @@ export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        prefix="$"
-        format="number"
+        value={{ field: "revenue", type: "number", format: "$,.0f" }}
         col={3}
       />
       <Metric
@@ -42,7 +41,7 @@ export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        format="number"
+        value={{ field: "sales_count", type: "number", format: ",.0f" }}
         col={3}
       />
       <Metric
@@ -52,7 +51,7 @@ export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        format="number"
+        value={{ field: "unique_customers", type: "number", format: ",.0f" }}
         col={3}
       />
       <Metric
@@ -62,8 +61,7 @@ export default (
           { dimension: "region", operator: "equals", value: "{{ filters.region }}" },
           { dimension: "created_at", operator: "between", value: { start: "{{ filters.date_range.start }}", end: "{{ filters.date_range.end }}" } },
         ]}
-        prefix="$"
-        format="number"
+        value={{ field: "avg_sale_value", type: "number", format: "$,.2f" }}
         col={3}
       />
     </Row>

--- a/testdata/dashboards/simple.dashboard.tsx
+++ b/testdata/dashboards/simple.dashboard.tsx
@@ -12,8 +12,8 @@ const tables = query("local_duckdb",
 const regionSeries = regions.rows.length ? regions.rows.map(([r]) => r) : ["placeholder"]
 
 // Reusable KPI component
-function KPI({ name, sql, prefix, ...rest }) {
-  return <Metric name={name} sql={sql} column="value" format="number" prefix={prefix} {...rest} />
+function KPI({ name, sql, format = ",.0f", ...rest }) {
+  return <Metric name={name} sql={sql} value={{ field: "value", type: "number", format }} {...rest} />
 }
 
 export default (
@@ -33,7 +33,7 @@ export default (
       {regions.rows.map(([region]) => (
         <KPI
           name={`${region}`}
-          prefix="$"
+          format="$,.0f"
           col={Math.floor(12 / regions.rows.length)}
           sql={`SELECT SUM(amount) as value FROM sales WHERE region = '${region}'`}
         />

--- a/testdata/dashboards/universal.dashboard.tsx
+++ b/testdata/dashboards/universal.dashboard.tsx
@@ -105,10 +105,11 @@ function titleCase(s) {
   return s.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
+// Returns a d3-format string suited to the column's name.
 function formatColumn(col) {
-  if (/amount|revenue|price|cost|budget|salary|spend|mrr/i.test(col)) return "currency"
-  if (/rate|pct|percent/i.test(col)) return "percent"
-  return "number"
+  if (/amount|revenue|price|cost|budget|salary|spend|mrr/i.test(col)) return "$,.2f"
+  if (/rate|pct|percent/i.test(col)) return ".1%"
+  return ",.0f"
 }
 
 function bestAggregate(colName) {
@@ -137,28 +138,25 @@ export default (
         name="Tables Discovered"
         col={3}
         sql={`SELECT ${tableNames.length} as value`}
-        column="value"
-        format="number"
+        value={{ field: "value", type: "number", format: ",.0f" }}
       />
       <Metric
         name="Total Rows"
         col={3}
         sql={`SELECT ${totalRows} as value`}
-        column="value"
-        format="number"
+        value={{ field: "value", type: "number", format: ",.0f" }}
       />
       <Metric
         name="Largest Table"
         col={3}
         sql={`SELECT '${largestTable}' as value`}
-        column="value"
+        value="value"
       />
       <Metric
         name={`${titleCase(largestTable)} Rows`}
         col={3}
         sql={`SELECT ${rowCounts[largestTable] || 0} as value`}
-        column="value"
-        format="number"
+        value={{ field: "value", type: "number", format: ",.0f" }}
       />
     </Row>
 
@@ -178,8 +176,7 @@ export default (
                 name="Row Count"
                 col={3}
                 sql={`SELECT COUNT(*) as value FROM "${table}"`}
-                column="value"
-                format="number"
+                value={{ field: "value", type: "number", format: ",.0f" }}
               />
               {kpiCols.slice(0, 3).map(col => {
                 const agg = bestAggregate(col.name)
@@ -189,10 +186,7 @@ export default (
                     name={`${agg === 'AVG' ? 'Avg' : 'Total'} ${titleCase(col.name)}`}
                     col={3}
                     sql={`SELECT ${agg}("${col.name}") as value FROM "${table}"`}
-                    column="value"
-                    format={fmt}
-                    prefix={fmt === "currency" ? "$" : ""}
-                    suffix={fmt === "percent" ? "%" : ""}
+                    value={{ field: "value", type: "number", format: fmt }}
                   />
                 )
               })}


### PR DESCRIPTION
## Summary

Two related schema cleanups for dashboard definitions:

### 1. Metric widgets use the value encoding (was: flat fields)
Metric widgets configured their value with four flat fields — `column`, `prefix`, `suffix`, and a keyword `format` (`number`/`currency`/`percent`). The chart family already moved to a structured `value:` encoding (`{ field, type, format }` with d3-format strings), matching the agent-runner/cloud schema. Metric was the last holdout.

Now metric widgets resolve their value through that same `value` encoding:

```yaml
# before
- type: metric
  sql: "SELECT SUM(amount) AS value FROM sales"
  column: value
  prefix: "$"
  format: number

# after
- type: metric
  sql: "SELECT SUM(amount) AS value FROM sales"
  value:
    field: value
    type: number
    format: "$,.0f"
```

Prefix/suffix and the keyword formats fold into the d3-format string (`$,.2f`, `,.0f`, `.1%`, …). The frontend formats via a shared d3-format/d3-time-format helper (`lib/format.ts`) mirroring the cloud renderer; the PPTX export does the same server-side.

### 2. Remove dead `theme:` and `refresh:` dashboard fields
- **`theme:`** — never read. Theme selection runs through the `--template` flag + theme registry; the per-dashboard field silently validated and did nothing.
- **`refresh:`** — decoded but never wired to any polling; auto-refresh never happened.

Both now fail loudly (`additional properties … not allowed`) instead of being silently ignored. Theme selection via `--template` is unchanged.

## Breaking changes
- Metric widgets using `column`/`prefix`/`suffix`/keyword-`format` no longer validate — use `value`.
- `theme:` and `refresh:` are rejected. Use `--template` for theming.
- All bundled examples, the `dac init` scaffold, docs, and the create-dashboard skill are migrated.

## Verification
- `make build` and `make test` green.
- `dac validate` passes on all examples; old fields now produce a clear schema error.
- Metric query executes and renders formatted (e.g. `11382725` → `$11,382,725`).