### PR TITLE
Render tables dynamically from query results

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -742,26 +742,16 @@ OHLC chart for financial/pricing data. Green when close ≥ open, red otherwise.
 
 ### Table Widget
 
-Data table with optional column configuration.
+Renders every column and row the query returns — no column configuration. Headers come from the result column names, numeric columns are auto-detected (right-aligned, locale-formatted), `id`/`*_id` columns stay plain, and headers are click-sortable. Shape the table in SQL: pick, order, and alias columns in the `SELECT`.
 
 ```yaml
 - name: Recent Orders
   type: table
   sql: |
-    SELECT id, customer_name, amount, status, created_at
+    SELECT id, customer_name AS customer, amount, status, created_at
     FROM orders ORDER BY created_at DESC LIMIT 25
-  columns:                      # Optional: customize column display
-    - name: customer_name       # Must match SQL column name
-      label: Customer           # Display header
-    - name: amount
-      label: Amount
-      format: currency          # "currency" adds $ prefix, "number" for locale formatting
-    - name: created_at
-      label: Date               # ISO dates auto-format to readable strings
   col: 12
 ```
-
-If `columns` is omitted, all result columns are shown with their SQL names as headers.
 
 ### Text Widget
 
@@ -919,14 +909,14 @@ Every YAML widget type has a corresponding JSX tag. Props map directly to YAML f
 
 | JSX Tag | YAML `type:` | Props |
 |---------|-------------|-------|
-| `<Dashboard>` | (root) | `name`, `connection`, `description`, `theme`, `refresh` |
+| `<Dashboard>` | (root) | `name`, `connection`, `description` |
 | `<Row>` | (row) | `height` |
 | `<Filter>` | (filter) | `name`, `type`, `default`, `multiple`, `options` |
-| `<Query>` | (named query) | `name`, `sql`, `file`, `connection` |
+| `<Query>` | (named query) | `name`, `sql`, `connection` |
 | `<Semantic>` | (semantic layer) | `source`, `metrics`, `dimensions` |
 | `<Metric>` | `metric` | `name`, `col`, `sql`, `query`, `value`, `metric` |
 | `<Chart>` | `chart` | `name`, `col`, `chart`, `sql`, `x`, `y`, `label`, `value`, `color`, `stacked`, `normalized`, `horizontal`, `dimension`, `metrics`, `limit`, etc. |
-| `<Table>` | `table` | `name`, `col`, `sql`, `query`, `columns` |
+| `<Table>` | `table` | `name`, `col`, `sql`, `query` |
 | `<Text>` | `text` | `name`, `col`, `content` |
 | `<Divider>` | `divider` | `name`, `col` |
 | `<Image>` | `image` | `name`, `col`, `src`, `alt` |
@@ -1359,12 +1349,6 @@ rows:
           WHERE event_name = 'page_view'
             AND event_date >= '{{ filters.date_range.start }}'
           GROUP BY 1 ORDER BY 2 DESC LIMIT 10
-        columns:
-          - name: page
-            label: Page
-          - name: views
-            label: Views
-            format: number
 ```
 
 ### Query-Based Dashboard (SQL mode)
@@ -1453,20 +1437,8 @@ rows:
         type: table
         col: 12
         sql: |
-          SELECT id, customer_name, amount, status, created_at
+          SELECT id, customer_name AS customer, amount, status, created_at
           FROM orders ORDER BY created_at DESC LIMIT 20
-        columns:
-          - name: id
-            label: Order ID
-          - name: customer_name
-            label: Customer
-          - name: amount
-            label: Amount
-            format: currency
-          - name: status
-            label: Status
-          - name: created_at
-            label: Date
 ```
 
 ---
@@ -1477,7 +1449,7 @@ rows:
 |------|----------------|--------------|-------------|
 | `metric` | `metric:` ref OR `value` + query | Declarative or SQL | Single KPI number card |
 | `chart` | `dimension` + `metrics` OR `chart` + x/y + query | Declarative or SQL | Visualization (21 chart types) |
-| `table` | — | SQL | Data table with optional column config |
+| `table` | — | SQL | Data table showing all query columns |
 | `text` | `content` | None | Markdown/text content |
 | `divider` | — | None | Horizontal separator line |
 | `image` | `src` | None | Image from URL |

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -436,16 +436,6 @@ __INIT_CTE_WIDGET__
         type: table
         col: 12
         query: filtered_sales
