### PR TITLE
Remove the TSX include() helper

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -50,7 +50,7 @@ my-project/
     lib/
       kpi.tsx                   # Shared TSX helpers (not auto-discovered)
     queries/
-      my_query.sql              # SQL files for TSX include() and dac query -f
+      my_query.sql              # SQL files for ad-hoc runs with dac query -f
   themes/
     corporate.yml               # Optional custom themes (token overrides)
 ```
@@ -59,7 +59,7 @@ my-project/
 - Any `*.dashboard.tsx` file is auto-discovered as a TSX dashboard.
 - Files in `lib/` or without the `.dashboard.tsx` suffix are NOT auto-discovered (use `require()` to import them).
 - Files starting with `.` are ignored (e.g. `.bruin.yml`).
-- SQL files in `queries/` are for TSX `include()` and `dac query -f` — YAML widgets always inline their SQL (or reference a named query).
+- SQL files in `queries/` are only for ad-hoc runs with `dac query -f` — widgets always inline their SQL (or reference a named query).
 
 ---
 
@@ -345,8 +345,6 @@ rows:
 Every widget (except `text`, `divider`, and `image`) needs a query source. **Priority order:**
 1. `query: <name>` — reference a named query from the `queries:` map
 2. `sql: |` — inline SQL
-
-(In TSX, `include("path/to/query.sql")` reads a .sql file into an inline `sql` string at load time.)
 
 ### Metric Widget
 
@@ -1042,20 +1040,6 @@ TSX dashboards support both JS template literals (resolved at load time) and Jin
 
 - **`${...}`** (JS template literal) — resolved when goja runs the script at load time
 - **`{{ ... }}`** (Jinja) — preserved in the SQL string, resolved per request with filter values
-
-### `include()` — Read SQL Files
-
-```tsx
-const sql = include("queries/recent_orders.sql")
-
-export default (
-  <Dashboard name="Orders" connection="duckdb">
-    <Row>
-      <Table name="Recent" sql={sql} col={12} />
-    </Row>
-  </Dashboard>
-)
-```
 
 ### `require()` — Import Shared Modules
 

--- a/docs/dashboards/tsx.md
+++ b/docs/dashboards/tsx.md
@@ -48,14 +48,13 @@ TSX is useful when you need:
 - loops and conditionals
 - shared variables and helpers
 - load-time queries to shape the dashboard
-- reusable modules and includes
+- reusable modules
 
 ## Global Functions
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `query` | `query(connection: string, sql: string): QueryResult` | Execute SQL at dashboard load time |
-| `include` | `include(path: string): string` | Read a file relative to the dashboard |
 | `require` | `require(path: string): any` | Import another module |
 
 ### QueryResult

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -132,16 +132,7 @@ func evalTSX(source, filePath string, cfg *tsxConfig) (*Dashboard, error) {
 	})
 	_ = vm.Set("console", console)
 
-	// Register include() for reading .sql files.
 	baseDir := filepath.Dir(filePath)
-	_ = vm.Set("include", func(call goja.FunctionCall) goja.Value {
-		relPath := call.Argument(0).String()
-		content, err := readQueryFile(baseDir, relPath)
-		if err != nil {
-			panic(vm.ToValue(err.Error()))
-		}
-		return vm.ToValue(content)
-	})
 
 	// Register require() for importing modules.
 	moduleCache := make(map[string]goja.Value)

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -703,48 +703,6 @@ export default (
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Include SQL files
-// ---------------------------------------------------------------------------
-
-func TestEvalTSX_IncludeSQLFile(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	sqlDir := filepath.Join(tmpDir, "queries")
-	if err := os.MkdirAll(sqlDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	sqlContent := "SELECT * FROM orders ORDER BY created_at DESC LIMIT 20"
-	if err := os.WriteFile(filepath.Join(sqlDir, "recent.sql"), []byte(sqlContent), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	dashCode := `
-const sql = include("queries/recent.sql")
-
-export default (
-  <Dashboard name="Include Test" connection="db">
-    <Row>
-      <Table name="Recent" sql={sql} col={12} />
-    </Row>
-  </Dashboard>
-)
-`
-	dashPath := filepath.Join(tmpDir, "test.dashboard.tsx")
-	if err := os.WriteFile(dashPath, []byte(dashCode), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	d, err := LoadTSXFile(dashPath)
-	assertNoErr(t, err)
-
-	w := d.Rows[0].Widgets[0]
-	if w.SQL != sqlContent {
-		t.Errorf("expected SQL from file, got: %s", w.SQL)
-	}
-}
-
 func TestLoadTSXFile_ProjectSemanticDashboard(t *testing.T) {
 	d, err := LoadTSXFile("../../testdata/project/dashboards/semantic.dashboard.tsx")
 	assertNoErr(t, err)

--- a/pkg/dashboard/loader.go
+++ b/pkg/dashboard/loader.go
@@ -126,16 +126,6 @@ func loadFileWithContext(path string, paths ProjectPaths, semanticModels semanti
 	return &d, nil
 }
 
-// readQueryFile reads a .sql file relative to the dashboard; used by the TSX include() helper.
-func readQueryFile(baseDir, relPath string) (string, error) {
-	path := filepath.Join(baseDir, relPath)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("reading query file %s: %w", relPath, err)
-	}
-	return string(data), nil
-}
-
 func isYAMLFile(name string) bool {
 	ext := strings.ToLower(filepath.Ext(name))
 	return ext == ".yml" || ext == ".yaml"


### PR DESCRIPTION
Follow-up to #29, which removed `file:` SQL references from YAML dashboards. TSX dashboards had an equivalent escape hatch: the `include("path.sql")` runtime helper, which read a .sql file into a string at load time.

This removes it so the rule is uniform across both formats: **a dashboard definition file always contains its SQL inline** (or references a named query). Nothing in the repo used `include()` — the only usages were the feature's own test and two doc mentions.

- Drop the `include` global from the TSX runtime and the now-unused file reader in the loader
- Drop the `include()` test
- Update the TSX docs and the create-dashboard skill; `queries/*.sql` files are now only for ad-hoc `dac query -f` runs

Stacked on #29 (the file reader it deletes was last referenced there); retarget to `main` after #29 merges if GitHub doesn't do it automatically.