-        columns:
-          - name: created_at
-            label: Date
-          - name: region
-            label: Region
-          - name: channel
-            label: Channel
-          - name: amount
-            label: Amount
-            format: currency
 `)
 
 const initSemanticModel = `name: sales
@@ -632,17 +622,6 @@ rows:
         sort:
           - name: revenue
             direction: desc
-        columns:
-          - name: region
-            label: Region
-          - name: channel
-            label: Channel
-          - name: revenue
-            label: Revenue
-            format: currency
-          - name: sales_count
-            label: Sales
-            format: number
         col: 12
 `
 
@@ -740,12 +719,6 @@ const initSemanticTSXDashboard = `export default (
         dimensions={[{ name: "region" }, { name: "channel" }]}
         metrics={["revenue", "sales_count"]}
         sort={[{ name: "revenue", direction: "desc" }]}
-        columns={[
-          { name: "region", label: "Region" },
-          { name: "channel", label: "Channel" },
-          { name: "revenue", label: "Revenue", format: "currency" },
-          { name: "sales_count", label: "Sales", format: "number" },
-        ]}
         col={12}
       />
     </Row>

--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -70,7 +70,7 @@ Created presentation: https://docs.google.com/presentation/d/1abc.../edit
 
 | Widget | Rendering |
 |--------|-----------|
-| Metric | Formatted text box with value, prefix/suffix |
+| Metric | Formatted text box with the rendered metric value |
 | Chart (line, area, bar, pie) | PNG image via go-chart |
 | Table | Native Slides table |
 | Text | Not currently exported |

--- a/docs/dashboards/queries.md
+++ b/docs/dashboards/queries.md
@@ -58,7 +58,6 @@ Named semantic queries use the same model resolution rules as widgets. If `model
 | Field | Type | Description |
 |-------|------|-------------|
 | `sql` | string | Inline SQL |
-| `file` | string | Path to a `.sql` file, relative to the dashboard |
 | `connection` | string | Connection override |
 
 ### Semantic Fields
@@ -78,13 +77,12 @@ Semantic query fields are compiled to SQL by the backend REST API when the widge
 
 ## Widget Query Sources
 
-Every data widget needs a query. You can provide one in five ways:
+Every data widget needs a query. You can provide one in four ways:
 
 1. `query`: reference a named query
 2. `sql`: inline SQL
-3. `file`: external `.sql` file
-4. `metric`: semantic metric reference with a model context
-5. semantic widget fields such as `dimension`, `dimensions`, `metrics`, `filters`, `segments`, `sort`, and `limit`
+3. `metric`: semantic metric reference with a model context
+4. semantic widget fields such as `dimension`, `dimensions`, `metrics`, `filters`, `segments`, `sort`, and `limit`
 
 Examples:
 

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -206,7 +206,9 @@ Charts using `dimension`, `metrics`, `segments`, or semantic `filters` are compi
 
 ## Table
 
-Tables display query results in a scrollable grid.
+Tables render every column and row the query returns — there is no column configuration. Headers come from the result column names, numeric columns are detected automatically (right-aligned, locale-formatted), columns named `id` or `*_id` stay plain, and headers are click-sortable.
+
+Control what the table shows in SQL: pick the columns, order them in the `SELECT`, and alias them for readable headers.
 
 SQL-backed example:
 
@@ -214,16 +216,10 @@ SQL-backed example:
 - name: Recent Orders
   type: table
   sql: |
-    SELECT id, customer_name, amount, status, created_at
+    SELECT id, customer_name AS customer, amount, status, created_at
     FROM orders
     ORDER BY created_at DESC
     LIMIT 20
-  columns:
-    - name: id
-      label: Order ID
-    - name: amount
-      label: Amount
-      format: currency
 ```
 
 Semantic example:
@@ -239,23 +235,7 @@ Semantic example:
   sort:
     - name: revenue
       direction: desc
-  columns:
-    - name: region
-      label: Region
-    - name: revenue
-      label: Revenue
-      format: currency
 ```
-
-Tables can mix semantic dimensions and metrics with explicit `columns` metadata for display labels and formatting.
-
-Table column fields:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | Result column name (must match the SQL output) |
-| `label` | string | Display header (defaults to `name`) |
-| `format` | string | `number` or `currency` |
 
 ## Text
 

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -11,7 +11,7 @@ Widgets are the visual building blocks of a dashboard. Each widget occupies a nu
 | `col` | integer | No | Column span from 1 to 12 |
 | `description` | string | No | Optional tooltip or subtitle |
 
-Data-backed widgets (`metric`, `chart`, `table`) also need a query source: `query` (named query reference), `sql` (inline), `file` (external `.sql` path), or a semantic reference (`metric:` for metric widgets, `dimension:` + `metrics:` for charts). See [Queries & Templating](/dashboards/queries) for the full reference, including the `connection` override.
+Data-backed widgets (`metric`, `chart`, `table`) also need a query source: `query` (named query reference), `sql` (inline), or a semantic reference (`metric:` for metric widgets, `dimension:` + `metrics:` for charts). See [Queries & Templating](/dashboards/queries) for the full reference, including the `connection` override.
 
 ## Metric
 

--- a/docs/dashboards/yaml.md
+++ b/docs/dashboards/yaml.md
@@ -145,9 +145,8 @@ Widgets can get their data from:
 
 1. `query`: reference a named query
 2. `sql`: inline SQL
-3. `file`: external `.sql` file relative to the dashboard
-4. `metric`: semantic metric reference with a model context
-5. semantic widget fields: `dimension`, `dimensions`, `metrics`, `filters`, `segments`, `sort`, `limit`
+3. `metric`: semantic metric reference with a model context
+4. semantic widget fields: `dimension`, `dimensions`, `metrics`, `filters`, `segments`, `sort`, `limit`
 
 ### Named Query Reference
 

--- a/examples/basic-yaml/dashboards/date-number-filters.yml
+++ b/examples/basic-yaml/dashboards/date-number-filters.yml
@@ -89,15 +89,3 @@ rows:
             AND amount >= {{ filters.min_order_value }}
           ORDER BY created_at DESC
           LIMIT 20
-        columns:
-          - name: id
-            label: Order ID
-          - name: customer_name
-            label: Customer
-          - name: amount
-            label: Amount
-            format: currency
-          - name: status
-            label: Status
-          - name: created_at
-            label: Date

--- a/examples/basic-yaml/dashboards/sales.yml
+++ b/examples/basic-yaml/dashboards/sales.yml
@@ -158,18 +158,6 @@ rows:
           GROUP BY 1
           ORDER BY 3 DESC
           LIMIT 10
-        columns:
-          - name: customer_name
-            label: Customer
-          - name: orders
-            label: Orders
-            format: number
-          - name: total_spent
-            label: Total Spent
-            format: currency
-          - name: avg_order
-            label: Average Order
-            format: currency
       - name: Revenue by Region & Month
         type: table
         col: 6
@@ -187,17 +175,6 @@ rows:
           {% endif %}
           GROUP BY 1, 2
           ORDER BY 1, 2
-        columns:
-          - name: region
-            label: Region
-          - name: month
-            label: Month
-          - name: sales_count
-            label: Sales
-            format: number
-          - name: revenue
-            label: Revenue
-            format: currency
 
   # Recent orders
   - widgets:
@@ -210,16 +187,4 @@ rows:
             AND created_at <= '{{ filters.date_range.end }}'
           ORDER BY created_at DESC
           LIMIT 25
-        columns:
-          - name: id
-            label: Order ID
-          - name: customer_name
-            label: Customer
-          - name: amount
-            label: Amount
-            format: currency
-          - name: status
-            label: Status
-          - name: created_at
-            label: Date
         col: 12

--- a/examples/semantic-tsx/dashboards/semantic.dashboard.tsx
+++ b/examples/semantic-tsx/dashboards/semantic.dashboard.tsx
@@ -99,12 +99,6 @@ export default (
         ]}
         sort={[{ name: "revenue", direction: "desc" }]}
         limit={20}
-        columns={[
-          { name: "region", label: "Region" },
-          { name: "channel", label: "Channel" },
-          { name: "revenue", label: "Revenue", format: "currency" },
-          { name: "sales_count", label: "Sales", format: "number" },
-        ]}
         col={12}
       />
     </Row>

--- a/examples/semantic-yaml/dashboards/semantic-sales.yml
+++ b/examples/semantic-yaml/dashboards/semantic-sales.yml
@@ -144,15 +144,4 @@ rows:
           - name: revenue
             direction: desc
         limit: 20
-        columns:
-          - name: region
-            label: Region
-          - name: channel
-            label: Channel
-          - name: revenue
-            label: Revenue
-            format: currency
-          - name: sales_count
-            label: Sales
-            format: number
         col: 12

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from "react";
 import type { Widget, WidgetData } from "../../types/dashboard";
 
 interface Props {
@@ -5,60 +6,93 @@ interface Props {
   data?: WidgetData;
 }
 
-export function TableWidget({ widget, data }: Props) {
-  if (!data?.rows?.length) {
+export function TableWidget({ data }: Props) {
+  const [sort, setSort] = useState<{ col: number; dir: "asc" | "desc" } | null>(null);
+
+  useEffect(() => {
+    setSort(null);
+  }, [data]);
+
+  const rows = data?.rows ?? [];
+  const columns = data?.columns ?? [];
+
+  const numericCols = useMemo(
+    () =>
+      columns.map((col, idx) => {
+        if (isIdColumn(col.name)) return false;
+        let sawNumber = false;
+        for (const row of rows) {
+          const val = row[idx];
+          if (val === null || val === undefined || val === "") continue;
+          if (!Number.isFinite(Number(val))) return false;
+          sawNumber = true;
+        }
+        return sawNumber;
+      }),
+    [columns, rows],
+  );
+
+  const sortedRows = useMemo(() => {
+    if (!sort) return rows;
+    const { col, dir } = sort;
+    const sign = dir === "asc" ? 1 : -1;
+    return [...rows].sort((a, b) => {
+      const av = a?.[col] ?? "";
+      const bv = b?.[col] ?? "";
+      const an = Number(av);
+      const bn = Number(bv);
+      if (Number.isFinite(an) && Number.isFinite(bn)) return (an - bn) * sign;
+      return String(av).localeCompare(String(bv)) * sign;
+    });
+  }, [rows, sort]);
+
+  if (!rows.length) {
     return <div className="text-[var(--dac-text-muted)] text-xs py-4 text-center">No data</div>;
   }
 
-  const columns = widget.columns?.length
-    ? widget.columns.map((col) => ({
-        name: col.name,
-        label: col.label || col.name,
-        format: col.format,
-        idx: data.columns.findIndex((c) => c.name === col.name),
-      }))
-    : data.columns.map((col, idx) => ({
-        name: col.name,
-        label: col.name,
-        format: undefined as string | undefined,
-        idx,
-      }));
-
-  const isNumeric = (format?: string) =>
-    format === "currency" || format === "number";
+  const toggleSort = (col: number) =>
+    setSort((prev) =>
+      prev?.col === col
+        ? { col, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { col, dir: "asc" },
+    );
 
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-[13px] min-w-[400px]">
         <thead>
           <tr className="bg-[var(--dac-surface)]">
-            {columns.map((col) => (
+            {columns.map((col, idx) => (
               <th
                 key={col.name}
-                className={`text-left py-2 px-4 text-[10px] font-semibold uppercase tracking-wider text-[var(--dac-text-muted)] border-b border-[var(--dac-border)] whitespace-nowrap ${
-                  isNumeric(col.format) ? "text-right" : ""
+                onClick={() => toggleSort(idx)}
+                className={`text-left py-2 px-4 text-[10px] font-semibold uppercase tracking-wider text-[var(--dac-text-muted)] border-b border-[var(--dac-border)] whitespace-nowrap cursor-pointer select-none hover:text-[var(--dac-text)] transition-colors ${
+                  numericCols[idx] ? "text-right" : ""
                 }`}
               >
-                {col.label}
+                {col.name}
+                {sort?.col === idx && (
+                  <span className="ml-1">{sort.dir === "asc" ? "↑" : "↓"}</span>
+                )}
               </th>
             ))}
           </tr>
         </thead>
         <tbody>
-          {data.rows.map((row, i) => (
+          {sortedRows.map((row, i) => (
             <tr
               key={i}
               className="border-b border-[var(--dac-border)] border-opacity-40 last:border-0 hover:bg-[var(--dac-surface)] transition-colors duration-75"
             >
-              {columns.map((col) => (
+              {columns.map((col, idx) => (
                 <td
                   key={col.name}
                   className={`py-1.5 px-4 whitespace-nowrap ${
-                    isNumeric(col.format) ? "text-right tabular-nums text-[12px]" : ""
+                    numericCols[idx] ? "text-right tabular-nums text-[12px]" : ""
                   }`}
-                  style={isNumeric(col.format) ? { fontFamily: '"Geist Mono", monospace' } : undefined}
+                  style={numericCols[idx] ? { fontFamily: '"Geist Mono", monospace' } : undefined}
                 >
-                  {formatCell(col.idx >= 0 ? row[col.idx] : null, col.format)}
+                  {formatCell(row[idx], col.name)}
                 </td>
               ))}
             </tr>
@@ -69,17 +103,23 @@ export function TableWidget({ widget, data }: Props) {
   );
 }
 
-function formatCell(value: unknown, format?: string): string {
-  if (value === null || value === undefined) return "—";
-  if (format === "currency") {
-    const num = Number(value);
-    return isNaN(num) ? String(value) : `$${num.toLocaleString(undefined, { minimumFractionDigits: 2 })}`;
-  }
-  if (format === "number") {
-    const num = Number(value);
-    return isNaN(num) ? String(value) : num.toLocaleString();
-  }
+// id-like columns hold identifiers, not quantities — never format or right-align them.
+function isIdColumn(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower === "id" || lower.endsWith("_id");
+}
+
+function formatCell(value: unknown, colName: string): string {
+  if (value === null || value === undefined || value === "") return "—";
   const s = String(value);
+  if (isIdColumn(colName)) return s;
+  const num = Number(value);
+  if (Number.isFinite(num)) {
+    if (!Number.isInteger(num)) {
+      return num.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 6 });
+    }
+    return num.toLocaleString("en-US");
+  }
   const isoMatch = s.match(/^(\d{4})-(\d{2})-(\d{2})T/);
   if (isoMatch) {
     return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -70,7 +70,7 @@ export function TableWidget({ data }: Props) {
                   numericCols[idx] ? "text-right" : ""
                 }`}
               >
-                {col.name}
+                {col.name.replace(/_/g, " ")}
                 {sort?.col === idx && (
                   <span className="ml-1">{sort.dir === "asc" ? "↑" : "↓"}</span>
                 )}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -96,21 +96,12 @@ export interface Widget {
   low?: string;        // candlestick: low column
   close?: string;      // candlestick: close column
 
-  // Table
-  columns?: TableColumn[];
-
   // Text
   content?: string;
 
   // Image
   src?: string;
   alt?: string;
-}
-
-export interface TableColumn {
-  name: string;
-  label?: string;
-  format?: string;
 }
 
 /** Structured encoding for a chart axis. `y.field` may list several series columns. */

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -544,9 +544,6 @@ func vnodeToWidget(n *vnode) Widget {
 		YMin:       asString(n.Props["yMin"]),
 		YMax:       asString(n.Props["yMax"]),
 
-		// Table fields
-		Columns: asTableColumns(n.Props["columns"]),
-
 		// Text fields
 		Content: asString(n.Props["content"]),
 
@@ -881,26 +878,6 @@ func asMap(v interface{}) map[string]interface{} {
 	return map[string]interface{}{}
 }
 
-func asTableColumns(v interface{}) []TableColumn {
-	if v == nil {
-		return nil
-	}
-	arr, ok := v.([]interface{})
-	if !ok {
-		return nil
-	}
-	var cols []TableColumn
-	for _, item := range arr {
-		if m, ok := item.(map[string]interface{}); ok {
-			cols = append(cols, TableColumn{
-				Name:   asString(m["name"]),
-				Label:  asString(m["label"]),
-				Format: asString(m["format"]),
-			})
-		}
-	}
-	return cols
-}
 
 // IsTSXFile checks if a filename matches the .dashboard.tsx convention.
 func IsTSXFile(name string) bool {

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -422,17 +422,12 @@ export default (
 	}
 }
 
-func TestEvalTSX_TableWithColumns(t *testing.T) {
+func TestEvalTSX_TableWidget(t *testing.T) {
 	source := `
 export default (
-  <Dashboard name="Table Cols" connection="db">
+  <Dashboard name="Table" connection="db">
     <Row>
-      <Table name="Orders" col={12}
-        sql="SELECT * FROM orders"
-        columns={[
-          { name: "id", label: "Order ID" },
-          { name: "amount", label: "Amount", format: "currency" },
-        ]} />
+      <Table name="Orders" col={12} sql="SELECT * FROM orders" />
     </Row>
   </Dashboard>
 )
@@ -441,14 +436,11 @@ export default (
 	assertNoErr(t, err)
 
 	w := d.Rows[0].Widgets[0]
-	if len(w.Columns) != 2 {
-		t.Fatalf("expected 2 columns, got %d", len(w.Columns))
+	if w.Type != WidgetTypeTable {
+		t.Errorf("expected table, got %q", w.Type)
 	}
-	if w.Columns[0].Name != "id" || w.Columns[0].Label != "Order ID" {
-		t.Errorf("unexpected column 0: %+v", w.Columns[0])
-	}
-	if w.Columns[1].Format != "currency" {
-		t.Errorf("expected format %q, got %q", "currency", w.Columns[1].Format)
+	if w.SQL != "SELECT * FROM orders" {
+		t.Errorf("unexpected sql: %q", w.SQL)
 	}
 }
 

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -171,21 +171,12 @@ type Widget struct {
 	Low        string         `yaml:"low,omitempty" json:"low,omitempty"`       // candlestick: low price column
 	Close      string         `yaml:"close,omitempty" json:"close,omitempty"`   // candlestick: close price column
 
-	// Table fields
-	Columns []TableColumn `yaml:"columns,omitempty" json:"columns,omitempty"`
-
 	// Text fields
 	Content string `yaml:"content,omitempty" json:"content,omitempty"`
 
 	// Image fields
 	Src string `yaml:"src,omitempty" json:"src,omitempty"`
 	Alt string `yaml:"alt,omitempty" json:"alt,omitempty"`
-}
-
-type TableColumn struct {
-	Name   string `yaml:"name" json:"name"`
-	Label  string `yaml:"label,omitempty" json:"label,omitempty"`
-	Format string `yaml:"format,omitempty" json:"format,omitempty"`
 }
 
 type SemanticDimensionRef struct {

--- a/pkg/slides/export.go
+++ b/pkg/slides/export.go
@@ -356,17 +356,10 @@ func tableReqs(prefix, slideID string, w *dashboard.Widget, data *server.WidgetQ
 
 	// Header row.
 	for c, col := range data.Columns {
-		label := col.Name
-		for _, wc := range w.Columns {
-			if wc.Name == col.Name && wc.Label != "" {
-				label = wc.Label
-				break
-			}
-		}
 		reqs = append(reqs, &slidesapi.Request{
 			InsertText: &slidesapi.InsertTextRequest{
 				ObjectId:     tableID,
-				Text:         label,
+				Text:         col.Name,
 				CellLocation: &slidesapi.TableCellLocation{RowIndex: 0, ColumnIndex: int64(c)},
 			},
 		})

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -340,12 +340,6 @@
         "close": {
           "type": "string"
         },
-        "columns": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/tableColumn"
-          }
-        },
         "content": {
           "type": "string"
         },
@@ -415,26 +409,6 @@
         },
         "direction": {
           "enum": ["asc", "desc"]
-        }
-      },
-      "patternProperties": {
-        "^x-": true
-      },
-      "additionalProperties": false
-    },
-    "tableColumn": {
-      "type": "object",
-      "required": ["name"],
-      "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "label": {
-          "type": "string"
-        },
-        "format": {
-          "type": "string"
         }
       },
       "patternProperties": {

--- a/testdata/dashboards/business-summary.yml
+++ b/testdata/dashboards/business-summary.yml
@@ -207,17 +207,3 @@ rows:
         type: table
         query: recent_orders
         col: 12
-        columns:
-          - name: id
-            label: Order ID
-          - name: customer_name
-            label: Customer
-          - name: status
-            label: Status
-          - name: payment_method
-            label: Payment Method
-          - name: amount
-            label: Amount
-            format: currency
-          - name: created_at
-            label: Order Date

--- a/testdata/dashboards/google-analytics.yml
+++ b/testdata/dashboards/google-analytics.yml
@@ -153,12 +153,3 @@ rows:
           GROUP BY 1
           ORDER BY 2 DESC
           LIMIT 20
-        columns:
-          - name: page
-            label: Page
-          - name: views
-            label: Views
-            format: number
-          - name: users
-            label: Users
-            format: number

--- a/testdata/dashboards/sales.yml
+++ b/testdata/dashboards/sales.yml
@@ -159,18 +159,6 @@ rows:
           GROUP BY 1
           ORDER BY 3 DESC
           LIMIT 10
-        columns:
-          - name: customer_name
-            label: Customer
-          - name: orders
-            label: Orders
-            format: number
-          - name: total_spent
-            label: Total Spent
-            format: currency
-          - name: avg_order
-            label: Average Order
-            format: currency
       - name: Revenue by Region & Month
         type: table
         col: 6
@@ -188,17 +176,6 @@ rows:
           {% endif %}
           GROUP BY 1, 2
           ORDER BY 1, 2
-        columns:
-          - name: region
-            label: Region
-          - name: month
-            label: Month
-          - name: sales_count
-            label: Sales
-            format: number
-          - name: revenue
-            label: Revenue
-            format: currency
 
   # Recent orders
   - widgets:
@@ -211,16 +188,4 @@ rows:
             AND created_at <= '{{ filters.date_range.end }}'
           ORDER BY created_at DESC
           LIMIT 25
-        columns:
-          - name: id
-            label: Order ID
-          - name: customer_name
-            label: Customer
-          - name: amount
-            label: Amount
-            format: currency
-          - name: status
-            label: Status
-          - name: created_at
-            label: Date
         col: 12

--- a/testdata/dashboards/semantic-sales.yml
+++ b/testdata/dashboards/semantic-sales.yml
@@ -145,15 +145,4 @@ rows:
           - name: revenue
             direction: desc
         limit: 20
-        columns:
-          - name: region
-            label: Region
-          - name: channel
-            label: Channel
-          - name: revenue
-            label: Revenue
-            format: currency
-          - name: sales_count
-            label: Sales
-            format: number
         col: 12

--- a/testdata/dashboards/semantic.dashboard.tsx
+++ b/testdata/dashboards/semantic.dashboard.tsx
@@ -99,12 +99,6 @@ export default (
         ]}
         sort={[{ name: "revenue", direction: "desc" }]}
         limit={20}
-        columns={[
-          { name: "region", label: "Region" },
-          { name: "channel", label: "Channel" },
-          { name: "revenue", label: "Revenue", format: "currency" },
-          { name: "sales_count", label: "Sales", format: "number" },
-        ]}
         col={12}
       />
     </Row>

--- a/testdata/project/dashboards/semantic-sales.yml
+++ b/testdata/project/dashboards/semantic-sales.yml
@@ -83,10 +83,3 @@ rows:
           - name: revenue
             direction: desc
         limit: 10
-        columns:
-          - name: country
-            label: Country
-          - name: revenue
-            label: Revenue
-          - name: order_count
-            label: Orders

--- a/testdata/project/dashboards/semantic.dashboard.tsx
+++ b/testdata/project/dashboards/semantic.dashboard.tsx
@@ -62,11 +62,6 @@ export default (
         filters={[{ dimension: "country", operator: "equals", value: "{{ filters.country }}" }]}
         sort={[{ name: "revenue", direction: "desc" }]}
         limit={10}
-        columns={[
-          { name: "country", label: "Country" },
-          { name: "revenue", label: "Revenue" },
-          { name: "order_count", label: "Orders" },
-        ]}
         col={12}
       />
     </Row>


### PR DESCRIPTION
## Summary
- remove per-widget `columns` configuration from table widgets
- render tables directly from query results with automatic formatting and sortable headers
- update example, testdata, schema, loader, and widget docs to match the new table behavior

## Testing
- `make test`
