### PR TITLE
[codex] add Metabase importer

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,651 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	mbimport "github.com/bruin-data/dac/pkg/importer/metabase"
+	"github.com/urfave/cli/v3"
+	"gopkg.in/yaml.v3"
+)
+
+func importCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "import",
+		Usage: "Import dashboards from external tools",
+		Commands: []*cli.Command{
+			importMetabaseCmd(),
+		},
+	}
+}
+
+func importMetabaseCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "metabase",
+		Usage: "Convert a Metabase dashboard to DAC YAML",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "input",
+				Aliases: []string{"i"},
+				Usage:   "Path to a Metabase dashboard API response JSON/YAML file",
+			},
+			&cli.StringFlag{
+				Name:  "url",
+				Usage: "Metabase base URL for live import",
+			},
+			&cli.StringFlag{
+				Name:  "dashboard-id",
+				Usage: "Metabase dashboard ID for live import",
+			},
+			&cli.StringFlag{
+				Name:    "api-key",
+				Usage:   "Metabase API key (or set METABASE_API_KEY)",
+				Sources: cli.EnvVars("METABASE_API_KEY"),
+			},
+			&cli.StringFlag{
+				Name:    "session-token",
+				Usage:   "Metabase session token (or set METABASE_SESSION_TOKEN)",
+				Sources: cli.EnvVars("METABASE_SESSION_TOKEN"),
+			},
+			&cli.StringFlag{
+				Name:    "connection",
+				Aliases: []string{"c"},
+				Usage:   "DAC connection name to set on the generated dashboard",
+			},
+			&cli.StringFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Usage:   "Output YAML path (default: <dir>/<dashboard-slug>.yml; use - for stdout)",
+			},
+			dirFlag,
+			&cli.BoolFlag{
+				Name:  "force",
+				Usage: "Overwrite an existing output file",
+			},
+			&cli.BoolFlag{
+				Name:  "strict",
+				Usage: "Fail instead of creating placeholders for unsupported Metabase cards",
+			},
+			&cli.BoolFlag{
+				Name:  "semantic",
+				Usage: "Generate DAC semantic models for explicit Metabase models/metrics and convert eligible widgets to semantic references",
+			},
+			&cli.BoolFlag{
+				Name:  "semantic-strict",
+				Usage: "Fail when semantic import cannot represent a Metabase model-backed card semantically",
+			},
+			&cli.StringFlag{
+				Name:  "semantic-dir",
+				Usage: "Directory for generated semantic model files (default: sibling semantic/ next to dashboards/)",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			data, source, err := readMetabaseInput(ctx, cmd)
+			if err != nil {
+				return err
+			}
+
+			semantic := cmd.Bool("semantic") || cmd.Bool("semantic-strict")
+			if semantic && cmd.String("output") == "-" {
+				return fmt.Errorf("--semantic cannot be used with --output - because generated semantic model files need filesystem paths")
+			}
+
+			project, report, err := mbimport.ConvertProject(data, mbimport.Options{
+				Connection:     cmd.String("connection"),
+				Strict:         cmd.Bool("strict"),
+				Semantic:       semantic,
+				SemanticStrict: cmd.Bool("semantic-strict"),
+			})
+			if err != nil {
+				return err
+			}
+			d := project.Dashboard
+
+			out, err := yaml.Marshal(d)
+			if err != nil {
+				return fmt.Errorf("encoding DAC YAML: %w", err)
+			}
+
+			outputPath := cmd.String("output")
+			if outputPath == "" {
+				outputPath = filepath.Join(cmd.String("dir"), slugifyFilename(d.Name)+".yml")
+			}
+			if err := writeImportOutput(outputPath, out, cmd.Bool("force")); err != nil {
+				return err
+			}
+
+			var semanticPaths []string
+			if semantic {
+				semanticDir := cmd.String("semantic-dir")
+				if semanticDir == "" {
+					semanticDir = defaultSemanticDir(cmd.String("dir"), outputPath)
+				}
+				for _, file := range project.SemanticModels {
+					data, err := yaml.Marshal(file.Model)
+					if err != nil {
+						return fmt.Errorf("encoding DAC semantic model %q: %w", file.Model.Name, err)
+					}
+					path := filepath.Join(semanticDir, file.Filename)
+					if err := writeImportOutput(path, data, cmd.Bool("force")); err != nil {
+						return err
+					}
+					semanticPaths = append(semanticPaths, path)
+				}
+			}
+
+			for _, warning := range report.Warnings {
+				fmt.Fprintf(os.Stderr, "warning: %s\n", warning)
+			}
+			if outputPath == "-" {
+				fmt.Fprintf(os.Stderr, "Imported %q from %s: %d widget(s), %d SQL-backed, %d semantic, %d placeholder(s).\n",
+					d.Name, source, report.WidgetCount, report.SQLWidgetCount, report.SemanticWidgetCount, report.PlaceholderCount)
+			} else {
+				if len(semanticPaths) > 0 {
+					fmt.Printf("Imported %q from %s to %s and %d semantic model file(s) (%d widget(s), %d SQL-backed, %d semantic, %d placeholder(s)).\n",
+						d.Name, source, outputPath, len(semanticPaths), report.WidgetCount, report.SQLWidgetCount, report.SemanticWidgetCount, report.PlaceholderCount)
+				} else {
+					fmt.Printf("Imported %q from %s to %s (%d widget(s), %d SQL-backed, %d semantic, %d placeholder(s)).\n",
+						d.Name, source, outputPath, report.WidgetCount, report.SQLWidgetCount, report.SemanticWidgetCount, report.PlaceholderCount)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func readMetabaseInput(ctx context.Context, cmd *cli.Command) ([]byte, string, error) {
+	input := cmd.String("input")
+	baseURL := cmd.String("url")
+	dashboardID := cmd.String("dashboard-id")
+
+	switch {
+	case input != "" && (baseURL != "" || dashboardID != ""):
+		return nil, "", fmt.Errorf("use either --input or --url/--dashboard-id, not both")
+	case input != "":
+		data, err := os.ReadFile(input)
+		if err != nil {
+			return nil, "", fmt.Errorf("reading Metabase input: %w", err)
+		}
+		return data, input, nil
+	case baseURL != "" || dashboardID != "":
+		if baseURL == "" || dashboardID == "" {
+			return nil, "", fmt.Errorf("live import requires both --url and --dashboard-id")
+		}
+		data, err := fetchMetabaseDashboard(ctx, baseURL, dashboardID, cmd.String("api-key"), cmd.String("session-token"))
+		if err != nil {
+			return nil, "", err
+		}
+		return data, strings.TrimRight(baseURL, "/") + "/api/dashboard/" + dashboardID, nil
+	default:
+		return nil, "", fmt.Errorf("provide --input or --url/--dashboard-id")
+	}
+}
+
+func fetchMetabaseDashboard(ctx context.Context, baseURL, dashboardID, apiKey, sessionToken string) ([]byte, error) {
+	if apiKey == "" && sessionToken == "" {
+		return nil, fmt.Errorf("live import requires --api-key, --session-token, METABASE_API_KEY, or METABASE_SESSION_TOKEN")
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Metabase URL: %w", err)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/api/dashboard/" + url.PathEscape(dashboardID)
+
+	client := http.DefaultClient
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating Metabase request: %w", err)
+	}
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	if sessionToken != "" {
+		req.Header.Set("X-Metabase-Session", sessionToken)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Metabase dashboard: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading Metabase response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return nil, fmt.Errorf("Metabase API returned %s: %s", resp.Status, msg)
+	}
+	return hydrateMetabaseSourceCards(ctx, client, u, body, apiKey, sessionToken)
+}
+
+func hydrateMetabaseSourceCards(ctx context.Context, client *http.Client, dashboardURL *url.URL, dashboardBody []byte, apiKey, sessionToken string) ([]byte, error) {
+	var root map[string]any
+	if err := json.Unmarshal(dashboardBody, &root); err != nil {
+		return dashboardBody, nil
+	}
+
+	sourceCards := map[string]any{}
+	metrics := map[string]any{}
+	tables := map[string]any{}
+	seenSourceCards := map[string]bool{}
+	seenMetrics := map[string]bool{}
+	seenTables := map[string]bool{}
+	for {
+		ids := collectMetabaseSourceCardIDs(root)
+		var fetched bool
+		for id := range ids {
+			if seenSourceCards[id] {
+				continue
+			}
+			seenSourceCards[id] = true
+			card, err := fetchMetabaseCard(ctx, client, dashboardURL, id, apiKey, sessionToken)
+			if err != nil {
+				return nil, err
+			}
+			sourceCards[id] = card
+			root["x-dac-metabase-source-cards"] = sourceCards
+			fetched = true
+		}
+
+		metricIDs := collectMetabaseMetricIDs(root)
+		for id := range metricIDs {
+			if seenMetrics[id] {
+				continue
+			}
+			seenMetrics[id] = true
+			metric, err := fetchMetabaseMetric(ctx, client, dashboardURL, id, apiKey, sessionToken)
+			if err != nil {
+				return nil, err
+			}
+			metrics[id] = metric
+			root["x-dac-metabase-metrics"] = metrics
+			fetched = true
+		}
+
+		tableIDs := collectMetabaseTableIDs(root)
+		for id := range tableIDs {
+			if seenTables[id] {
+				continue
+			}
+			seenTables[id] = true
+			table, err := fetchMetabaseTableMetadata(ctx, client, dashboardURL, id, apiKey, sessionToken)
+			if err != nil {
+				return nil, err
+			}
+			tables[id] = table
+			root["x-dac-metabase-tables"] = tables
+			fetched = true
+		}
+
+		if !fetched {
+			break
+		}
+	}
+	if len(sourceCards) == 0 && len(metrics) == 0 && len(tables) == 0 {
+		return dashboardBody, nil
+	}
+	out, err := json.Marshal(root)
+	if err != nil {
+		return nil, fmt.Errorf("encoding hydrated Metabase dashboard: %w", err)
+	}
+	return out, nil
+}
+
+func fetchMetabaseCard(ctx context.Context, client *http.Client, dashboardURL *url.URL, id, apiKey, sessionToken string) (map[string]any, error) {
+	u := *dashboardURL
+	u.RawQuery = ""
+	prefix := u.Path
+	if idx := strings.Index(prefix, "/api/dashboard/"); idx >= 0 {
+		prefix = prefix[:idx]
+	}
+	u.Path = strings.TrimRight(prefix, "/") + "/api/card/" + url.PathEscape(strings.TrimPrefix(id, "card__"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating Metabase card request: %w", err)
+	}
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	if sessionToken != "" {
+		req.Header.Set("X-Metabase-Session", sessionToken)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Metabase source card %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading Metabase source card %s: %w", id, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return nil, fmt.Errorf("Metabase API returned %s for source card %s: %s", resp.Status, id, msg)
+	}
+	var card map[string]any
+	if err := json.Unmarshal(body, &card); err != nil {
+		return nil, fmt.Errorf("parsing Metabase source card %s: %w", id, err)
+	}
+	return card, nil
+}
+
+func fetchMetabaseMetric(ctx context.Context, client *http.Client, dashboardURL *url.URL, id, apiKey, sessionToken string) (map[string]any, error) {
+	u := *dashboardURL
+	u.RawQuery = ""
+	prefix := u.Path
+	if idx := strings.Index(prefix, "/api/dashboard/"); idx >= 0 {
+		prefix = prefix[:idx]
+	}
+	u.Path = strings.TrimRight(prefix, "/") + "/api/metric/" + url.PathEscape(strings.TrimPrefix(id, "metric__"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating Metabase metric request: %w", err)
+	}
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	if sessionToken != "" {
+		req.Header.Set("X-Metabase-Session", sessionToken)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Metabase metric %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading Metabase metric %s: %w", id, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return nil, fmt.Errorf("Metabase API returned %s for metric %s: %s", resp.Status, id, msg)
+	}
+	var metric map[string]any
+	if err := json.Unmarshal(body, &metric); err != nil {
+		return nil, fmt.Errorf("parsing Metabase metric %s: %w", id, err)
+	}
+	return metric, nil
+}
+
+func fetchMetabaseTableMetadata(ctx context.Context, client *http.Client, dashboardURL *url.URL, id, apiKey, sessionToken string) (map[string]any, error) {
+	u := *dashboardURL
+	u.RawQuery = ""
+	prefix := u.Path
+	if idx := strings.Index(prefix, "/api/dashboard/"); idx >= 0 {
+		prefix = prefix[:idx]
+	}
+	u.Path = strings.TrimRight(prefix, "/") + "/api/table/" + url.PathEscape(id) + "/query_metadata"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating Metabase table metadata request: %w", err)
+	}
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	if sessionToken != "" {
+		req.Header.Set("X-Metabase-Session", sessionToken)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Metabase table %s metadata: %w", id, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading Metabase table %s metadata: %w", id, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return nil, fmt.Errorf("Metabase API returned %s for table %s metadata: %s", resp.Status, id, msg)
+	}
+	var table map[string]any
+	if err := json.Unmarshal(body, &table); err != nil {
+		return nil, fmt.Errorf("parsing Metabase table %s metadata: %w", id, err)
+	}
+	return table, nil
+}
+
+func collectMetabaseSourceCardIDs(v any) map[string]bool {
+	ids := map[string]bool{}
+	var walk func(any)
+	walk = func(v any) {
+		switch x := v.(type) {
+		case map[string]any:
+			for key, value := range x {
+				switch key {
+				case "source-card", "source_card":
+					if id := metabaseSourceCardID(value); id != "" {
+						ids[id] = true
+					}
+				case "source-table", "source_table":
+					if id := metabaseSourceTableCardID(value); id != "" {
+						ids[id] = true
+					}
+				}
+				walk(value)
+			}
+		case []any:
+			for _, item := range x {
+				walk(item)
+			}
+		}
+	}
+	walk(v)
+	return ids
+}
+
+func metabaseSourceCardID(v any) string {
+	switch x := v.(type) {
+	case string:
+		if strings.HasPrefix(x, "card__") {
+			return strings.TrimPrefix(x, "card__")
+		}
+	case float64:
+		return fmt.Sprintf("%.0f", x)
+	case int:
+		return fmt.Sprintf("%d", x)
+	case json.Number:
+		return x.String()
+	}
+	return ""
+}
+
+func metabaseSourceTableCardID(v any) string {
+	switch x := v.(type) {
+	case string:
+		if strings.HasPrefix(x, "card__") {
+			return strings.TrimPrefix(x, "card__")
+		}
+	}
+	return ""
+}
+
+func collectMetabaseTableIDs(v any) map[string]bool {
+	ids := map[string]bool{}
+	var walk func(any)
+	walk = func(v any) {
+		switch x := v.(type) {
+		case map[string]any:
+			for key, value := range x {
+				switch key {
+				case "source-table", "source_table":
+					if id := metabasePhysicalTableID(value); id != "" {
+						ids[id] = true
+					}
+				}
+				walk(value)
+			}
+		case []any:
+			for _, item := range x {
+				walk(item)
+			}
+		}
+	}
+	walk(v)
+	return ids
+}
+
+func metabasePhysicalTableID(v any) string {
+	switch x := v.(type) {
+	case string:
+		if strings.HasPrefix(x, "card__") {
+			return ""
+		}
+		return strings.TrimSpace(x)
+	case float64:
+		return fmt.Sprintf("%.0f", x)
+	case int:
+		return fmt.Sprintf("%d", x)
+	case json.Number:
+		return x.String()
+	default:
+		return ""
+	}
+}
+
+func collectMetabaseMetricIDs(v any) map[string]bool {
+	ids := map[string]bool{}
+	var walk func(any)
+	walk = func(v any) {
+		switch x := v.(type) {
+		case map[string]any:
+			for key, value := range x {
+				switch key {
+				case "metric-id", "metric_id":
+					if id := metabaseMetricID(value); id != "" {
+						ids[id] = true
+					}
+				}
+				walk(value)
+			}
+		case []any:
+			if id := metabaseMetricAggregationID(x); id != "" {
+				ids[id] = true
+			}
+			for _, item := range x {
+				walk(item)
+			}
+		}
+	}
+	walk(v)
+	return ids
+}
+
+func metabaseMetricAggregationID(parts []any) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	kind, _ := parts[0].(string)
+	if kind != "metric" {
+		return ""
+	}
+	for _, part := range parts[1:] {
+		if id := metabaseMetricID(part); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func metabaseMetricID(v any) string {
+	switch x := v.(type) {
+	case string:
+		return strings.TrimPrefix(x, "metric__")
+	case float64:
+		return fmt.Sprintf("%.0f", x)
+	case int:
+		return fmt.Sprintf("%d", x)
+	case json.Number:
+		return x.String()
+	case map[string]any:
+		for _, key := range []string{"metric-id", "metric_id", "id"} {
+			if id := metabaseMetricID(x[key]); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+func writeImportOutput(path string, data []byte, force bool) error {
+	if path == "-" {
+		_, err := os.Stdout.Write(data)
+		return err
+	}
+	if !force {
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("%s already exists; pass --force to overwrite", path)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("checking output path: %w", err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing import output: %w", err)
+	}
+	return nil
+}
+
+func defaultSemanticDir(dashboardDir, outputPath string) string {
+	baseDir := filepath.Clean(dashboardDir)
+	if outputPath != "" && outputPath != "-" {
+		baseDir = filepath.Dir(filepath.Clean(outputPath))
+	}
+	if filepath.Base(baseDir) == "dashboards" {
+		return filepath.Join(filepath.Dir(baseDir), "semantic")
+	}
+	return filepath.Join(baseDir, "semantic")
+}
+
+var filenameSlugPattern = strings.NewReplacer(
+	" ", "-",
+	"_", "-",
+	"/", "-",
+	"\\", "-",
+)
+
+func slugifyFilename(name string) string {
+	s := strings.ToLower(strings.TrimSpace(filenameSlugPattern.Replace(name)))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "metabase-dashboard"
+	}
+	return out
+}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/dac/pkg/dashboard"
+)
+
+const metabaseImportFixture = `{
+  "name": "Sales Ops",
+  "ordered_cards": [{
+    "row": 0,
+    "col": 0,
+    "size_x": 12,
+    "size_y": 3,
+    "card": {
+      "name": "Orders",
+      "display": "scalar",
+      "dataset_query": {
+        "type": "native",
+        "native": {"query": "SELECT COUNT(*) AS order_count FROM orders"}
+      },
+      "result_metadata": [
+        {"name": "order_count", "base_type": "type/Integer"}
+      ]
+    }
+  }]
+}`
+
+func TestImportMetabaseCommandWritesDashboardYAML(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "metabase.json")
+	if err := os.WriteFile(input, []byte(metabaseImportFixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	output := filepath.Join(dir, "dashboards", "sales-ops.yml")
+
+	app := NewApp(BuildInfo{Version: "test"})
+	stdout := captureStdout(t, func() {
+		if err := app.Run(context.Background(), []string{
+			"dac", "import", "metabase",
+			"--input", input,
+			"--output", output,
+			"--connection", "warehouse",
+		}); err != nil {
+			t.Fatalf("import failed: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, "Imported \"Sales Ops\"") {
+		t.Fatalf("expected import summary, got %q", stdout)
+	}
+
+	d, err := dashboard.LoadFile(output)
+	if err != nil {
+		t.Fatalf("load generated dashboard: %v", err)
+	}
+	if d.Connection != "warehouse" {
+		t.Fatalf("expected connection to be set, got %q", d.Connection)
+	}
+	if err := dashboard.Validate(d); err != nil {
+		t.Fatalf("generated dashboard should validate: %v", err)
+	}
+}
+
+func TestImportMetabaseCommandFetchesDashboard(t *testing.T) {
+	var gotAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/dashboard/42" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		gotAPIKey = r.Header.Get("X-API-Key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(metabaseImportFixture))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	output := filepath.Join(dir, "dashboard.yml")
+	app := NewApp(BuildInfo{Version: "test"})
+
+	if err := app.Run(context.Background(), []string{
+		"dac", "import", "metabase",
+		"--url", server.URL,
+		"--dashboard-id", "42",
+		"--api-key", "secret",
+		"--output", output,
+	}); err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+	if gotAPIKey != "secret" {
+		t.Fatalf("expected API key header, got %q", gotAPIKey)
+	}
+	if _, err := dashboard.LoadFile(output); err != nil {
+		t.Fatalf("load generated dashboard: %v", err)
+	}
+}
+
+func TestImportMetabaseCommandHydratesSourceModelCards(t *testing.T) {
+	var fetchedSourceCard bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/dashboard/42":
+			_, _ = w.Write([]byte(`{
+  "name": "Model Import",
+  "dashcards": [{
+    "row": 0,
+    "col": 0,
+    "size_x": 12,
+    "size_y": 6,
+    "card": {
+      "id": 100,
+      "name": "Revenue by Region",
+      "display": "bar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 99,
+          "breakout": [["field", {"base-type": "type/Text"}, "region"]],
+          "aggregation": [["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+        }]
+      },
+      "result_metadata": [
+        {"name": "region", "base_type": "type/Text"},
+        {"name": "sum", "base_type": "type/Decimal"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["region"],
+        "graph.metrics": ["sum"]
+      }
+    }
+  }]
+}`))
+		case "/api/card/99":
+			fetchedSourceCard = true
+			_, _ = w.Write([]byte(`{
+  "id": 99,
+  "name": "Sales Model",
+  "type": "model",
+  "display": "table",
+  "dataset_query": {
+    "database": 2,
+    "stages": [{
+      "native": "SELECT region, revenue FROM sales_summary"
+    }]
+  }
+}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	output := filepath.Join(dir, "dashboard.yml")
+	app := NewApp(BuildInfo{Version: "test"})
+
+	if err := app.Run(context.Background(), []string{
+		"dac", "import", "metabase",
+		"--url", server.URL,
+		"--dashboard-id", "42",
+		"--api-key", "secret",
+		"--output", output,
+	}); err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+	if !fetchedSourceCard {
+		t.Fatal("expected source model card to be fetched")
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !strings.Contains(string(data), "WITH source AS") || !strings.Contains(string(data), "SELECT region, revenue FROM sales_summary") {
+		t.Fatalf("expected hydrated model SQL, got:\n%s", string(data))
+	}
+}
+
+func TestImportMetabaseCommandHydratesPhysicalSourceTables(t *testing.T) {
+	var fetchedPhysicalTableAsCard bool
+	var fetchedTableMetadata bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/dashboard/42":
+			_, _ = w.Write([]byte(`{
+  "name": "Physical Table Import",
+  "dashcards": [{
+    "row": 0,
+    "col": 0,
+    "size_x": 12,
+    "size_y": 6,
+    "card": {
+      "id": 100,
+      "name": "Orders by Status",
+      "display": "bar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-table": 15,
+          "breakout": [["field", {"base-type": "type/Text"}, "status"]],
+          "aggregation": [["count"]]
+        }]
+      },
+      "result_metadata": [
+        {"name": "status", "base_type": "type/Text"},
+        {"name": "count", "base_type": "type/Integer"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["status"],
+        "graph.metrics": ["count"]
+      }
+    }
+  }]
+}`))
+		case "/api/card/15":
+			fetchedPhysicalTableAsCard = true
+			http.Error(w, "physical tables are not cards", http.StatusInternalServerError)
+		case "/api/table/15/query_metadata":
+			fetchedTableMetadata = true
+			_, _ = w.Write([]byte(`{
+  "id": 15,
+  "name": "orders",
+  "schema": "public",
+  "fields": [
+    {"id": 201, "name": "status", "base_type": "type/Text"}
+  ]
+}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	output := filepath.Join(dir, "dashboard.yml")
+	app := NewApp(BuildInfo{Version: "test"})
+
+	if err := app.Run(context.Background(), []string{
+		"dac", "import", "metabase",
+		"--url", server.URL,
+		"--dashboard-id", "42",
+		"--api-key", "secret",
+		"--output", output,
+	}); err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+	if fetchedPhysicalTableAsCard {
+		t.Fatal("did not expect numeric source-table to be fetched as a card")
+	}
+	if !fetchedTableMetadata {
+		t.Fatal("expected physical source table metadata to be fetched")
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !strings.Contains(string(data), `FROM "public"."orders"`) || strings.Contains(string(data), "Unsupported Metabase card") {
+		t.Fatalf("expected hydrated physical table SQL, got:\n%s", string(data))
+	}
+}
+
+func TestImportMetabaseCommandWritesSemanticModelFiles(t *testing.T) {
+	var fetchedSourceCard bool
+	var fetchedMetric bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/dashboard/42":
+			_, _ = w.Write([]byte(`{
+  "name": "Semantic Model Import",
+  "dashcards": [{
+    "row": 0,
+    "col": 0,
+    "size_x": 12,
+    "size_y": 6,
+    "card": {
+      "id": 100,
+      "name": "Official Revenue by Region",
+      "display": "bar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 99,
+          "breakout": [["field", {"base-type": "type/Text"}, "region"]],
+          "aggregation": [["metric", 200]]
+        }]
+      }
+    }
+  }]
+}`))
+		case "/api/card/99":
+			fetchedSourceCard = true
+			_, _ = w.Write([]byte(`{
+  "id": 99,
+  "name": "Sales Model",
+  "type": "model",
+  "dataset_query": {
+    "database": 2,
+    "stages": [{
+      "native": "SELECT region, revenue FROM sales_summary"
+    }]
+  },
+  "result_metadata": [
+    {"name": "region", "base_type": "type/Text"},
+    {"name": "revenue", "base_type": "type/Decimal"}
+  ]
+}`))
+		case "/api/metric/200":
+			fetchedMetric = true
+			_, _ = w.Write([]byte(`{
+  "id": 200,
+  "name": "Official Revenue",
+  "type": "metric",
+  "dataset_query": {
+    "database": 2,
+    "stages": [{
+      "source-card": 99,
+      "aggregation": [["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+    }]
+  }
+}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	output := filepath.Join(dir, "dashboards", "semantic-model-import.yml")
+	app := NewApp(BuildInfo{Version: "test"})
+
+	stdout := captureStdout(t, func() {
+		if err := app.Run(context.Background(), []string{
+			"dac", "import", "metabase",
+			"--url", server.URL,
+			"--dashboard-id", "42",
+			"--api-key", "secret",
+			"--output", output,
+			"--connection", "warehouse",
+			"--semantic",
+		}); err != nil {
+			t.Fatalf("import failed: %v", err)
+		}
+	})
+	if !fetchedSourceCard || !fetchedMetric {
+		t.Fatalf("expected source model and metric to be fetched, source=%v metric=%v", fetchedSourceCard, fetchedMetric)
+	}
+	if !strings.Contains(stdout, "1 semantic model file") {
+		t.Fatalf("expected semantic import summary, got %q", stdout)
+	}
+
+	modelPath := filepath.Join(dir, "semantic", "sales_model.yml")
+	modelData, err := os.ReadFile(modelPath)
+	if err != nil {
+		t.Fatalf("read generated semantic model: %v", err)
+	}
+	if !strings.Contains(string(modelData), "name: sales_model") || !strings.Contains(string(modelData), "name: official_revenue") {
+		t.Fatalf("unexpected semantic model YAML:\n%s", string(modelData))
+	}
+
+	d, err := dashboard.LoadFile(output)
+	if err != nil {
+		t.Fatalf("load generated dashboard: %v", err)
+	}
+	if err := dashboard.Validate(d); err != nil {
+		t.Fatalf("generated semantic dashboard should validate: %v", err)
+	}
+}
+
+func TestImportMetabaseCommandRejectsSemanticStdout(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "metabase.json")
+	if err := os.WriteFile(input, []byte(metabaseImportFixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	app := NewApp(BuildInfo{Version: "test"})
+	err := app.Run(context.Background(), []string{
+		"dac", "import", "metabase",
+		"--input", input,
+		"--output", "-",
+		"--semantic",
+	})
+	if err == nil {
+		t.Fatal("expected semantic stdout import to fail")
+	}
+	if !strings.Contains(err.Error(), "--semantic cannot be used with --output -") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,7 @@ func NewApp(build BuildInfo) *cli.Command {
 			withTelemetry(lsCmd()),
 			withTelemetry(connectionsCmd()),
 			withTelemetry(skillsCmd()),
+			withTelemetry(importCmd()),
 			withTelemetry(exportCmd()),
 			withTelemetry(upgradeCmd(build)),
 			versionCmd(build),

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -54,6 +54,7 @@ export default defineConfig({
           { text: "query", link: "/commands/query" },
           { text: "connections", link: "/commands/connections" },
           { text: "skills", link: "/commands/skills" },
+          { text: "import", link: "/commands/import" },
           { text: "export", link: "/commands/export" },
           { text: "upgrade", link: "/commands/upgrade" },
         ],

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -1,0 +1,106 @@
+# dac import
+
+Import dashboards from external tools into DAC YAML.
+
+## dac import metabase
+
+Convert a Metabase dashboard into a DAC dashboard file.
+
+```shell
+dac import metabase [flags]
+```
+
+The importer supports two input paths:
+
+- A saved Metabase dashboard API response from `GET /api/dashboard/:id`
+- A live Metabase fetch using `--url`, `--dashboard-id`, and an API key or session token
+
+Native SQL questions are converted to DAC metric, chart, and table widgets. Supported Metabase query-builder/MBQL cards are compiled to SQL when they are built on a Metabase model or a physical database table with available table metadata. Unsupported MBQL cards are converted to explicit text placeholders by default. Use `--strict` to fail instead.
+
+For live imports, DAC also fetches Metabase source cards referenced by `source-card` / `card__ID` and table metadata referenced by physical `source-table` IDs so simple query-builder questions can be converted.
+
+Use `--semantic` to generate DAC semantic model files from explicit Metabase semantic artifacts. In this mode, DAC creates semantic dimensions from Metabase models and semantic metrics only from explicit Metabase metrics. Dashboard-card aggregations such as `sum(revenue)` are not promoted into DAC metrics automatically; those cards stay SQL-backed unless they reference a named Metabase metric. Use `--semantic-strict` to fail instead of falling back to SQL for model-backed cards that cannot be represented semantically.
+
+### Flags
+
+| Flag | Alias | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--input` | `-i` | string | | Path to a Metabase dashboard API response JSON/YAML file |
+| `--url` | | string | | Metabase base URL for live import |
+| `--dashboard-id` | | string | | Metabase dashboard ID for live import |
+| `--api-key` | | string | `METABASE_API_KEY` | Metabase API key |
+| `--session-token` | | string | `METABASE_SESSION_TOKEN` | Metabase session token |
+| `--connection` | `-c` | string | | DAC connection name to set on the generated dashboard |
+| `--output` | `-o` | string | `<dir>/<dashboard-slug>.yml` | Output YAML path; use `-` for stdout |
+| `--dir` | `-d` | string | `.` | Dashboard definitions directory used for the default output path |
+| `--force` | | boolean | `false` | Overwrite an existing output file |
+| `--strict` | | boolean | `false` | Fail on unsupported Metabase cards instead of creating placeholders |
+| `--semantic` | | boolean | `false` | Generate DAC semantic model files and convert eligible widgets to semantic references |
+| `--semantic-strict` | | boolean | `false` | Enable semantic import and fail when a model-backed card cannot be represented semantically |
+| `--semantic-dir` | | string | Sibling `semantic/` directory | Directory for generated semantic model files |
+
+### Examples
+
+Import from a saved API response:
+
+```shell
+curl \
+  -H "X-API-Key: $METABASE_API_KEY" \
+  https://metabase.example.com/api/dashboard/42 \
+  -o metabase-dashboard.json
+
+dac import metabase \
+  --input metabase-dashboard.json \
+  --output dashboards/sales.yml \
+  --connection warehouse
+```
+
+Import directly from Metabase:
+
+```shell
+dac import metabase \
+  --url https://metabase.example.com \
+  --dashboard-id 42 \
+  --api-key "$METABASE_API_KEY" \
+  --dir dashboards \
+  --connection warehouse
+```
+
+Import Metabase models and named metrics into DAC's semantic layer:
+
+```shell
+dac import metabase \
+  --url https://metabase.example.com \
+  --dashboard-id 42 \
+  --api-key "$METABASE_API_KEY" \
+  --output dashboards/sales.yml \
+  --connection warehouse \
+  --semantic
+```
+
+Write the converted YAML to stdout:
+
+```shell
+dac import metabase \
+  --input metabase-dashboard.json \
+  --output -
+```
+
+### Conversion Notes
+
+- Metabase dashboard cards are mapped onto DAC's 12-column grid.
+- Metabase card widths and positions are imported, but Metabase `size_y` card heights are not mapped to DAC row heights yet.
+- Scalar cards become metric widgets.
+- Line, bar, area, combo, pie, funnel, gauge, treemap, scatter, and waterfall cards map to DAC charts when native SQL is available.
+- Pivot and map cards are mapped to tables.
+- Metabase SQL template variables are rewritten as DAC filter references only when the dashboard has an explicit parameter mapping for that card. Unmapped template variables use their Metabase card defaults when available; optional `[[...]]` clauses without a mapped or default value are omitted.
+- Metabase optional SQL markers `[[...]]` are removed and reported as warnings so the generated SQL can be reviewed.
+- When Metabase omits result metadata, DAC infers simple widget fields and common metric/date types from SQL aliases.
+- Dashboard parameters become DAC filters when present in the Metabase dashboard response, even if they are not connected to every card.
+- Parameter mappings on model-backed cards are converted into SQL `WHERE` clauses for supported field targets only when the mapping is explicitly scoped to that Metabase card. Unscoped or stale mappings are ignored to match Metabase dashboard behavior.
+- Simple Metabase model-backed questions are converted into SQL over the model's source SQL when they use supported raw-field breakouts, filters, order fields, limits, and aggregations such as `sum`, `avg`, `min`, `max`, `count`, and `count-distinct`.
+- Simple Metabase physical-table questions are converted into SQL over the source table when table metadata is available and the card uses supported raw-field breakouts, aggregations, filters, order fields, and limits. Detail-row physical-table cards are imported as table widgets with a default `LIMIT 2000` when Metabase does not provide an explicit limit.
+- With `--semantic`, explicit Metabase models generate `semantic/*.yml` model files and their result metadata becomes DAC dimensions.
+- With `--semantic`, explicit Metabase metrics generate DAC semantic metrics, including supported metric filters. Unnamed dashboard aggregations are deliberately not inferred as semantic metrics because they do not carry durable metric names.
+- Model-backed cards that use explicit Metabase metric references can become semantic widgets with DAC dimensions, metrics, filters, and sort fields.
+- Model-backed cards that cannot be represented semantically fall back to SQL by default and emit warnings. `--semantic-strict` turns those fallbacks into errors.

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -25,5 +25,6 @@ These flags apply to all commands:
 | [`query`](/commands/query) | Run SQL against a connection |
 | [`connections`](/commands/connections) | Test database connections |
 | [`skills`](/commands/skills) | List and install DAC agent skills |
+| [`import`](/commands/import) | Import dashboards from external tools |
 | [`export`](/commands/export) | Export dashboards to external formats |
 | [`upgrade`](/commands/upgrade) | Upgrade the DAC CLI in place (alias: `update`) |

--- a/pkg/importer/metabase/convert.go
+++ b/pkg/importer/metabase/convert.go
@@ -1,0 +1,2304 @@
+package metabase
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/bruin-data/dac/pkg/dashboard"
+	"github.com/bruin-data/dac/schemas"
+	"gopkg.in/yaml.v3"
+)
+
+type Options struct {
+	Connection     string
+	Strict         bool
+	Semantic       bool
+	SemanticStrict bool
+}
+
+type Report struct {
+	WidgetCount         int
+	SQLWidgetCount      int
+	SemanticWidgetCount int
+	SemanticModelCount  int
+	PlaceholderCount    int
+	Warnings            []string
+}
+
+type positionedWidget struct {
+	w      dashboard.Widget
+	row    int
+	col    int
+	sizeX  int
+	source string
+}
+
+type columnInfo struct {
+	Name string
+	Type string
+}
+
+type metabaseTableInfo struct {
+	ID         string
+	Name       string
+	Schema     string
+	Expression string
+	FieldNames map[string]string
+	Columns    []columnInfo
+}
+
+type sqlTemplateVariable struct {
+	FilterName string
+	UseFilter  bool
+	Quote      bool
+	Default    any
+	HasDefault bool
+}
+
+type conversionContext struct {
+	filterNames     map[string]string
+	filters         map[string]dashboard.Filter
+	modelSQL        map[string]string
+	tables          map[string]*metabaseTableInfo
+	semantic        bool
+	semanticStrict  bool
+	semanticModels  map[string]*semanticModelInfo
+	semanticMetrics map[string]semanticMetricInfo
+}
+
+// Convert converts a Metabase dashboard API response or serialized dashboard
+// document into a DAC dashboard. Native SQL questions are converted to data
+// widgets. Supported query-builder/MBQL cards are compiled to SQL; unsupported
+// cards are represented as text placeholders unless Strict is set.
+func Convert(data []byte, opts Options) (*dashboard.Dashboard, Report, error) {
+	project, report, err := ConvertProject(data, opts)
+	if err != nil {
+		return nil, report, err
+	}
+	return project.Dashboard, report, nil
+}
+
+// ConvertProject converts a Metabase dashboard and returns any generated DAC
+// semantic model files alongside the dashboard.
+func ConvertProject(data []byte, opts Options) (*Project, Report, error) {
+	root, err := parseInput(data)
+	if err != nil {
+		return nil, Report{}, err
+	}
+
+	dashboardRoot := unwrapDashboard(root)
+	name := firstString(dashboardRoot, "name", "display_name", "display-name", "title")
+	if name == "" {
+		name = "Imported Metabase Dashboard"
+	}
+
+	report := Report{}
+	dac := &dashboard.Dashboard{
+		Schema:      schemas.DashboardV1ID,
+		Name:        name,
+		Description: firstString(dashboardRoot, "description"),
+		Connection:  opts.Connection,
+	}
+	project := &Project{Dashboard: dac}
+
+	semanticEnabled := opts.Semantic || opts.SemanticStrict
+	modelSQL := collectModelSQL(root, dashboardRoot)
+	tables := collectMetabaseTables(root, dashboardRoot)
+	var inventory semanticInventory
+	if semanticEnabled {
+		inventory = collectSemanticInventory(root, dashboardRoot, modelSQL)
+		project.SemanticModels = inventory.Files
+		report.SemanticModelCount = len(project.SemanticModels)
+		report.Warnings = append(report.Warnings, inventory.Warnings...)
+	}
+	ctx := conversionContext{
+		filterNames:     map[string]string{},
+		filters:         map[string]dashboard.Filter{},
+		modelSQL:        modelSQL,
+		tables:          tables,
+		semantic:        semanticEnabled,
+		semanticStrict:  opts.SemanticStrict,
+		semanticModels:  inventory.Models,
+		semanticMetrics: inventory.Metrics,
+	}
+	seenFilters := map[string]bool{}
+	for _, filter := range convertDashboardFilters(dashboardRoot) {
+		dac.Filters = append(dac.Filters, filter)
+		ctx.filters[filter.Name] = filter
+		seenFilters[filter.Name] = true
+		registerFilterAliases(ctx.filterNames, filter.Name, filter.Name)
+	}
+	for _, param := range mapList(dashboardRoot, "parameters", "params") {
+		filterName := normalizeName(firstString(param, "slug", "name", "id"))
+		registerFilterAliases(ctx.filterNames, filterName, firstString(param, "id"), firstString(param, "slug"), firstString(param, "name"))
+	}
+
+	cards := extractCards(dashboardRoot)
+	if len(cards) == 0 {
+		return nil, report, fmt.Errorf("no Metabase dashboard cards found")
+	}
+
+	positioned := make([]positionedWidget, 0, len(cards))
+	for i, cardRoot := range cards {
+		w, warnings, tagFilters, convertedSQL, convertedSemantic, placeholder, err := convertCard(cardRoot, i+1, ctx, opts)
+		if err != nil {
+			return nil, report, err
+		}
+		for _, filter := range tagFilters {
+			if seenFilters[filter.Name] {
+				continue
+			}
+			dac.Filters = append(dac.Filters, filter)
+			ctx.filters[filter.Name] = filter
+			seenFilters[filter.Name] = true
+		}
+		report.Warnings = append(report.Warnings, warnings...)
+		if convertedSQL {
+			report.SQLWidgetCount++
+		}
+		if convertedSemantic {
+			report.SemanticWidgetCount++
+		}
+		if placeholder {
+			report.PlaceholderCount++
+		}
+		positioned = append(positioned, positionedWidget{
+			w:      w,
+			row:    intField(cardRoot, 0, "row", "y"),
+			col:    intField(cardRoot, 0, "col", "x"),
+			sizeX:  intField(cardRoot, defaultWidthForWidget(w), "size_x", "size-x", "width", "w"),
+			source: cardName(cardRoot, i+1),
+		})
+	}
+
+	dac.Rows = layoutRows(positioned)
+	report.WidgetCount = len(positioned)
+	attachSemanticModels(dac, project.SemanticModels)
+	if err := dashboard.Validate(dac); err != nil {
+		return nil, report, fmt.Errorf("generated dashboard failed validation: %w", err)
+	}
+	return project, report, nil
+}
+
+func parseInput(data []byte) (map[string]any, error) {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err == nil {
+		root, ok := normalizeValue(raw).(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("Metabase input must be an object")
+		}
+		return root, nil
+	}
+
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing Metabase input as JSON or YAML: %w", err)
+	}
+	root, ok := normalizeValue(raw).(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("Metabase input must be an object")
+	}
+	return root, nil
+}
+
+func normalizeValue(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, v := range x {
+			out[k] = normalizeValue(v)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(x))
+		for k, v := range x {
+			out[fmt.Sprint(k)] = normalizeValue(v)
+		}
+		return out
+	case []any:
+		for i := range x {
+			x[i] = normalizeValue(x[i])
+		}
+		return x
+	default:
+		return v
+	}
+}
+
+func unwrapDashboard(root map[string]any) map[string]any {
+	for _, key := range []string{"dashboard", "data"} {
+		if child, ok := mapField(root, key); ok && looksLikeDashboard(child) {
+			return child
+		}
+	}
+	return root
+}
+
+func looksLikeDashboard(m map[string]any) bool {
+	if firstString(m, "name", "display_name", "display-name", "title") == "" {
+		return false
+	}
+	return len(extractCards(m)) > 0
+}
+
+func extractCards(root map[string]any) []map[string]any {
+	for _, key := range []string{"dashcards", "ordered_cards", "ordered-cards", "cards"} {
+		if list := mapList(root, key); len(list) > 0 {
+			return list
+		}
+	}
+	return nil
+}
+
+func convertDashboardFilters(root map[string]any) []dashboard.Filter {
+	params := mapList(root, "parameters", "params")
+	seen := map[string]bool{}
+	var filters []dashboard.Filter
+	for _, param := range params {
+		name := normalizeName(firstString(param, "slug", "name", "id"))
+		if name == "" || seen[name] {
+			continue
+		}
+		filter := dashboard.Filter{
+			Name:    name,
+			Type:    dacFilterType(firstString(param, "type", "section_id", "section-id")),
+			Default: normalizeFilterDefault(firstValue(param, "default", "default_value", "default-value"), firstString(param, "type")),
+		}
+		if values := extractStaticFilterValues(param); len(values) > 0 {
+			filter.Options = &dashboard.FilterOptions{Values: values}
+		}
+		filters = append(filters, filter)
+		seen[name] = true
+	}
+	return filters
+}
+
+func registerFilterAliases(aliases map[string]string, dacName string, rawNames ...string) {
+	if aliases == nil {
+		return
+	}
+	if dacName == "" {
+		return
+	}
+	for _, raw := range rawNames {
+		if raw == "" {
+			continue
+		}
+		aliases[raw] = dacName
+		aliases[normalizeName(raw)] = dacName
+	}
+}
+
+func mappedFilterName(aliases map[string]string, rawNames ...string) string {
+	for _, raw := range rawNames {
+		if raw == "" {
+			continue
+		}
+		if aliases != nil {
+			if mapped := aliases[raw]; mapped != "" {
+				return mapped
+			}
+			if mapped := aliases[normalizeName(raw)]; mapped != "" {
+				return mapped
+			}
+		}
+	}
+	return ""
+}
+
+func registerTemplateVariableAlias(aliases map[string]sqlTemplateVariable, raw string, info sqlTemplateVariable) {
+	if aliases == nil || raw == "" {
+		return
+	}
+	aliases[raw] = info
+	aliases[normalizeName(raw)] = info
+}
+
+func dashboardTemplateTagFilterAliases(cardRoot map[string]any, ctx conversionContext) map[string]string {
+	aliases := map[string]string{}
+	for _, mapping := range mapList(cardRoot, "parameter_mappings", "parameter-mappings") {
+		if !parameterMappingAppliesToCard(mapping, cardRoot) {
+			continue
+		}
+		filter, ok := filterForParameterMapping(mapping, ctx)
+		if !ok {
+			continue
+		}
+		tagName := targetTemplateTagName(mapping["target"])
+		if tagName == "" {
+			tagName = targetFieldName(mapping["target"])
+		}
+		if tagName == "" {
+			continue
+		}
+		registerFilterAliases(aliases, filter.Name, tagName)
+	}
+	return aliases
+}
+
+func convertCard(cardRoot map[string]any, index int, ctx conversionContext, opts Options) (dashboard.Widget, []string, []dashboard.Filter, bool, bool, bool, error) {
+	card, _ := mapField(cardRoot, "card", "question")
+	if card == nil {
+		card = cardRoot
+	}
+	if virtual, ok := mapField(cardRoot, "virtual_card", "virtual-card"); ok {
+		card = virtual
+	}
+	if virtual, ok := mapField(mapFieldOrEmpty(cardRoot, "visualization_settings", "visualization-settings"), "virtual_card", "virtual-card"); ok {
+		card = virtual
+	}
+
+	name := cardName(cardRoot, index)
+	display := strings.ToLower(firstString(card, "display", "display_type", "display-type", "type"))
+	settings := mergeMaps(
+		mapFieldOrEmpty(card, "visualization_settings", "visualization-settings"),
+		mapFieldOrEmpty(cardRoot, "visualization_settings", "visualization-settings"),
+	)
+
+	if text := textContent(cardRoot, card, settings); text != "" && !hasNativeSQL(card) {
+		return dashboard.Widget{
+			Name:    name,
+			Type:    dashboard.WidgetTypeText,
+			Content: text,
+			Col:     12,
+		}, nil, nil, false, false, false, nil
+	}
+
+	sql, templateWarnings := nativeSQL(card, dashboardTemplateTagFilterAliases(cardRoot, ctx))
+	if ctx.semantic && sql == "" {
+		widget, warnings, converted, attempted, reason, err := semanticWidgetForCard(cardRoot, card, name, display, settings, ctx)
+		if err != nil {
+			return dashboard.Widget{}, nil, nil, false, false, false, err
+		}
+		if converted {
+			for i, warning := range warnings {
+				warnings[i] = fmt.Sprintf("%s: %s", name, warning)
+			}
+			return widget, warnings, nil, false, true, false, nil
+		}
+		if attempted {
+			if ctx.semanticStrict {
+				return dashboard.Widget{}, nil, nil, false, false, false, fmt.Errorf("%s: cannot convert to semantic widget: %s", name, reason)
+			}
+			if reason != "" {
+				templateWarnings = append(templateWarnings, "semantic import skipped: "+reason)
+			}
+		}
+	}
+	if sql == "" {
+		var modelWarnings []string
+		sql, modelWarnings = modelBackedSQL(card, cardRoot, ctx)
+		templateWarnings = append(templateWarnings, modelWarnings...)
+	}
+	if sql == "" {
+		var tableWarnings []string
+		var displayOverride string
+		sql, tableWarnings, displayOverride = physicalTableBackedSQL(card, cardRoot, ctx)
+		templateWarnings = append(templateWarnings, tableWarnings...)
+		if displayOverride != "" {
+			display = displayOverride
+		}
+	}
+	if sql == "" {
+		reason := "Metabase query-builder/MBQL cards cannot be converted because DAC needs native SQL"
+		if display == "" {
+			reason = "Metabase card does not contain a native SQL query"
+		}
+		if len(templateWarnings) > 0 {
+			reason = templateWarnings[len(templateWarnings)-1]
+		}
+		if opts.Strict {
+			return dashboard.Widget{}, nil, nil, false, false, false, fmt.Errorf("%s: %s", name, reason)
+		}
+		content := fmt.Sprintf("**Unsupported Metabase card**\n\n%s.\n\nOriginal card: `%s`", reason, name)
+		warnings := make([]string, 0, len(templateWarnings)+1)
+		for _, warning := range templateWarnings {
+			warnings = append(warnings, fmt.Sprintf("%s: %s", name, warning))
+		}
+		if len(templateWarnings) == 0 || templateWarnings[len(templateWarnings)-1] != reason {
+			warnings = append(warnings, fmt.Sprintf("%s: %s", name, reason))
+		}
+		return dashboard.Widget{
+			Name:    name,
+			Type:    dashboard.WidgetTypeText,
+			Content: content,
+			Col:     12,
+		}, warnings, nil, false, false, true, nil
+	}
+
+	columns := resultColumns(card)
+	widget, warnings := widgetForDisplay(name, display, sql, settings, columns)
+	warnings = append(warnings, templateWarnings...)
+	for i, warning := range warnings {
+		warnings[i] = fmt.Sprintf("%s: %s", name, warning)
+	}
+	return widget, warnings, nil, true, false, false, nil
+}
+
+func hasNativeSQL(card map[string]any) bool {
+	sql, _ := nativeSQL(card, nil)
+	return sql != ""
+}
+
+func nativeSQL(card map[string]any, filterNames map[string]string) (string, []string) {
+	dataset, ok := mapField(card, "dataset_query", "dataset-query")
+	if !ok {
+		return "", nil
+	}
+	query, templateTags := nativeQueryAndTemplateTags(dataset)
+	if query == "" {
+		return "", nil
+	}
+
+	var warnings []string
+	variables := map[string]sqlTemplateVariable{}
+	for tagName, raw := range templateTags {
+		tag, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		dacName := normalizeName(firstString(tag, "name", "display_name", "display-name"))
+		if dacName == "" {
+			dacName = normalizeName(tagName)
+		}
+		tagType := firstString(tag, "type", "widget_type", "widget-type")
+		filterName := mappedFilterName(filterNames, tagName, dacName, firstString(tag, "name"), firstString(tag, "display_name", "display-name"))
+		defaultValue, hasDefault := firstPresentValue(tag, "default", "default_value", "default-value")
+		info := sqlTemplateVariable{
+			FilterName: filterName,
+			UseFilter:  filterName != "",
+			Quote:      filterTypeNeedsQuotes(dacFilterType(tagType)),
+			Default:    defaultValue,
+			HasDefault: hasDefault && defaultValue != nil,
+		}
+		for _, alias := range []string{tagName, dacName, firstString(tag, "name"), firstString(tag, "display_name", "display-name")} {
+			registerTemplateVariableAlias(variables, alias, info)
+		}
+		if strings.EqualFold(tagType, "dimension") {
+			warnings = append(warnings, fmt.Sprintf("field filter %q was converted to a plain DAC filter reference; review the WHERE clause", tagName))
+		}
+	}
+
+	converted, optionalCount, unresolved := convertSQLTemplate(query, variables)
+	if optionalCount > 0 {
+		warnings = append(warnings, "Metabase optional SQL clause markers [[...]] were removed; review empty-filter behavior")
+	}
+	for _, name := range unresolved {
+		warnings = append(warnings, fmt.Sprintf("native SQL variable %q is not mapped to a dashboard filter and has no default; review the generated SQL", name))
+	}
+	return converted, warnings
+}
+
+func nativeQueryAndTemplateTags(dataset map[string]any) (string, map[string]any) {
+	if native, ok := mapField(dataset, "native"); ok {
+		return firstString(native, "query"), mapFieldOrEmpty(native, "template_tags", "template-tags")
+	}
+
+	for _, stage := range mapList(dataset, "stages") {
+		var query string
+		switch raw := stage["native"].(type) {
+		case string:
+			query = raw
+		case map[string]any:
+			query = firstString(raw, "query")
+		}
+		if query == "" {
+			continue
+		}
+		tags := mapFieldOrEmpty(stage, "template_tags", "template-tags")
+		if len(tags) == 0 {
+			tags = mapFieldOrEmpty(stage, "template-tags")
+		}
+		return query, tags
+	}
+	return "", nil
+}
+
+func collectModelSQL(root, dashboardRoot map[string]any) map[string]string {
+	models := map[string]string{}
+	addCard := func(card map[string]any) {
+		id := firstString(card, "id")
+		if id == "" {
+			return
+		}
+		if firstString(card, "type") != "model" && firstString(card, "query_type", "query-type") != "native" {
+			return
+		}
+		sql, _ := nativeSQL(card, nil)
+		if sql == "" {
+			return
+		}
+		models[id] = sql
+	}
+
+	for _, source := range []map[string]any{root, dashboardRoot} {
+		for _, key := range []string{"x-dac-metabase-source-cards", "source_cards", "source-cards", "models"} {
+			if sourceCards, ok := mapField(source, key); ok {
+				for _, raw := range sourceCards {
+					if card, ok := raw.(map[string]any); ok {
+						addCard(card)
+					}
+				}
+			}
+			for _, card := range mapList(source, key) {
+				addCard(card)
+			}
+		}
+	}
+	for _, dashcard := range extractCards(dashboardRoot) {
+		if card, ok := mapField(dashcard, "card", "question"); ok {
+			addCard(card)
+		}
+	}
+	return models
+}
+
+func collectMetabaseTables(root, dashboardRoot map[string]any) map[string]*metabaseTableInfo {
+	tables := map[string]*metabaseTableInfo{}
+	for _, source := range []map[string]any{root, dashboardRoot} {
+		for _, key := range []string{"x-dac-metabase-tables", "metabase_tables", "metabase-tables"} {
+			if rawTables, ok := mapField(source, key); ok {
+				ids := make([]string, 0, len(rawTables))
+				for id := range rawTables {
+					ids = append(ids, id)
+				}
+				sort.Strings(ids)
+				for _, id := range ids {
+					if table, ok := rawTables[id].(map[string]any); ok {
+						if info := parseMetabaseTable(table); info != nil {
+							tables[info.ID] = info
+						}
+					}
+				}
+			}
+			for _, table := range mapList(source, key) {
+				if info := parseMetabaseTable(table); info != nil {
+					tables[info.ID] = info
+				}
+			}
+		}
+	}
+	return tables
+}
+
+func parseMetabaseTable(table map[string]any) *metabaseTableInfo {
+	id := firstString(table, "id")
+	name := firstString(table, "name")
+	if id == "" || name == "" {
+		return nil
+	}
+	info := &metabaseTableInfo{
+		ID:         id,
+		Name:       name,
+		Schema:     firstString(table, "schema"),
+		FieldNames: map[string]string{},
+	}
+	if info.Schema != "" {
+		info.Expression = quoteIdent(info.Schema) + "." + quoteIdent(info.Name)
+	} else {
+		info.Expression = quoteIdent(info.Name)
+	}
+	for _, field := range mapList(table, "fields") {
+		fieldName := firstString(field, "name")
+		if fieldName == "" {
+			continue
+		}
+		for _, alias := range []string{
+			firstString(field, "id"),
+			fieldName,
+			firstString(field, "display_name", "display-name"),
+			normalizeName(firstString(field, "display_name", "display-name")),
+		} {
+			if alias != "" {
+				info.FieldNames[alias] = fieldName
+			}
+		}
+		info.Columns = append(info.Columns, columnInfo{
+			Name: fieldName,
+			Type: strings.ToLower(firstString(field, "base_type", "base-type", "effective_type", "effective-type", "semantic_type", "semantic-type")),
+		})
+	}
+	return info
+}
+
+func modelBackedSQL(card, cardRoot map[string]any, ctx conversionContext) (string, []string) {
+	dataset, ok := mapField(card, "dataset_query", "dataset-query")
+	if !ok {
+		return "", nil
+	}
+	stages := mapList(dataset, "stages")
+	if len(stages) == 0 {
+		if query, ok := mapField(dataset, "query"); ok {
+			stages = []map[string]any{query}
+		}
+	}
+	if len(stages) == 0 {
+		return "", nil
+	}
+
+	stage := stages[0]
+	sourceID := sourceCardID(stage)
+	if sourceID == "" {
+		sourceID = sourceCardID(dataset)
+	}
+	baseSQL := ctx.modelSQL[sourceID]
+	if baseSQL == "" {
+		return "", nil
+	}
+
+	breakouts, ok := fieldList(stage["breakout"])
+	if !ok {
+		return "", []string{"unsupported MBQL breakout"}
+	}
+	aggregations, ok := aggregationList(stage["aggregation"], resultColumns(card), len(breakouts))
+	if !ok {
+		return "", []string{"unsupported MBQL aggregation"}
+	}
+	filterClauses, ok := mbqlFilterClauses(stage["filter"])
+	if !ok {
+		return "", []string{"unsupported MBQL filter"}
+	}
+	clauses := append(filterClauses, dashboardFilterClauses(cardRoot, ctx)...)
+	if len(breakouts) == 0 && len(aggregations) == 0 {
+		orderBy, ok := mbqlOrderByClauses(stage, nil, nil, fieldRefName)
+		if !ok {
+			return "", []string{"unsupported MBQL order-by"}
+		}
+		return selectFromModel(baseSQL, []string{"*"}, clauses, nil, orderBy, intField(stage, 0, "limit")), nil
+	}
+
+	selects := make([]string, 0, len(breakouts)+len(aggregations))
+	groupBy := make([]string, 0, len(breakouts))
+	for i, field := range breakouts {
+		selects = append(selects, fmt.Sprintf("%s AS %s", quoteIdent(field), quoteIdent(field)))
+		groupBy = append(groupBy, strconv.Itoa(i+1))
+	}
+	for _, agg := range aggregations {
+		selects = append(selects, fmt.Sprintf("%s AS %s", agg.Expression, quoteIdent(agg.Alias)))
+	}
+	if len(selects) == 0 {
+		selects = append(selects, "*")
+	}
+
+	display := strings.ToLower(firstString(card, "display", "display_type", "display-type", "type"))
+	orderBy, ok := mbqlOrderByClauses(stage, breakouts, aggregations, fieldRefName)
+	if !ok {
+		return "", []string{"unsupported MBQL order-by"}
+	}
+	if len(orderBy) == 0 && len(breakouts) > 0 && chronologicalDisplay(display) {
+		orderBy = append(orderBy, quoteIdent(breakouts[0])+" ASC")
+	} else if len(orderBy) == 0 && len(aggregations) > 0 {
+		orderBy = append(orderBy, quoteIdent(aggregations[0].Alias)+" DESC")
+	}
+	return selectFromModel(baseSQL, selects, clauses, groupBy, orderBy, intField(stage, 0, "limit")), nil
+}
+
+func physicalTableBackedSQL(card, cardRoot map[string]any, ctx conversionContext) (string, []string, string) {
+	dataset, ok := mapField(card, "dataset_query", "dataset-query")
+	if !ok {
+		return "", nil, ""
+	}
+	stages := mapList(dataset, "stages")
+	if len(stages) == 0 {
+		if query, ok := mapField(dataset, "query"); ok {
+			stages = []map[string]any{query}
+		}
+	}
+	if len(stages) == 0 {
+		return "", nil, ""
+	}
+
+	stage := stages[0]
+	tableID := sourceTableID(stage)
+	if tableID == "" {
+		tableID = sourceTableID(dataset)
+	}
+	if tableID == "" {
+		return "", nil, ""
+	}
+	tableInfo := ctx.tables[tableID]
+	if tableInfo == nil {
+		return "", nil, ""
+	}
+
+	columns := resultColumns(card)
+	if len(columns) == 0 {
+		columns = tableInfo.Columns
+	}
+	resolver := tableInfo.resolveFieldRef
+	breakouts, ok := fieldListWithResolver(stage["breakout"], resolver)
+	if !ok {
+		return "", []string{"unsupported MBQL breakout"}, ""
+	}
+	aggregations, ok := aggregationListWithResolver(stage["aggregation"], columns, len(breakouts), resolver)
+	if !ok {
+		return "", []string{"unsupported MBQL aggregation"}, ""
+	}
+	filterClauses, ok := mbqlFilterClausesWithResolver(stage["filter"], resolver)
+	if !ok {
+		return "", []string{"unsupported MBQL filter"}, ""
+	}
+	clauses := append(filterClauses, dashboardFilterClausesWithResolver(cardRoot, ctx, resolver)...)
+
+	limit := intField(stage, 0, "limit")
+	if len(breakouts) == 0 && len(aggregations) == 0 {
+		if limit == 0 {
+			limit = 2000
+		}
+		orderBy, ok := mbqlOrderByClauses(stage, nil, nil, resolver)
+		if !ok {
+			return "", []string{"unsupported MBQL order-by"}, ""
+		}
+		return selectFromTable(tableInfo.Expression, []string{"*"}, clauses, nil, orderBy, limit), nil, "table"
+	}
+
+	selects := make([]string, 0, len(breakouts)+len(aggregations))
+	groupBy := make([]string, 0, len(breakouts))
+	for i, field := range breakouts {
+		selects = append(selects, fmt.Sprintf("%s AS %s", quoteIdent(field), quoteIdent(field)))
+		groupBy = append(groupBy, strconv.Itoa(i+1))
+	}
+	for _, agg := range aggregations {
+		selects = append(selects, fmt.Sprintf("%s AS %s", agg.Expression, quoteIdent(agg.Alias)))
+	}
+	if len(selects) == 0 {
+		return "", nil, ""
+	}
+
+	display := strings.ToLower(firstString(card, "display", "display_type", "display-type", "type"))
+	orderBy, ok := mbqlOrderByClauses(stage, breakouts, aggregations, resolver)
+	if !ok {
+		return "", []string{"unsupported MBQL order-by"}, ""
+	}
+	if len(orderBy) == 0 {
+		if len(breakouts) > 0 && chronologicalDisplay(display) {
+			orderBy = append(orderBy, quoteIdent(breakouts[0])+" ASC")
+		} else if len(aggregations) > 0 {
+			orderBy = append(orderBy, quoteIdent(aggregations[0].Alias)+" DESC")
+		}
+	}
+	return selectFromTable(tableInfo.Expression, selects, clauses, groupBy, orderBy, limit), nil, ""
+}
+
+func chronologicalDisplay(display string) bool {
+	switch display {
+	case "line", "area", "combo":
+		return true
+	default:
+		return false
+	}
+}
+
+type aggregation struct {
+	Expression string
+	Alias      string
+}
+
+func aggregationList(raw any, columns []columnInfo, breakoutCount int) ([]aggregation, bool) {
+	return aggregationListWithResolver(raw, columns, breakoutCount, fieldRefName)
+}
+
+func aggregationListWithResolver(raw any, columns []columnInfo, breakoutCount int, resolveField func(any) string) ([]aggregation, bool) {
+	if raw == nil {
+		return nil, true
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+	out := make([]aggregation, 0, len(list))
+	for i, item := range list {
+		parts, ok := item.([]any)
+		if !ok || len(parts) == 0 {
+			return nil, false
+		}
+		fn, _ := parts[0].(string)
+		field := ""
+		for _, part := range parts[1:] {
+			if name := resolveField(part); name != "" {
+				field = name
+				break
+			}
+		}
+		expr := ""
+		switch fn {
+		case "count":
+			if field == "" {
+				expr = "COUNT(*)"
+			} else {
+				expr = "COUNT(" + quoteIdent(field) + ")"
+			}
+		case "sum", "avg", "min", "max":
+			if field == "" {
+				return nil, false
+			}
+			expr = strings.ToUpper(fn) + "(" + quoteIdent(field) + ")"
+		case "distinct", "count-distinct":
+			if field == "" {
+				return nil, false
+			}
+			expr = "COUNT(DISTINCT " + quoteIdent(field) + ")"
+		default:
+			return nil, false
+		}
+		alias := ""
+		if breakoutCount+i < len(columns) {
+			alias = columns[breakoutCount+i].Name
+		}
+		if alias == "" {
+			alias = fn
+			if field != "" && fn != "count" {
+				alias += "_" + field
+			}
+		}
+		out = append(out, aggregation{Expression: expr, Alias: alias})
+	}
+	return out, true
+}
+
+func selectFromTable(tableExpression string, selects, whereClauses, groupBy, orderBy []string, limit int) string {
+	var b strings.Builder
+	b.WriteString("SELECT ")
+	b.WriteString(strings.Join(selects, ", "))
+	b.WriteString("\nFROM ")
+	b.WriteString(tableExpression)
+	b.WriteString("\nWHERE 1=1")
+	for _, clause := range whereClauses {
+		if strings.TrimSpace(clause) == "" {
+			continue
+		}
+		b.WriteString("\n  AND ")
+		b.WriteString(clause)
+	}
+	if len(groupBy) > 0 {
+		b.WriteString("\nGROUP BY ")
+		b.WriteString(strings.Join(groupBy, ", "))
+	}
+	if len(orderBy) > 0 {
+		b.WriteString("\nORDER BY ")
+		b.WriteString(strings.Join(orderBy, ", "))
+	}
+	if limit > 0 {
+		b.WriteString("\nLIMIT ")
+		b.WriteString(strconv.Itoa(limit))
+	}
+	return b.String()
+}
+
+func selectFromModel(baseSQL string, selects, whereClauses, groupBy, orderBy []string, limit int) string {
+	var b strings.Builder
+	b.WriteString("WITH source AS (\n")
+	b.WriteString(trimSQLTerminator(baseSQL))
+	b.WriteString("\n)\nSELECT ")
+	b.WriteString(strings.Join(selects, ", "))
+	b.WriteString("\nFROM source\nWHERE 1=1")
+	for _, clause := range whereClauses {
+		if strings.TrimSpace(clause) == "" {
+			continue
+		}
+		b.WriteString("\n  AND ")
+		b.WriteString(clause)
+	}
+	if len(groupBy) > 0 {
+		b.WriteString("\nGROUP BY ")
+		b.WriteString(strings.Join(groupBy, ", "))
+	}
+	if len(orderBy) > 0 {
+		b.WriteString("\nORDER BY ")
+		b.WriteString(strings.Join(orderBy, ", "))
+	}
+	if limit > 0 {
+		b.WriteString("\nLIMIT ")
+		b.WriteString(strconv.Itoa(limit))
+	}
+	return b.String()
+}
+
+func trimSQLTerminator(sql string) string {
+	sql = strings.TrimSpace(sql)
+	for strings.HasSuffix(sql, ";") {
+		sql = strings.TrimSpace(strings.TrimSuffix(sql, ";"))
+	}
+	return sql
+}
+
+func sourceTableID(m map[string]any) string {
+	for _, key := range []string{"source-table", "source_table"} {
+		switch v := m[key].(type) {
+		case float64:
+			return strconv.FormatInt(int64(v), 10)
+		case int:
+			return strconv.Itoa(v)
+		case json.Number:
+			return v.String()
+		case string:
+			if strings.HasPrefix(v, "card__") {
+				continue
+			}
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func sourceCardID(m map[string]any) string {
+	for _, key := range []string{"source-card", "source_card"} {
+		switch v := m[key].(type) {
+		case float64:
+			return strconv.FormatInt(int64(v), 10)
+		case int:
+			return strconv.Itoa(v)
+		case string:
+			return strings.TrimPrefix(v, "card__")
+		}
+	}
+	if sourceTable := firstString(m, "source-table", "source_table"); strings.HasPrefix(sourceTable, "card__") {
+		return strings.TrimPrefix(sourceTable, "card__")
+	}
+	return ""
+}
+
+func dashboardFilterClauses(cardRoot map[string]any, ctx conversionContext) []string {
+	return dashboardFilterClausesWithResolver(cardRoot, ctx, fieldRefName)
+}
+
+func dashboardFilterClausesWithResolver(cardRoot map[string]any, ctx conversionContext, resolveField func(any) string) []string {
+	var clauses []string
+	for _, mapping := range mapList(cardRoot, "parameter_mappings", "parameter-mappings") {
+		if !parameterMappingAppliesToCard(mapping, cardRoot) {
+			continue
+		}
+		filter, ok := filterForParameterMapping(mapping, ctx)
+		if !ok {
+			continue
+		}
+		field := targetFieldNameWithResolver(mapping["target"], resolveField)
+		if field == "" {
+			continue
+		}
+		if clause := filterClause(field, filter); clause != "" {
+			clauses = append(clauses, clause)
+		}
+	}
+	return clauses
+}
+
+func filterForParameterMapping(mapping map[string]any, ctx conversionContext) (dashboard.Filter, bool) {
+	paramID := firstString(mapping, "parameter_id", "parameter-id")
+	filterName := mappedFilterName(ctx.filterNames, paramID)
+	if filterName == "" {
+		filterName = normalizeName(paramID)
+	}
+	filter, ok := ctx.filters[filterName]
+	return filter, ok
+}
+
+func parameterMappingAppliesToCard(mapping, cardRoot map[string]any) bool {
+	if id := metabaseID(firstValue(mapping, "card_id", "card-id")); id != "" {
+		return id == currentCardID(cardRoot)
+	}
+	if id := metabaseID(firstValue(mapping, "dashcard_id", "dashcard-id", "dashboard_card_id", "dashboard-card-id")); id != "" {
+		return id == currentDashcardID(cardRoot)
+	}
+	return false
+}
+
+func currentCardID(cardRoot map[string]any) string {
+	if id := metabaseID(firstValue(cardRoot, "card_id", "card-id")); id != "" {
+		return id
+	}
+	for _, key := range []string{"card", "question", "virtual_card", "virtual-card"} {
+		if child, ok := mapField(cardRoot, key); ok {
+			if id := metabaseID(firstValue(child, "id")); id != "" {
+				return id
+			}
+		}
+	}
+	if settings, ok := mapField(cardRoot, "visualization_settings", "visualization-settings"); ok {
+		if virtual, ok := mapField(settings, "virtual_card", "virtual-card"); ok {
+			if id := metabaseID(firstValue(virtual, "id")); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+func currentDashcardID(cardRoot map[string]any) string {
+	return metabaseID(firstValue(cardRoot, "id"))
+}
+
+func metabaseID(v any) string {
+	return strings.TrimPrefix(metabaseScalarID(v), "card__")
+}
+
+func mbqlFilterClauses(raw any) ([]string, bool) {
+	return mbqlFilterClausesWithResolver(raw, fieldRefName)
+}
+
+func mbqlFilterClausesWithResolver(raw any, resolveField func(any) string) ([]string, bool) {
+	if raw == nil {
+		return nil, true
+	}
+	parts, ok := raw.([]any)
+	if !ok || len(parts) == 0 {
+		return nil, false
+	}
+	op, _ := parts[0].(string)
+	if op == "and" {
+		var clauses []string
+		for _, child := range parts[1:] {
+			childClauses, ok := mbqlFilterClausesWithResolver(child, resolveField)
+			if !ok {
+				return nil, false
+			}
+			clauses = append(clauses, childClauses...)
+		}
+		return clauses, true
+	}
+	if op == "is-null" || op == "not-null" {
+		if len(parts) < 2 {
+			return nil, false
+		}
+		field := resolveField(parts[1])
+		if field == "" {
+			return nil, false
+		}
+		if op == "is-null" {
+			return []string{quoteIdent(field) + " IS NULL"}, true
+		}
+		return []string{quoteIdent(field) + " IS NOT NULL"}, true
+	}
+	if len(parts) < 3 {
+		return nil, false
+	}
+	field := resolveField(parts[1])
+	if field == "" {
+		return nil, false
+	}
+	switch op {
+	case "=":
+		return []string{quoteIdent(field) + " = " + sqlLiteral(parts[2])}, true
+	case "!=":
+		return []string{quoteIdent(field) + " <> " + sqlLiteral(parts[2])}, true
+	case "<", ">", "<=", ">=":
+		return []string{quoteIdent(field) + " " + op + " " + sqlLiteral(parts[2])}, true
+	case "between":
+		if len(parts) < 4 {
+			return nil, false
+		}
+		return []string{quoteIdent(field) + " BETWEEN " + sqlLiteral(parts[2]) + " AND " + sqlLiteral(parts[3])}, true
+	default:
+		return nil, false
+	}
+}
+
+func filterClause(field string, filter dashboard.Filter) string {
+	name := filter.Name
+	ident := quoteIdent(field)
+	switch filter.Type {
+	case "date-range":
+		return fmt.Sprintf("%s >= '{{ filters.%s.start }}' AND %s <= '{{ filters.%s.end }}'", ident, name, ident, name)
+	case "date":
+		return fmt.Sprintf("%s = '{{ filters.%s }}'", ident, name)
+	case "number":
+		return fmt.Sprintf("%s = {{ filters.%s }}", ident, name)
+	case "select", "text":
+		if filter.Multiple {
+			return fmt.Sprintf("%s IN ('{{ filters.%s | join(\"','\") }}')", ident, name)
+		}
+		return fmt.Sprintf("%s = '{{ filters.%s }}'", ident, name)
+	default:
+		return ""
+	}
+}
+
+func fieldList(raw any) ([]string, bool) {
+	return fieldListWithResolver(raw, fieldRefName)
+}
+
+func fieldListWithResolver(raw any, resolveField func(any) string) ([]string, bool) {
+	if raw == nil {
+		return nil, true
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+	var fields []string
+	for _, item := range list {
+		if metabaseTemporalGranularity(item) != "" {
+			return nil, false
+		}
+		name := resolveField(item)
+		if name == "" {
+			return nil, false
+		}
+		fields = append(fields, name)
+	}
+	return fields, true
+}
+
+func targetFieldName(raw any) string {
+	return targetFieldNameWithResolver(raw, fieldRefName)
+}
+
+func targetFieldNameWithResolver(raw any, resolveField func(any) string) string {
+	parts, ok := raw.([]any)
+	if !ok || len(parts) == 0 {
+		return ""
+	}
+	kind, _ := parts[0].(string)
+	switch kind {
+	case "dimension":
+		for _, part := range parts[1:] {
+			if name := resolveField(part); name != "" {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+func targetTemplateTagName(raw any) string {
+	parts, ok := raw.([]any)
+	if !ok || len(parts) == 0 {
+		return ""
+	}
+	kind, _ := parts[0].(string)
+	if kind == "template-tag" {
+		if len(parts) < 2 {
+			return ""
+		}
+		return metabaseID(parts[1])
+	}
+	for _, part := range parts[1:] {
+		if name := targetTemplateTagName(part); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func fieldRefName(raw any) string {
+	parts, ok := raw.([]any)
+	if !ok || len(parts) == 0 {
+		return ""
+	}
+	kind, _ := parts[0].(string)
+	if kind != "field" {
+		return ""
+	}
+	for i := len(parts) - 1; i >= 1; i-- {
+		if s, ok := parts[i].(string); ok && s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func (t *metabaseTableInfo) resolveFieldRef(raw any) string {
+	if name := fieldRefName(raw); name != "" {
+		if mapped := t.FieldNames[name]; mapped != "" {
+			return mapped
+		}
+		return name
+	}
+	parts, ok := raw.([]any)
+	if !ok || len(parts) == 0 {
+		return ""
+	}
+	kind, _ := parts[0].(string)
+	if kind != "field" {
+		return ""
+	}
+	for _, part := range parts[1:] {
+		if id := metabaseScalarID(part); id != "" {
+			if mapped := t.FieldNames[id]; mapped != "" {
+				return mapped
+			}
+		}
+	}
+	return ""
+}
+
+func metabaseScalarID(v any) string {
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case float64:
+		return strconv.FormatInt(int64(x), 10)
+	case int:
+		return strconv.Itoa(x)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case json.Number:
+		return x.String()
+	default:
+		return ""
+	}
+}
+
+func mbqlOrderByClauses(stage map[string]any, breakouts []string, aggregations []aggregation, resolveField func(any) string) ([]string, bool) {
+	raw, present := firstPresentValue(stage, "order-by", "order_by")
+	if !present || raw == nil {
+		return nil, true
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+	var out []string
+	for _, item := range list {
+		parts, ok := item.([]any)
+		if !ok || len(parts) < 2 {
+			return nil, false
+		}
+		direction, _ := parts[0].(string)
+		direction = strings.ToUpper(direction)
+		if direction != "ASC" && direction != "DESC" {
+			return nil, false
+		}
+		name := mbqlOrderByName(parts[1], breakouts, aggregations, resolveField)
+		if name == "" {
+			return nil, false
+		}
+		out = append(out, quoteIdent(name)+" "+direction)
+	}
+	return out, true
+}
+
+func mbqlOrderByName(raw any, breakouts []string, aggregations []aggregation, resolveField func(any) string) string {
+	if name := resolveField(raw); name != "" {
+		return name
+	}
+	parts, ok := raw.([]any)
+	if !ok || len(parts) == 0 {
+		return ""
+	}
+	kind, _ := parts[0].(string)
+	switch kind {
+	case "aggregation":
+		if len(parts) < 2 {
+			return ""
+		}
+		idx, ok := intValue(parts[1])
+		if !ok || idx < 0 || idx >= len(aggregations) {
+			return ""
+		}
+		return aggregations[idx].Alias
+	case "breakout":
+		if len(parts) < 2 {
+			return ""
+		}
+		idx, ok := intValue(parts[1])
+		if !ok || idx < 0 || idx >= len(breakouts) {
+			return ""
+		}
+		return breakouts[idx]
+	default:
+		return ""
+	}
+}
+
+func intValue(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case float64:
+		return int(x), true
+	case json.Number:
+		i, err := x.Int64()
+		return int(i), err == nil
+	default:
+		return 0, false
+	}
+}
+
+func quoteIdent(name string) string {
+	if regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(name) {
+		return `"` + name + `"`
+	}
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+func sqlLiteral(v any) string {
+	switch x := v.(type) {
+	case string:
+		return "'" + strings.ReplaceAll(x, "'", "''") + "'"
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(x)
+	case bool:
+		if x {
+			return "TRUE"
+		}
+		return "FALSE"
+	default:
+		return "'" + strings.ReplaceAll(fmt.Sprint(x), "'", "''") + "'"
+	}
+}
+
+var metabaseVarPattern = regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
+var metabaseOptionalPattern = regexp.MustCompile(`(?s)\[\[(.*?)\]\]`)
+
+func convertSQLTemplate(sql string, variables map[string]sqlTemplateVariable) (string, int, []string) {
+	optionalCount := strings.Count(sql, "[[")
+	sql = convertOptionalSQLClauses(sql, variables)
+	matches := metabaseVarPattern.FindAllStringSubmatchIndex(sql, -1)
+	if len(matches) == 0 {
+		return sql, optionalCount, nil
+	}
+
+	var b strings.Builder
+	last := 0
+	unresolvedSeen := map[string]bool{}
+	var unresolved []string
+	for _, match := range matches {
+		if len(match) < 4 {
+			continue
+		}
+		start, end := match[0], match[1]
+		name := sql[match[2]:match[3]]
+		b.WriteString(sql[last:start])
+		variable, ok := sqlTemplateVariableForName(name, variables)
+		if !ok {
+			if !unresolvedSeen[name] {
+				unresolvedSeen[name] = true
+				unresolved = append(unresolved, name)
+			}
+			b.WriteString(nullTemplateReplacement(sql, start, end))
+			last = end
+			continue
+		}
+		replacement := ""
+		if variable.UseFilter {
+			replacement = "{{ filters." + variable.FilterName + " }}"
+			if variable.Quote && !insideSingleQuotedString(sql, start) {
+				replacement = "'" + replacement + "'"
+			}
+		} else if variable.HasDefault {
+			replacement = sqlTemplateDefaultLiteral(variable.Default, variable.Quote, insideSingleQuotedString(sql, start))
+		} else {
+			if !unresolvedSeen[name] {
+				unresolvedSeen[name] = true
+				unresolved = append(unresolved, name)
+			}
+			replacement = nullTemplateReplacement(sql, start, end)
+		}
+		b.WriteString(replacement)
+		last = end
+	}
+	b.WriteString(sql[last:])
+	return b.String(), optionalCount, unresolved
+}
+
+func convertOptionalSQLClauses(sql string, variables map[string]sqlTemplateVariable) string {
+	matches := metabaseOptionalPattern.FindAllStringSubmatchIndex(sql, -1)
+	if len(matches) == 0 {
+		return sql
+	}
+	var b strings.Builder
+	last := 0
+	for _, match := range matches {
+		if len(match) < 4 {
+			continue
+		}
+		b.WriteString(sql[last:match[0]])
+		body := sql[match[2]:match[3]]
+		if optionalClauseHasValues(body, variables) {
+			b.WriteString(body)
+		}
+		last = match[1]
+	}
+	b.WriteString(sql[last:])
+	return b.String()
+}
+
+func optionalClauseHasValues(sql string, variables map[string]sqlTemplateVariable) bool {
+	matches := metabaseVarPattern.FindAllStringSubmatch(sql, -1)
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		variable, ok := sqlTemplateVariableForName(match[1], variables)
+		if !ok || (!variable.UseFilter && !variable.HasDefault) {
+			return false
+		}
+	}
+	return true
+}
+
+func sqlTemplateVariableForName(name string, variables map[string]sqlTemplateVariable) (sqlTemplateVariable, bool) {
+	if variables == nil {
+		return sqlTemplateVariable{}, false
+	}
+	if variable, ok := variables[name]; ok {
+		return variable, true
+	}
+	variable, ok := variables[normalizeName(name)]
+	return variable, ok
+}
+
+func sqlTemplateDefaultLiteral(value any, quote bool, alreadyQuoted bool) string {
+	if alreadyQuoted && quote {
+		return strings.ReplaceAll(fmt.Sprint(value), "'", "''")
+	}
+	if quote {
+		return sqlLiteral(value)
+	}
+	switch x := value.(type) {
+	case string:
+		return strings.ReplaceAll(x, "'", "''")
+	default:
+		return sqlLiteral(value)
+	}
+}
+
+func nullTemplateReplacement(sql string, start, end int) string {
+	if insideSingleQuotedString(sql, start) {
+		return ""
+	}
+	return "NULL"
+}
+
+func insideSingleQuotedString(sql string, pos int) bool {
+	inString := false
+	for i := 0; i < pos && i < len(sql); i++ {
+		if sql[i] != '\'' {
+			continue
+		}
+		if inString && i+1 < pos && sql[i+1] == '\'' {
+			i++
+			continue
+		}
+		inString = !inString
+	}
+	return inString
+}
+
+func widgetForDisplay(name, display, sql string, settings map[string]any, columns []columnInfo) (dashboard.Widget, []string) {
+	base := dashboard.Widget{
+		Name: name,
+		SQL:  sql,
+		Col:  defaultWidthForDisplay(display),
+	}
+
+	switch display {
+	case "scalar", "smartscalar":
+		field := firstNumericColumn(columns)
+		if field == "" {
+			field = firstColumn(columns)
+		}
+		base.Type = dashboard.WidgetTypeMetric
+		base.Value = &dashboard.ValueEncoding{Field: field, Type: valueType(field, columns), Format: numberFormat(field, columns)}
+		return base, nil
+
+	case "line", "area", "bar", "row", "combo", "scatter", "waterfall":
+		base.Type = dashboard.WidgetTypeChart
+		base.Chart = chartType(display)
+		base.X, base.Y = xyEncodings(display, settings, columns)
+		if display == "row" {
+			base.Horizontal = true
+		}
+		if display == "combo" {
+			base.Lines = comboLineFields(base.Y)
+		}
+		return base, nil
+
+	case "pie", "funnel", "treemap":
+		base.Type = dashboard.WidgetTypeChart
+		base.Chart = display
+		base.Label = firstSettingString(settings, []string{"pie.dimension", "funnel.dimension", "treemap.label", "graph.dimensions"})
+		if base.Label == "" {
+			base.Label = firstCategoryColumn(columns)
+		}
+		if base.Label == "" {
+			base.Label = "label"
+		}
+		value := firstSettingString(settings, []string{"pie.metric", "funnel.metric", "treemap.value", "graph.metrics"})
+		if value == "" {
+			value = firstNumericColumn(columns)
+		}
+		if value == "" {
+			value = "value"
+		}
+		base.Value = &dashboard.ValueEncoding{Field: value, Type: "number", Format: numberFormat(value, columns)}
+		return base, nil
+
+	case "gauge", "progress":
+		base.Type = dashboard.WidgetTypeChart
+		base.Chart = "gauge"
+		field := firstNumericColumn(columns)
+		if field == "" {
+			field = firstColumn(columns)
+		}
+		base.Value = &dashboard.ValueEncoding{Field: field, Type: "number", Format: numberFormat(field, columns)}
+		base.Target = firstSettingString(settings, []string{"gauge.target", "gauge.max"})
+		return base, nil
+
+	case "table", "object":
+		base.Type = dashboard.WidgetTypeTable
+		base.Col = 12
+		base.Columns = tableColumns(columns)
+		return base, nil
+
+	case "pivot", "map":
+		base.Type = dashboard.WidgetTypeTable
+		base.Col = 12
+		base.Columns = tableColumns(columns)
+		return base, []string{fmt.Sprintf("display type %q was mapped to a table", display)}
+
+	default:
+		base.Type = dashboard.WidgetTypeTable
+		base.Col = 12
+		base.Columns = tableColumns(columns)
+		if display == "" {
+			return base, []string{"missing Metabase display type was mapped to a table"}
+		}
+		return base, []string{fmt.Sprintf("unsupported display type %q was mapped to a table", display)}
+	}
+}
+
+func chartType(display string) string {
+	switch display {
+	case "row":
+		return "bar"
+	default:
+		return display
+	}
+}
+
+func xyEncodings(display string, settings map[string]any, columns []columnInfo) (*dashboard.AxisEncoding, *dashboard.AxisEncoding) {
+	if display == "scatter" {
+		numeric := numericColumns(columns)
+		x := firstColumn(columns)
+		y := ""
+		if len(numeric) > 0 {
+			x = numeric[0]
+		}
+		if len(numeric) > 1 {
+			y = numeric[1]
+		} else if len(columns) > 1 {
+			y = columns[1].Name
+		} else {
+			y = x
+		}
+		return axisForColumn(x, columns, false), axisForColumnList([]string{y}, columns)
+	}
+
+	x := firstSettingString(settings, []string{"graph.dimensions", "graph.x_axis", "graph.x-axis"})
+	if x == "" {
+		x = firstDateColumn(columns)
+	}
+	if x == "" {
+		x = firstCategoryColumn(columns)
+	}
+	if x == "" {
+		x = firstColumn(columns)
+	}
+
+	y := firstSettingStringList(settings, []string{"graph.metrics", "graph.y_axis", "graph.y-axis"})
+	if len(y) == 0 {
+		for _, col := range numericColumns(columns) {
+			if col != x {
+				y = append(y, col)
+			}
+		}
+	}
+	if len(y) == 0 {
+		for _, col := range columns {
+			if col.Name != x {
+				y = append(y, col.Name)
+				break
+			}
+		}
+	}
+	if len(y) == 0 && x != "" {
+		y = []string{x}
+	}
+	return axisForColumn(x, columns, false), axisForColumnList(y, columns)
+}
+
+func comboLineFields(y *dashboard.AxisEncoding) []string {
+	fields := y.FieldList()
+	if len(fields) < 2 {
+		return nil
+	}
+	return []string{fields[len(fields)-1]}
+}
+
+func axisForColumn(name string, columns []columnInfo, list bool) *dashboard.AxisEncoding {
+	if name == "" {
+		return nil
+	}
+	field := any(name)
+	if list {
+		field = []string{name}
+	}
+	return &dashboard.AxisEncoding{Field: field, Type: valueType(name, columns), Format: axisFormat(name, columns)}
+}
+
+func axisForColumnList(names []string, columns []columnInfo) *dashboard.AxisEncoding {
+	if len(names) == 0 {
+		return nil
+	}
+	return &dashboard.AxisEncoding{Field: names, Type: "number", Format: numberFormat(names[0], columns)}
+}
+
+func resultColumns(card map[string]any) []columnInfo {
+	for _, key := range []string{"result_metadata", "result-metadata", "metadata"} {
+		if list := mapList(card, key); len(list) > 0 {
+			return parseColumns(list)
+		}
+	}
+	if dataset, ok := mapField(card, "dataset_query", "dataset-query"); ok {
+		if list := mapList(dataset, "result_metadata", "result-metadata", "metadata"); len(list) > 0 {
+			return parseColumns(list)
+		}
+	}
+	return inferColumnsFromSQL(card)
+}
+
+var sqlAliasPattern = regexp.MustCompile(`(?i)\bas\s+"?([A-Za-z_][A-Za-z0-9_]*)"?`)
+
+func inferColumnsFromSQL(card map[string]any) []columnInfo {
+	sql, _ := nativeSQL(card, nil)
+	if sql == "" {
+		return nil
+	}
+	matches := sqlAliasPattern.FindAllStringSubmatch(sql, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	cols := make([]columnInfo, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 || match[1] == "" || seen[match[1]] {
+			continue
+		}
+		cols = append(cols, columnInfo{Name: match[1]})
+		seen[match[1]] = true
+	}
+	return cols
+}
+
+func parseColumns(list []map[string]any) []columnInfo {
+	cols := make([]columnInfo, 0, len(list))
+	for _, item := range list {
+		name := firstString(item, "name", "field_ref", "field-ref", "display_name", "display-name")
+		if strings.HasPrefix(name, "[") {
+			name = ""
+		}
+		if name == "" {
+			continue
+		}
+		cols = append(cols, columnInfo{
+			Name: name,
+			Type: strings.ToLower(firstString(item, "base_type", "base-type", "semantic_type", "semantic-type", "effective_type", "effective-type")),
+		})
+	}
+	return cols
+}
+
+func tableColumns(columns []columnInfo) []dashboard.TableColumn {
+	out := make([]dashboard.TableColumn, 0, len(columns))
+	for _, col := range columns {
+		out = append(out, dashboard.TableColumn{Name: col.Name, Label: titleFromName(col.Name)})
+	}
+	return out
+}
+
+func textContent(cardRoot, card, settings map[string]any) string {
+	for _, source := range []map[string]any{cardRoot, card, settings} {
+		if text := firstString(source, "text", "content", "body", "markdown"); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func cardName(cardRoot map[string]any, index int) string {
+	card, _ := mapField(cardRoot, "card", "question")
+	for _, source := range []map[string]any{cardRoot, card} {
+		if source == nil {
+			continue
+		}
+		if name := firstString(source, "name", "display_name", "display-name", "title"); name != "" {
+			return name
+		}
+	}
+	return fmt.Sprintf("Metabase Card %d", index)
+}
+
+func layoutRows(widgets []positionedWidget) []dashboard.Row {
+	if len(widgets) == 0 {
+		return []dashboard.Row{{
+			Widgets: []dashboard.Widget{{
+				Name:    "Empty Metabase Dashboard",
+				Type:    dashboard.WidgetTypeText,
+				Content: "No Metabase cards were found.",
+				Col:     12,
+			}},
+		}}
+	}
+
+	gridWidth := inferGridWidth(widgets)
+	for i := range widgets {
+		widgets[i].w.Col = scaleWidth(widgets[i].sizeX, gridWidth)
+	}
+
+	sort.SliceStable(widgets, func(i, j int) bool {
+		if widgets[i].row != widgets[j].row {
+			return widgets[i].row < widgets[j].row
+		}
+		return widgets[i].col < widgets[j].col
+	})
+
+	var rows []dashboard.Row
+	var current []dashboard.Widget
+	currentRow := widgets[0].row
+	currentCols := 0
+
+	flush := func() {
+		if len(current) == 0 {
+			return
+		}
+		rows = append(rows, dashboard.Row{Widgets: current})
+		current = nil
+		currentCols = 0
+	}
+
+	for _, item := range widgets {
+		if item.row != currentRow || currentCols+item.w.Col > 12 {
+			flush()
+			currentRow = item.row
+		}
+		current = append(current, item.w)
+		currentCols += item.w.Col
+	}
+	flush()
+	return rows
+}
+
+func inferGridWidth(widgets []positionedWidget) int {
+	maxExtent := 12
+	for _, w := range widgets {
+		extent := w.col + w.sizeX
+		if extent > maxExtent {
+			maxExtent = extent
+		}
+	}
+	if maxExtent <= 12 {
+		return 12
+	}
+	if maxExtent <= 24 {
+		return 24
+	}
+	return maxExtent
+}
+
+func scaleWidth(width, gridWidth int) int {
+	if width <= 0 {
+		return 12
+	}
+	scaled := int(math.Ceil(float64(width) * 12 / float64(gridWidth)))
+	if scaled < 1 {
+		return 1
+	}
+	if scaled > 12 {
+		return 12
+	}
+	return scaled
+}
+
+func defaultWidthForWidget(w dashboard.Widget) int {
+	if w.Type == dashboard.WidgetTypeMetric {
+		return 6
+	}
+	if w.Type == dashboard.WidgetTypeTable || w.Type == dashboard.WidgetTypeText {
+		return 12
+	}
+	return 8
+}
+
+func defaultWidthForDisplay(display string) int {
+	switch display {
+	case "scalar", "smartscalar", "gauge", "progress":
+		return 3
+	case "table", "pivot", "object":
+		return 12
+	default:
+		return 6
+	}
+}
+
+func firstColumn(columns []columnInfo) string {
+	if len(columns) == 0 {
+		return "value"
+	}
+	return columns[0].Name
+}
+
+func firstNumericColumn(columns []columnInfo) string {
+	for _, col := range columns {
+		if columnValueType(col) == "number" {
+			return col.Name
+		}
+	}
+	return ""
+}
+
+func firstDateColumn(columns []columnInfo) string {
+	for _, col := range columns {
+		if columnValueType(col) == "date" {
+			return col.Name
+		}
+	}
+	return ""
+}
+
+func firstCategoryColumn(columns []columnInfo) string {
+	for _, col := range columns {
+		if columnValueType(col) == "category" {
+			return col.Name
+		}
+	}
+	return ""
+}
+
+func numericColumns(columns []columnInfo) []string {
+	var out []string
+	for _, col := range columns {
+		if columnValueType(col) == "number" {
+			out = append(out, col.Name)
+		}
+	}
+	return out
+}
+
+func isNumericType(t string) bool {
+	return strings.Contains(t, "number") ||
+		strings.Contains(t, "integer") ||
+		strings.Contains(t, "float") ||
+		strings.Contains(t, "decimal")
+}
+
+func isDateType(t string) bool {
+	return strings.Contains(t, "date") || strings.Contains(t, "time")
+}
+
+func valueType(name string, columns []columnInfo) string {
+	for _, col := range columns {
+		if col.Name != name {
+			continue
+		}
+		return columnValueType(col)
+	}
+	return ""
+}
+
+func columnValueType(col columnInfo) string {
+	if isDateType(col.Type) {
+		return "date"
+	}
+	if isNumericType(col.Type) {
+		return "number"
+	}
+	if inferred := inferValueTypeFromName(col.Name); inferred != "" {
+		return inferred
+	}
+	return "category"
+}
+
+func inferValueTypeFromName(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.Contains(lower, "date"), strings.Contains(lower, "time"), strings.HasSuffix(lower, "_at"):
+		return "date"
+	case strings.Contains(lower, "count"), strings.Contains(lower, "num"),
+		strings.Contains(lower, "total"), strings.Contains(lower, "sum"),
+		strings.Contains(lower, "avg"), strings.Contains(lower, "amount"),
+		strings.Contains(lower, "revenue"), strings.Contains(lower, "profit"),
+		strings.Contains(lower, "cost"), strings.Contains(lower, "orders"),
+		strings.Contains(lower, "sales"), strings.Contains(lower, "price"),
+		strings.Contains(lower, "rate"), strings.Contains(lower, "pct"),
+		strings.Contains(lower, "percent"):
+		return "number"
+	default:
+		return ""
+	}
+}
+
+func axisFormat(name string, columns []columnInfo) string {
+	if valueType(name, columns) == "date" {
+		return "%Y-%m-%d"
+	}
+	return numberFormat(name, columns)
+}
+
+func numberFormat(name string, columns []columnInfo) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.Contains(lower, "pct"), strings.Contains(lower, "percent"), strings.Contains(lower, "rate"):
+		return ".1%"
+	case strings.Contains(lower, "count"), strings.HasPrefix(lower, "num_"), strings.HasSuffix(lower, "_num"):
+		return ",.0f"
+	default:
+		return ""
+	}
+}
+
+func dacFilterType(sourceType string) string {
+	t := strings.ToLower(sourceType)
+	switch {
+	case strings.Contains(t, "date") && (strings.Contains(t, "range") || strings.Contains(t, "relative") || strings.Contains(t, "all-options")):
+		return "date-range"
+	case strings.Contains(t, "date"):
+		return "date"
+	case strings.Contains(t, "number"), strings.Contains(t, "integer"), strings.Contains(t, "float"), strings.Contains(t, "decimal"):
+		return "number"
+	case strings.Contains(t, "category"), strings.Contains(t, "select"):
+		return "select"
+	default:
+		return "text"
+	}
+}
+
+func filterTypeNeedsQuotes(filterType string) bool {
+	switch filterType {
+	case "date", "date-range", "select", "text":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeFilterDefault(v any, filterType string) any {
+	if v == nil {
+		return nil
+	}
+	t := strings.ToLower(filterType)
+	if strings.Contains(t, "date") {
+		if s, ok := v.(string); ok {
+			return metabaseDateDefault(s, dacFilterType(t))
+		}
+		return nil
+	}
+	return v
+}
+
+func metabaseDateDefault(value, filterType string) any {
+	v := strings.TrimSpace(strings.ToLower(value))
+	if v == "" {
+		return nil
+	}
+	if filterType == "date" {
+		switch v {
+		case "today":
+			return "TODAY"
+		case "yesterday":
+			return "TODAY-1"
+		}
+		if regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`).MatchString(value) {
+			return value
+		}
+		return nil
+	}
+	switch v {
+	case "past7days", "past7days~", "last7days", "last_7_days":
+		return "last_7_days"
+	case "past30days", "past30days~", "last30days", "last_30_days":
+		return "last_30_days"
+	case "past90days", "past90days~", "last90days", "last_90_days":
+		return "last_90_days"
+	case "today":
+		return "today"
+	case "yesterday":
+		return "yesterday"
+	}
+	if filterType == "date-range" {
+		if start, end, ok := metabaseFixedDateRange(value); ok {
+			return map[string]any{"start": start, "end": end}
+		}
+	}
+	if regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`).MatchString(value) {
+		return value
+	}
+	return nil
+}
+
+func metabaseFixedDateRange(value string) (string, string, bool) {
+	value = strings.TrimSpace(value)
+	datePattern := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+	if datePattern.MatchString(value) {
+		return value, value, true
+	}
+	start, end, found := strings.Cut(value, "~")
+	if !found {
+		return "", "", false
+	}
+	start = strings.TrimSpace(start)
+	end = strings.TrimSpace(end)
+	if !datePattern.MatchString(start) || !datePattern.MatchString(end) {
+		return "", "", false
+	}
+	return start, end, true
+}
+
+func extractStaticFilterValues(m map[string]any) []string {
+	for _, key := range []string{"values", "options"} {
+		if raw, ok := m[key]; ok {
+			if values := stringList(raw); len(values) > 0 {
+				return values
+			}
+		}
+	}
+	if config, ok := mapField(m, "values_source_config", "values-source-config"); ok {
+		for _, key := range []string{"values", "options"} {
+			if raw, ok := config[key]; ok {
+				if values := stringList(raw); len(values) > 0 {
+					return values
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func mapField(m map[string]any, keys ...string) (map[string]any, bool) {
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			child, ok := v.(map[string]any)
+			if ok {
+				return child, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func mapFieldOrEmpty(m map[string]any, keys ...string) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+	if child, ok := mapField(m, keys...); ok {
+		return child
+	}
+	return map[string]any{}
+}
+
+func mapList(m map[string]any, keys ...string) []map[string]any {
+	for _, key := range keys {
+		raw, ok := m[key]
+		if !ok {
+			continue
+		}
+		list, ok := raw.([]any)
+		if !ok {
+			continue
+		}
+		out := make([]map[string]any, 0, len(list))
+		for _, item := range list {
+			if child, ok := item.(map[string]any); ok {
+				out = append(out, child)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func firstValue(m map[string]any, keys ...string) any {
+	value, _ := firstPresentValue(m, keys...)
+	return value
+}
+
+func firstPresentValue(m map[string]any, keys ...string) (any, bool) {
+	if m == nil {
+		return nil, false
+	}
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func firstString(m map[string]any, keys ...string) string {
+	if m == nil {
+		return ""
+	}
+	for _, key := range keys {
+		v, ok := m[key]
+		if !ok || v == nil {
+			continue
+		}
+		switch x := v.(type) {
+		case string:
+			return x
+		case json.Number:
+			return x.String()
+		case float64:
+			if x == math.Trunc(x) {
+				return strconv.FormatInt(int64(x), 10)
+			}
+			return strconv.FormatFloat(x, 'f', -1, 64)
+		case int:
+			return strconv.Itoa(x)
+		}
+	}
+	return ""
+}
+
+func intField(m map[string]any, fallback int, keys ...string) int {
+	for _, key := range keys {
+		v, ok := m[key]
+		if !ok {
+			continue
+		}
+		switch x := v.(type) {
+		case int:
+			return x
+		case int64:
+			return int(x)
+		case float64:
+			return int(x)
+		case json.Number:
+			i, err := x.Int64()
+			if err == nil {
+				return int(i)
+			}
+		case string:
+			i, err := strconv.Atoi(x)
+			if err == nil {
+				return i
+			}
+		}
+	}
+	return fallback
+}
+
+func mergeMaps(left, right map[string]any) map[string]any {
+	out := map[string]any{}
+	for k, v := range left {
+		out[k] = v
+	}
+	for k, v := range right {
+		out[k] = v
+	}
+	return out
+}
+
+func firstSettingString(settings map[string]any, paths []string) string {
+	for _, path := range paths {
+		if values := firstSettingStringList(settings, []string{path}); len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+func firstSettingStringList(settings map[string]any, paths []string) []string {
+	for _, path := range paths {
+		if raw, ok := settings[path]; ok {
+			if values := stringList(raw); len(values) > 0 {
+				return values
+			}
+			if s, ok := raw.(string); ok && s != "" {
+				return []string{s}
+			}
+		}
+		if raw, ok := nestedValue(settings, strings.Split(path, ".")); ok {
+			if values := stringList(raw); len(values) > 0 {
+				return values
+			}
+			if s, ok := raw.(string); ok && s != "" {
+				return []string{s}
+			}
+		}
+	}
+	return nil
+}
+
+func nestedValue(m map[string]any, path []string) (any, bool) {
+	var current any = m
+	for _, part := range path {
+		asMap, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		value, ok := asMap[part]
+		if !ok {
+			return nil, false
+		}
+		current = value
+	}
+	return current, true
+}
+
+func stringList(raw any) []string {
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			switch x := item.(type) {
+			case string:
+				if x != "" {
+					out = append(out, x)
+				}
+			case map[string]any:
+				if s := firstString(x, "name", "value", "display_name", "display-name"); s != "" {
+					out = append(out, s)
+				}
+			}
+		}
+		return out
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []string{v}
+	default:
+		return nil
+	}
+}
+
+var nonNameChars = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
+
+func normalizeName(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, " ", "_")
+	s = nonNameChars.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	s = strings.ToLower(s)
+	if s == "" {
+		return ""
+	}
+	if s[0] >= '0' && s[0] <= '9' {
+		s = "filter_" + s
+	}
+	return s
+}
+
+func titleFromName(s string) string {
+	parts := strings.Fields(strings.ReplaceAll(strings.ReplaceAll(s, "_", " "), "-", " "))
+	for i := range parts {
+		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+	}
+	return strings.Join(parts, " ")
+}

--- a/pkg/importer/metabase/convert_test.go
+++ b/pkg/importer/metabase/convert_test.go
@@ -1,0 +1,1375 @@
+package metabase
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/dac/pkg/dashboard"
+)
+
+func TestConvertNativeSQLDashboard(t *testing.T) {
+	input := []byte(`{
+  "name": "Executive Sales",
+  "description": "Imported from Metabase",
+  "parameters": [
+    {"id": "region_param", "slug": "region", "name": "Region", "type": "category", "default": "All", "values": ["All", "EU", "US"]}
+  ],
+  "ordered_cards": [
+    {
+      "row": 0,
+      "col": 0,
+      "size_x": 12,
+      "size_y": 4,
+      "card_id": 10,
+      "parameter_mappings": [{
+        "parameter_id": "region_param",
+        "card_id": 10,
+        "target": ["variable", ["template-tag", "region"]]
+      }],
+      "card": {
+        "id": 10,
+        "name": "Revenue Trend",
+        "display": "line",
+        "dataset_query": {
+          "type": "native",
+          "native": {
+            "query": "SELECT month, revenue FROM sales WHERE region = '{{region}}' [[AND created_at >= '{{start_date}}']]",
+            "template_tags": {
+              "region": {"name": "region", "type": "text"},
+              "start_date": {"name": "start_date", "type": "date"}
+            }
+          }
+        },
+        "result_metadata": [
+          {"name": "month", "base_type": "type/Date"},
+          {"name": "revenue", "base_type": "type/Float"}
+        ],
+        "visualization_settings": {
+          "graph.dimensions": ["month"],
+          "graph.metrics": ["revenue"]
+        }
+      }
+    },
+    {
+      "row": 0,
+      "col": 12,
+      "size_x": 12,
+      "size_y": 3,
+      "card": {
+        "name": "Order Count",
+        "display": "scalar",
+        "dataset_query": {
+          "type": "native",
+          "native": {"query": "SELECT COUNT(*) AS order_count FROM orders"}
+        },
+        "result_metadata": [
+          {"name": "order_count", "base_type": "type/Integer"}
+        ]
+      }
+    }
+  ]
+}`)
+
+	d, report, err := Convert(input, Options{Connection: "warehouse"})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if err := dashboard.Validate(d); err != nil {
+		t.Fatalf("generated dashboard should validate: %v", err)
+	}
+	if d.Name != "Executive Sales" || d.Connection != "warehouse" {
+		t.Fatalf("unexpected dashboard metadata: %+v", d)
+	}
+	if len(d.Filters) != 1 {
+		t.Fatalf("expected only the dashboard filter, got %d", len(d.Filters))
+	}
+	if d.Rows[0].Widgets[0].Chart != "line" {
+		t.Fatalf("expected line chart, got %+v", d.Rows[0].Widgets[0])
+	}
+	if got := d.Rows[0].Widgets[0].SQL; !strings.Contains(got, "{{ filters.region }}") || strings.Contains(got, "start_date") {
+		t.Fatalf("expected only the mapped SQL template variable to use a DAC filter, got %q", got)
+	}
+	if strings.Contains(d.Rows[0].Widgets[0].SQL, "[[") {
+		t.Fatalf("expected Metabase optional markers to be removed, got %q", d.Rows[0].Widgets[0].SQL)
+	}
+	if d.Rows[0].Widgets[1].Type != dashboard.WidgetTypeMetric {
+		t.Fatalf("expected scalar card to become metric, got %+v", d.Rows[0].Widgets[1])
+	}
+	if d.Rows[0].Height != nil {
+		t.Fatalf("expected Metabase size_y not to set DAC row height, got %+v", d.Rows[0].Height)
+	}
+	if report.WidgetCount != 2 || report.SQLWidgetCount != 2 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if len(report.Warnings) == 0 {
+		t.Fatal("expected warning about optional SQL clause conversion")
+	}
+}
+
+func TestConvertUnquotedMetabaseTemplateVariablesQuotesDACFilters(t *testing.T) {
+	input := []byte(`{
+  "name": "Unquoted Variables",
+  "parameters": [
+    {"id": "region_param", "slug": "region", "name": "Region", "type": "category"},
+    {"id": "start_param", "slug": "start_date", "name": "Start Date", "type": "date"},
+    {"id": "orders_param", "slug": "min_orders", "name": "Minimum Orders", "type": "number"}
+  ],
+  "ordered_cards": [{
+    "card_id": 20,
+    "parameter_mappings": [
+      {"parameter_id": "region_param", "card_id": 20, "target": ["variable", ["template-tag", "region"]]},
+      {"parameter_id": "start_param", "card_id": 20, "target": ["variable", ["template-tag", "start_date"]]},
+      {"parameter_id": "orders_param", "card_id": 20, "target": ["variable", ["template-tag", "min_orders"]]}
+    ],
+    "card": {
+      "id": 20,
+      "name": "Revenue",
+      "display": "scalar",
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT SUM(revenue) AS total_revenue FROM sales_summary WHERE region = {{region}} AND order_date >= {{start_date}} AND orders >= {{min_orders}}",
+          "template_tags": {
+            "region": {"name": "region", "type": "text"},
+            "start_date": {"name": "start_date", "type": "date"},
+            "min_orders": {"name": "min_orders", "type": "number"}
+          }
+        }
+      },
+      "result_metadata": [
+        {"name": "total_revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  }]
+}`)
+
+	d, _, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	sql := d.Rows[0].Widgets[0].SQL
+	for _, want := range []string{
+		"region = '{{ filters.region }}'",
+		"order_date >= '{{ filters.start_date }}'",
+		"orders >= {{ filters.min_orders }}",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("expected SQL to contain %q, got %q", want, sql)
+		}
+	}
+}
+
+func TestConvertMetabaseTemplateVariableInsideStringLiteral(t *testing.T) {
+	input := []byte(`{
+  "name": "String Pattern Variables",
+  "parameters": [
+    {"id": "search_param", "slug": "search", "name": "Search", "type": "text"}
+  ],
+  "ordered_cards": [{
+    "card_id": 22,
+    "parameter_mappings": [{
+      "parameter_id": "search_param",
+      "card_id": 22,
+      "target": ["variable", ["template-tag", "search"]]
+    }],
+    "card": {
+      "id": 22,
+      "name": "Customer Search",
+      "display": "table",
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT customer_name FROM customers WHERE customer_name LIKE '%{{search}}%'",
+          "template_tags": {
+            "search": {"name": "search", "type": "text"}
+          }
+        }
+      },
+      "result_metadata": [
+        {"name": "customer_name", "base_type": "type/Text"}
+      ]
+    }
+  }]
+}`)
+
+	d, _, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	sql := d.Rows[0].Widgets[0].SQL
+	if !strings.Contains(sql, "LIKE '%{{ filters.search }}%'") {
+		t.Fatalf("expected embedded string filter to stay inside the existing literal, got %q", sql)
+	}
+	if strings.Contains(sql, "'{{ filters.search }}'") {
+		t.Fatalf("expected no extra quotes around embedded string filter, got %q", sql)
+	}
+}
+
+func TestConvertNativeSQLTemplateTagsWithoutDashboardMappingUseDefaults(t *testing.T) {
+	input := []byte(`{
+  "name": "Native Defaults",
+  "parameters": [
+    {"id": "region_param", "slug": "region", "name": "Region", "type": "category", "default": "Europe"}
+  ],
+  "ordered_cards": [{
+    "card": {
+      "id": 21,
+      "name": "Margin",
+      "display": "bar",
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT plan, SUM(revenue) AS revenue FROM revenue_model WHERE 1=1 [[AND region = {{region}}]] [[AND order_date >= {{start_date}}]] [[AND order_date <= {{end_date}}]] [[AND channel = {{channel}}]] GROUP BY 1",
+          "template_tags": {
+            "region": {"name": "region", "type": "text", "default": "North America"},
+            "start_date": {"name": "start_date", "type": "date", "default": "2026-03-01"},
+            "end_date": {"name": "end_date", "type": "date", "default": "2026-06-15"},
+            "channel": {"name": "channel", "type": "text"}
+          }
+        }
+      },
+      "result_metadata": [
+        {"name": "plan", "base_type": "type/Text"},
+        {"name": "revenue", "base_type": "type/Decimal"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["plan"],
+        "graph.metrics": ["revenue"]
+      }
+    }
+  }]
+}`)
+
+	d, _, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if len(d.Filters) != 1 || d.Filters[0].Name != "region" {
+		t.Fatalf("expected only the Metabase dashboard parameter as a DAC filter, got %+v", d.Filters)
+	}
+	sql := d.Rows[0].Widgets[0].SQL
+	for _, want := range []string{
+		"region = 'North America'",
+		"order_date >= '2026-03-01'",
+		"order_date <= '2026-06-15'",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("expected SQL to contain default literal %q, got %q", want, sql)
+		}
+	}
+	for _, notWant := range []string{"filters.start_date", "filters.end_date", "filters.region", "channel ="} {
+		if strings.Contains(sql, notWant) {
+			t.Fatalf("expected SQL not to contain %q, got %q", notWant, sql)
+		}
+	}
+}
+
+func TestConvertMetabaseDateParameterDefaultsValidate(t *testing.T) {
+	input := []byte(`{
+  "name": "Date Defaults",
+  "parameters": [
+    {"id": "range_param", "slug": "created_range", "name": "Created Range", "type": "date/all-options", "default": "past30days"},
+    {"id": "fixed_range_param", "slug": "fixed_range", "name": "Fixed Range", "type": "date/range", "default": "2026-01-01~2026-01-31"},
+    {"id": "literal_range_param", "slug": "literal_range", "name": "Literal Range", "type": "date/all-options", "default": "2026-02-15"},
+    {"id": "unknown_range_param", "slug": "unknown_range", "name": "Unknown Range", "type": "date/all-options", "default": "previous-week"},
+    {"id": "single_param", "slug": "as_of_date", "name": "As Of Date", "type": "date/single", "default": "today"}
+  ],
+  "ordered_cards": [{
+    "card": {
+      "name": "Orders",
+      "display": "scalar",
+      "dataset_query": {
+        "type": "native",
+        "native": {"query": "SELECT COUNT(*) AS order_count FROM orders"}
+      },
+      "result_metadata": [
+        {"name": "order_count", "base_type": "type/Integer"}
+      ]
+    }
+  }]
+}`)
+
+	d, _, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if len(d.Filters) != 5 {
+		t.Fatalf("expected five filters, got %+v", d.Filters)
+	}
+	if d.Filters[0].Type != "date-range" || d.Filters[0].Default != "last_30_days" {
+		t.Fatalf("expected range default to stay a date-range preset, got %+v", d.Filters[0])
+	}
+	if d.Filters[1].Type != "date-range" {
+		t.Fatalf("expected fixed range filter to be date-range, got %+v", d.Filters[1])
+	}
+	if got, ok := d.Filters[1].Default.(map[string]any); !ok || got["start"] != "2026-01-01" || got["end"] != "2026-01-31" {
+		t.Fatalf("expected fixed range default map, got %+v", d.Filters[1].Default)
+	}
+	if d.Filters[2].Type != "date-range" {
+		t.Fatalf("expected literal range filter to be date-range, got %+v", d.Filters[2])
+	}
+	if got, ok := d.Filters[2].Default.(map[string]any); !ok || got["start"] != "2026-02-15" || got["end"] != "2026-02-15" {
+		t.Fatalf("expected literal range default map, got %+v", d.Filters[2].Default)
+	}
+	if d.Filters[3].Type != "date-range" || d.Filters[3].Default != nil {
+		t.Fatalf("expected unknown range default to be omitted, got %+v", d.Filters[3])
+	}
+	if d.Filters[4].Type != "date" || d.Filters[4].Default != "TODAY" {
+		t.Fatalf("expected single-date default to use a DAC date expression, got %+v", d.Filters[4])
+	}
+	if err := dashboard.Validate(d); err != nil {
+		t.Fatalf("generated dashboard should validate: %v", err)
+	}
+}
+
+func TestConvertUnsupportedMBQLCreatesPlaceholder(t *testing.T) {
+	input := []byte(`{
+  "name": "Query Builder Dashboard",
+  "ordered_cards": [{
+    "card": {
+      "name": "Built with GUI",
+      "display": "bar",
+      "dataset_query": {"type": "query", "query": {"source-table": 1}}
+    }
+  }]
+}`)
+
+	d, report, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Type != dashboard.WidgetTypeText {
+		t.Fatalf("expected placeholder text widget, got %+v", w)
+	}
+	if report.PlaceholderCount != 1 || len(report.Warnings) != 1 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestConvertPhysicalTableMBQLDetailRows(t *testing.T) {
+	input := []byte(`{
+  "name": "Physical Table Dashboard",
+  "x-dac-metabase-tables": {
+    "15": {
+      "id": 15,
+      "name": "orders",
+      "schema": "public",
+      "fields": [
+        {"id": 112, "name": "order_id", "base_type": "type/Integer"},
+        {"id": 117, "name": "region", "base_type": "type/Text"},
+        {"id": 129, "name": "net_revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  },
+  "ordered_cards": [{
+    "card": {
+      "name": "Raw Orders",
+      "display": "bar",
+      "dataset_query": {
+        "type": "query",
+        "query": {"source-table": 15}
+      }
+    }
+  }]
+}`)
+
+	d, report, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Type != dashboard.WidgetTypeTable {
+		t.Fatalf("expected physical table MBQL without aggregations to become table, got %+v", w)
+	}
+	for _, want := range []string{
+		`SELECT *`,
+		`FROM "public"."orders"`,
+		`LIMIT 2000`,
+	} {
+		if !strings.Contains(w.SQL, want) {
+			t.Fatalf("expected SQL to contain %q, got:\n%s", want, w.SQL)
+		}
+	}
+	if report.SQLWidgetCount != 1 || report.PlaceholderCount != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestConvertPhysicalTableMBQLAggregationWithFieldIDs(t *testing.T) {
+	input := []byte(`{
+  "name": "Physical Table Dashboard",
+  "x-dac-metabase-tables": {
+    "15": {
+      "id": 15,
+      "name": "orders",
+      "schema": "public",
+      "fields": [
+        {"id": 115, "name": "order_date", "base_type": "type/Date"},
+        {"id": 117, "name": "region", "base_type": "type/Text"},
+        {"id": 129, "name": "net_revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  },
+  "ordered_cards": [{
+    "card": {
+      "name": "Orders by Region",
+      "display": "bar",
+      "dataset_query": {
+        "type": "query",
+        "query": {
+          "source-table": 15,
+          "breakout": [["field", 117, null]],
+          "aggregation": [["sum", ["field", 129, null]]],
+          "filter": [">=", ["field", 115, null], "2026-01-01"],
+          "order-by": [["desc", ["aggregation", 0]]],
+          "limit": 10
+        }
+      },
+      "result_metadata": [
+        {"name": "region", "base_type": "type/Text"},
+        {"name": "sum", "base_type": "type/Decimal"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["region"],
+        "graph.metrics": ["sum"]
+      }
+    }
+  }]
+}`)
+
+	d, report, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Type != dashboard.WidgetTypeChart || w.Chart != "bar" {
+		t.Fatalf("expected bar chart, got %+v", w)
+	}
+	for _, want := range []string{
+		`SELECT "region" AS "region", SUM("net_revenue") AS "sum"`,
+		`FROM "public"."orders"`,
+		`"order_date" >= '2026-01-01'`,
+		`GROUP BY 1`,
+		`ORDER BY "sum" DESC`,
+		`LIMIT 10`,
+	} {
+		if !strings.Contains(w.SQL, want) {
+			t.Fatalf("expected SQL to contain %q, got:\n%s", want, w.SQL)
+		}
+	}
+	if report.SQLWidgetCount != 1 || report.PlaceholderCount != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestConvertPhysicalTableUnsupportedMBQLFilterCreatesPlaceholder(t *testing.T) {
+	input := []byte(`{
+  "name": "Unsupported Filter Dashboard",
+  "x-dac-metabase-tables": {
+    "15": {
+      "id": 15,
+      "name": "orders",
+      "schema": "public",
+      "fields": [
+        {"id": 117, "name": "region", "base_type": "type/Text"}
+      ]
+    }
+  },
+  "ordered_cards": [{
+    "card": {
+      "name": "Contains Region",
+      "display": "table",
+      "dataset_query": {
+        "type": "query",
+        "query": {
+          "source-table": 15,
+          "filter": ["contains", ["field", 117, null], "EU"]
+        }
+      },
+      "result_metadata": [
+        {"name": "region", "base_type": "type/Text"}
+      ]
+    }
+  }]
+}`)
+
+	d, report, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Type != dashboard.WidgetTypeText {
+		t.Fatalf("expected unsupported filter to become placeholder, got %+v", w)
+	}
+	if report.SQLWidgetCount != 0 || report.PlaceholderCount != 1 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if !containsWarning(report.Warnings, "unsupported MBQL filter") {
+		t.Fatalf("expected unsupported filter warning, got %+v", report.Warnings)
+	}
+}
+
+func TestConvertPhysicalTableUnsupportedMBQLAggregationCreatesPlaceholder(t *testing.T) {
+	input := []byte(`{
+  "name": "Unsupported Aggregation Dashboard",
+  "x-dac-metabase-tables": {
+    "15": {
+      "id": 15,
+      "name": "orders",
+      "schema": "public",
+      "fields": [
+        {"id": 117, "name": "region", "base_type": "type/Text"},
+        {"id": 129, "name": "net_revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  },
+  "ordered_cards": [{
+    "card": {
+      "name": "Median Revenue",
+      "display": "bar",
+      "dataset_query": {
+        "type": "query",
+        "query": {
+          "source-table": 15,
+          "breakout": [["field", 117, null]],
+          "aggregation": [["median", ["field", 129, null]]]
+        }
+      },
+      "result_metadata": [
+        {"name": "region", "base_type": "type/Text"},
+        {"name": "median", "base_type": "type/Decimal"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["region"],
+        "graph.metrics": ["median"]
+      }
+    }
+  }]
+}`)
+
+	d, report, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Type != dashboard.WidgetTypeText {
+		t.Fatalf("expected unsupported aggregation to become placeholder, got %+v", w)
+	}
+	if report.SQLWidgetCount != 0 || report.PlaceholderCount != 1 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if !containsWarning(report.Warnings, "unsupported MBQL aggregation") {
+		t.Fatalf("expected unsupported aggregation warning, got %+v", report.Warnings)
+	}
+}
+
+func TestConvertPhysicalTableTemporalBreakoutCreatesPlaceholder(t *testing.T) {
+	input := []byte(`{
+  "name": "Temporal Breakout Dashboard",
+  "x-dac-metabase-tables": {
+    "15": {
+      "id": 15,
+      "name": "orders",
+      "schema": "public",
+      "fields": [
+        {"id": 115, "name": "order_date", "base_type": "type/Date"},
+        {"id": 129, "name": "net_revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  },
+  "ordered_cards": [{
+    "card": {
+      "name": "Monthly Revenue",
+      "display": "bar",
+      "dataset_query": {
+        "type": "query",
+        "query": {
+          "source-table": 15,
+          "breakout": [["field", 115, {"temporal-unit": "month"}]],
+          "aggregation": [["sum", ["field", 129, null]]]
+        }
+      },
+      "result_metadata": [
+        {"name": "order_date", "base_type": "type/Date"},
+        {"name": "sum", "base_type": "type/Decimal"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["order_date"],
+        "graph.metrics": ["sum"]
+      }
+    }
+  }]
+}`)
+
+	d, report, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Type != dashboard.WidgetTypeText {
+		t.Fatalf("expected temporal breakout to become placeholder, got %+v", w)
+	}
+	if report.SQLWidgetCount != 0 || report.PlaceholderCount != 1 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if !containsWarning(report.Warnings, "unsupported MBQL breakout") {
+		t.Fatalf("expected unsupported breakout warning, got %+v", report.Warnings)
+	}
+}
+
+func TestConvertMetabaseStagedNativeQuery(t *testing.T) {
+	input := []byte(`{
+  "name": "Staged Native Dashboard",
+  "dashcards": [{
+    "row": 0,
+    "col": 0,
+    "size_x": 12,
+    "size_y": 4,
+    "card": {
+      "name": "Revenue",
+      "display": "scalar",
+      "query_type": "native",
+      "dataset_query": {
+        "lib/type": "mbql/query",
+        "database": 2,
+        "stages": [{
+          "lib/type": "mbql.stage/native",
+          "native": "SELECT ROUND(SUM(revenue), 2) AS total_revenue FROM sales_summary"
+        }]
+      },
+      "result_metadata": [
+        {"name": "total_revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  }]
+}`)
+
+	d, report, err := Convert(input, Options{Connection: "warehouse"})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Type != dashboard.WidgetTypeMetric {
+		t.Fatalf("expected metric widget, got %+v", w)
+	}
+	if !strings.Contains(w.SQL, "SUM(revenue)") {
+		t.Fatalf("expected SQL from staged native query, got %q", w.SQL)
+	}
+	if report.SQLWidgetCount != 1 || report.PlaceholderCount != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestConvertNativeScalarInfersValueFieldFromSQLAlias(t *testing.T) {
+	input := []byte(`{
+  "name": "Native Dashboard",
+  "dashcards": [{
+    "card": {
+      "name": "Revenue",
+      "display": "scalar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "native": "SELECT ROUND(SUM(revenue), 2) AS total_revenue FROM sales_summary"
+        }]
+      },
+      "result_metadata": null
+    }
+  }]
+}`)
+
+	d, _, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Value == nil || w.Value.Field != "total_revenue" {
+		t.Fatalf("expected value field from SQL alias, got %+v", w.Value)
+	}
+	if w.Value.Type != "number" {
+		t.Fatalf("expected inferred numeric value type, got %+v", w.Value)
+	}
+}
+
+func TestConvertModelBackedQuestionWithDashboardFilter(t *testing.T) {
+	input := []byte(`{
+  "name": "Model Dashboard",
+  "parameters": [{
+    "id": "region_param",
+    "slug": "region",
+    "name": "Region",
+    "type": "category",
+    "default": "Europe",
+    "values_source_config": {"values": ["Europe", "APAC"]}
+  }],
+  "x-dac-metabase-source-cards": {
+    "46": {
+      "id": 46,
+      "name": "Sales Summary Model",
+      "type": "model",
+      "display": "table",
+      "dataset_query": {
+        "lib/type": "mbql/query",
+        "database": 2,
+        "stages": [{
+          "lib/type": "mbql.stage/native",
+          "native": "SELECT order_date, region, revenue FROM sales_summary;"
+        }]
+      }
+    }
+  },
+  "dashcards": [{
+    "row": 0,
+    "col": 0,
+    "size_x": 12,
+    "size_y": 6,
+    "parameter_mappings": [{
+      "parameter_id": "region_param",
+      "card_id": 47,
+      "target": ["dimension", ["field", {"base-type": "type/Text"}, "region"]]
+    }],
+    "card": {
+      "id": 47,
+      "name": "Revenue by Region",
+      "display": "bar",
+      "query_type": "query",
+      "dataset_query": {
+        "lib/type": "mbql/query",
+        "database": 2,
+        "stages": [{
+          "lib/type": "mbql.stage/mbql",
+          "source-card": 46,
+          "breakout": [["field", {"base-type": "type/Text"}, "region"]],
+          "aggregation": [["sum", {"lib/uuid": "abc"}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+        }]
+      },
+      "result_metadata": [
+        {"name": "region", "base_type": "type/Text", "source": "breakout"},
+        {"name": "sum", "base_type": "type/Decimal", "source": "aggregation"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["region"],
+        "graph.metrics": ["sum"]
+      }
+    }
+  }]
+}`)
+
+	d, report, err := Convert(input, Options{Connection: "warehouse"})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if len(d.Filters) != 1 {
+		t.Fatalf("expected one dashboard filter, got %d", len(d.Filters))
+	}
+	if d.Filters[0].Name != "region" || d.Filters[0].Type != "select" {
+		t.Fatalf("unexpected filter: %+v", d.Filters[0])
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Type != dashboard.WidgetTypeChart || w.Chart != "bar" {
+		t.Fatalf("expected bar chart, got %+v", w)
+	}
+	for _, want := range []string{
+		"WITH source AS",
+		"SELECT order_date, region, revenue FROM sales_summary",
+		`SUM("revenue") AS "sum"`,
+		`"region" = '{{ filters.region }}'`,
+		"GROUP BY 1",
+	} {
+		if !strings.Contains(w.SQL, want) {
+			t.Fatalf("expected generated SQL to contain %q, got:\n%s", want, w.SQL)
+		}
+	}
+	if strings.Contains(w.SQL, "sales_summary;\n)") {
+		t.Fatalf("expected trailing source SQL terminator to be stripped, got:\n%s", w.SQL)
+	}
+	if report.SQLWidgetCount != 1 || report.PlaceholderCount != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestConvertModelBackedQuestionWithSingleDateDashboardFilter(t *testing.T) {
+	input := []byte(`{
+  "name": "Model Date Dashboard",
+  "parameters": [{
+    "id": "as_of_param",
+    "slug": "as_of_date",
+    "name": "As Of Date",
+    "type": "date/single",
+    "default": "today"
+  }],
+  "x-dac-metabase-source-cards": {
+    "46": {
+      "id": 46,
+      "name": "Sales Summary Model",
+      "type": "model",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "native": "SELECT order_date, revenue FROM sales_summary"
+        }]
+      }
+    }
+  },
+  "dashcards": [{
+    "parameter_mappings": [{
+      "parameter_id": "as_of_param",
+      "card_id": 47,
+      "target": ["dimension", ["field", {"base-type": "type/Date"}, "order_date"]]
+    }],
+    "card": {
+      "id": 47,
+      "name": "Revenue As Of Date",
+      "display": "scalar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "aggregation": [["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+        }]
+      },
+      "result_metadata": [
+        {"name": "sum", "base_type": "type/Decimal"}
+      ]
+    }
+  }]
+}`)
+
+	d, _, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	sql := d.Rows[0].Widgets[0].SQL
+	if !strings.Contains(sql, `"order_date" = '{{ filters.as_of_date }}'`) {
+		t.Fatalf("expected single-date dashboard mapping to use equality, got:\n%s", sql)
+	}
+	if strings.Contains(sql, `"order_date" >=`) {
+		t.Fatalf("expected single-date dashboard mapping not to widen to >=, got:\n%s", sql)
+	}
+}
+
+func TestConvertModelBackedQuestionIgnoresUnscopedDashboardFilterMapping(t *testing.T) {
+	input := []byte(`{
+  "name": "Model Dashboard",
+  "parameters": [{
+    "id": "region_param",
+    "slug": "region",
+    "name": "Region",
+    "type": "category",
+    "default": "Europe"
+  }],
+  "x-dac-metabase-source-cards": {
+    "46": {
+      "id": 46,
+      "name": "Sales Summary Model",
+      "type": "model",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "native": "SELECT region, revenue FROM sales_summary"
+        }]
+      }
+    }
+  },
+  "dashcards": [{
+    "card_id": 47,
+    "parameter_mappings": [{
+      "parameter_id": "region_param",
+      "target": ["dimension", ["field", {"base-type": "type/Text"}, "region"]]
+    }],
+    "card": {
+      "id": 47,
+      "name": "Revenue by Region",
+      "display": "bar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "breakout": [["field", {"base-type": "type/Text"}, "region"]],
+          "aggregation": [["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+        }]
+      },
+      "result_metadata": [
+        {"name": "region", "base_type": "type/Text"},
+        {"name": "sum", "base_type": "type/Decimal"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["region"],
+        "graph.metrics": ["sum"]
+      }
+    }
+  }]
+}`)
+
+	d, _, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if len(d.Filters) != 1 {
+		t.Fatalf("expected dashboard filter to remain visible, got %+v", d.Filters)
+	}
+	if sql := d.Rows[0].Widgets[0].SQL; strings.Contains(sql, "filters.region") {
+		t.Fatalf("expected unscoped Metabase mapping not to apply to widget SQL, got:\n%s", sql)
+	}
+}
+
+func TestConvertModelBackedLineChartOrdersByBreakout(t *testing.T) {
+	input := []byte(`{
+  "name": "Model Trend Dashboard",
+  "x-dac-metabase-source-cards": {
+    "46": {
+      "id": 46,
+      "name": "Sales Summary Model",
+      "type": "model",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "native": "SELECT order_date, region, revenue, profit FROM sales_summary"
+        }]
+      }
+    }
+  },
+  "dashcards": [{
+    "card": {
+      "id": 50,
+      "name": "Revenue Trend",
+      "display": "line",
+      "query_type": "query",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "breakout": [["field", {"base-type": "type/Date"}, "order_date"]],
+          "aggregation": [
+            ["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]],
+            ["sum", {}, ["field", {"base-type": "type/Decimal"}, "profit"]]
+          ]
+        }]
+      },
+      "result_metadata": [
+        {"name": "order_date", "base_type": "type/Date", "source": "breakout"},
+        {"name": "sum", "base_type": "type/Decimal", "source": "aggregation"},
+        {"name": "sum_2", "base_type": "type/Decimal", "source": "aggregation"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["order_date"],
+        "graph.metrics": ["sum", "sum_2"]
+      }
+    }
+  }]
+}`)
+
+	d, report, err := Convert(input, Options{})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := d.Rows[0].Widgets[0]
+	if w.Chart != "line" {
+		t.Fatalf("expected line chart, got %+v", w)
+	}
+	if !strings.Contains(w.SQL, `ORDER BY "order_date" ASC`) {
+		t.Fatalf("expected line chart SQL to order by date breakout, got:\n%s", w.SQL)
+	}
+	if strings.Contains(w.SQL, `ORDER BY "sum" DESC`) {
+		t.Fatalf("expected line chart not to order by aggregate, got:\n%s", w.SQL)
+	}
+	if report.SQLWidgetCount != 1 || report.PlaceholderCount != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestConvertSemanticImportDoesNotInferUnnamedAggregations(t *testing.T) {
+	input := []byte(`{
+  "name": "Semantic Safe Import",
+  "x-dac-metabase-source-cards": {
+    "46": {
+      "id": 46,
+      "name": "Sales Summary Model",
+      "type": "model",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "native": "SELECT region, revenue FROM sales_summary"
+        }]
+      },
+      "result_metadata": [
+        {"name": "region", "base_type": "type/Text"},
+        {"name": "revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  },
+  "dashcards": [{
+    "card": {
+      "id": 47,
+      "name": "Revenue by Region",
+      "display": "bar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "breakout": [["field", {"base-type": "type/Text"}, "region"]],
+          "aggregation": [["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+        }]
+      },
+      "result_metadata": [
+        {"name": "region", "base_type": "type/Text"},
+        {"name": "sum", "base_type": "type/Decimal"}
+      ],
+      "visualization_settings": {
+        "graph.dimensions": ["region"],
+        "graph.metrics": ["sum"]
+      }
+    }
+  }]
+}`)
+
+	project, report, err := ConvertProject(input, Options{Semantic: true})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if report.SemanticModelCount != 1 || len(project.SemanticModels) != 1 {
+		t.Fatalf("expected one generated semantic model, got report=%+v project=%+v", report, project.SemanticModels)
+	}
+	if len(project.SemanticModels[0].Model.Metrics) != 0 {
+		t.Fatalf("expected no inferred DAC metrics, got %+v", project.SemanticModels[0].Model.Metrics)
+	}
+	if report.SemanticWidgetCount != 0 || report.SQLWidgetCount != 1 {
+		t.Fatalf("expected SQL fallback, got report %+v", report)
+	}
+	w := project.Dashboard.Rows[0].Widgets[0]
+	if w.SQL == "" || !strings.Contains(w.SQL, "WITH source AS") {
+		t.Fatalf("expected SQL-backed fallback widget, got %+v", w)
+	}
+	if w.MetricRef != "" || len(w.MetricRefs) > 0 {
+		t.Fatalf("expected no semantic metric refs on fallback widget, got %+v", w)
+	}
+	if !containsWarning(report.Warnings, "unnamed Metabase aggregations") {
+		t.Fatalf("expected warning about unnamed aggregations, got %+v", report.Warnings)
+	}
+
+	_, _, err = ConvertProject(input, Options{Semantic: true, SemanticStrict: true})
+	if err == nil {
+		t.Fatal("expected semantic strict import to fail")
+	}
+	if !strings.Contains(err.Error(), "unnamed Metabase aggregations") {
+		t.Fatalf("expected strict error about unnamed aggregations, got %v", err)
+	}
+}
+
+func TestConvertSemanticImportUsesExplicitMetabaseMetrics(t *testing.T) {
+	input := []byte(`{
+  "name": "Semantic Metric Import",
+  "parameters": [{
+    "id": "region_param",
+    "slug": "region",
+    "name": "Region",
+    "type": "category",
+    "default": "Europe",
+    "values": ["Europe", "APAC"]
+  }, {
+    "id": "as_of_param",
+    "slug": "as_of_date",
+    "name": "As Of Date",
+    "type": "date/single",
+    "default": "today"
+  }],
+  "x-dac-metabase-source-cards": {
+    "46": {
+      "id": 46,
+      "name": "Sales Summary Model",
+      "type": "model",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "native": "SELECT order_date, region, category, status, revenue FROM sales_summary;"
+        }]
+      },
+      "result_metadata": [
+        {"name": "order_date", "base_type": "type/Date"},
+        {"name": "region", "base_type": "type/Text"},
+        {"name": "category", "base_type": "type/Text"},
+        {"name": "status", "base_type": "type/Text"},
+        {"name": "revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  },
+  "x-dac-metabase-metrics": {
+    "200": {
+      "id": 200,
+      "name": "Official Revenue",
+      "type": "metric",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "filter": ["=", ["field", {"base-type": "type/Text"}, "status"], "paid"],
+          "aggregation": [["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+        }]
+      }
+    }
+  },
+  "dashcards": [{
+    "row": 0,
+    "col": 0,
+    "size_x": 12,
+    "size_y": 6,
+    "parameter_mappings": [{
+      "parameter_id": "region_param",
+      "card_id": 47,
+      "target": ["dimension", ["field", {"base-type": "type/Text"}, "region"]]
+    }, {
+      "parameter_id": "as_of_param",
+      "card_id": 47,
+      "target": ["dimension", ["field", {"base-type": "type/Date"}, "order_date"]]
+    }],
+    "card": {
+      "id": 47,
+      "name": "Official Revenue by Category",
+      "display": "bar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "breakout": [["field", {"base-type": "type/Text"}, "category"]],
+          "aggregation": [["metric", 200]]
+        }]
+      }
+    }
+  }]
+}`)
+
+	project, report, err := ConvertProject(input, Options{Semantic: true, Connection: "warehouse"})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if report.SemanticModelCount != 1 || report.SemanticWidgetCount != 1 || report.SQLWidgetCount != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	model := project.SemanticModels[0].Model
+	if model.Name != "sales_summary_model" {
+		t.Fatalf("unexpected semantic model name: %q", model.Name)
+	}
+	if len(model.Metrics) != 1 || model.Metrics[0].Name != "official_revenue" {
+		t.Fatalf("expected explicit metric import, got %+v", model.Metrics)
+	}
+	if model.Metrics[0].Expression != `SUM("revenue")` {
+		t.Fatalf("unexpected metric expression: %q", model.Metrics[0].Expression)
+	}
+	if model.Metrics[0].Filter != `"status" = 'paid'` {
+		t.Fatalf("expected explicit metric filter to be imported, got %q", model.Metrics[0].Filter)
+	}
+	if strings.Contains(model.Source.Table, "sales_summary;\n)") {
+		t.Fatalf("expected trailing source SQL terminator to be stripped, got:\n%s", model.Source.Table)
+	}
+	w := project.Dashboard.Rows[0].Widgets[0]
+	if w.SQL != "" {
+		t.Fatalf("semantic widget should not have inline SQL, got %q", w.SQL)
+	}
+	if w.Model != "sales_summary_model" || w.Dimension != "category" {
+		t.Fatalf("unexpected semantic widget model/dimension: %+v", w)
+	}
+	if len(w.MetricRefs) != 1 || w.MetricRefs[0] != "official_revenue" {
+		t.Fatalf("unexpected semantic metric refs: %+v", w.MetricRefs)
+	}
+	if len(w.Filters) != 2 || w.Filters[0].Dimension != "region" || w.Filters[0].Operator != "equals" {
+		t.Fatalf("expected semantic dashboard filter mapping, got %+v", w.Filters)
+	}
+	if w.Filters[1].Dimension != "order_date" || w.Filters[1].Operator != "equals" {
+		t.Fatalf("expected semantic single-date filter to use equality, got %+v", w.Filters)
+	}
+	if err := dashboard.Validate(project.Dashboard); err != nil {
+		t.Fatalf("generated semantic dashboard should validate: %v", err)
+	}
+}
+
+func TestConvertSemanticImportIgnoresUnscopedDashboardFilterMapping(t *testing.T) {
+	input := []byte(`{
+  "name": "Semantic Metric Import",
+  "parameters": [{
+    "id": "region_param",
+    "slug": "region",
+    "name": "Region",
+    "type": "category",
+    "default": "Europe"
+  }],
+  "x-dac-metabase-source-cards": {
+    "46": {
+      "id": 46,
+      "name": "Sales Summary Model",
+      "type": "model",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "native": "SELECT region, category, revenue FROM sales_summary"
+        }]
+      },
+      "result_metadata": [
+        {"name": "region", "base_type": "type/Text"},
+        {"name": "category", "base_type": "type/Text"},
+        {"name": "revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  },
+  "x-dac-metabase-metrics": {
+    "200": {
+      "id": 200,
+      "name": "Official Revenue",
+      "type": "metric",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "aggregation": [["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+        }]
+      }
+    }
+  },
+  "dashcards": [{
+    "card_id": 47,
+    "parameter_mappings": [{
+      "parameter_id": "region_param",
+      "target": ["dimension", ["field", {"base-type": "type/Text"}, "region"]]
+    }],
+    "card": {
+      "id": 47,
+      "name": "Official Revenue by Category",
+      "display": "bar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "breakout": [["field", {"base-type": "type/Text"}, "category"]],
+          "aggregation": [["metric", 200]]
+        }]
+      }
+    }
+  }]
+}`)
+
+	project, _, err := ConvertProject(input, Options{Semantic: true})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	w := project.Dashboard.Rows[0].Widgets[0]
+	if w.Model == "" || len(w.MetricRefs) != 1 {
+		t.Fatalf("expected semantic widget conversion, got %+v", w)
+	}
+	if len(w.Filters) != 0 {
+		t.Fatalf("expected unscoped Metabase mapping not to apply to semantic widget, got %+v", w.Filters)
+	}
+}
+
+func TestConvertSemanticImportIgnoresUnreferencedMetabaseInventory(t *testing.T) {
+	input := []byte(`{
+  "name": "Semantic Metric Import",
+  "models": {
+    "99": {
+      "id": 99,
+      "name": "Unrelated Metabase Model",
+      "type": "model"
+    }
+  },
+  "metrics": {
+    "100": {
+      "id": 100,
+      "name": "Unrelated Metabase Metric",
+      "type": "metric",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 99,
+          "aggregation": [["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+        }]
+      }
+    }
+  },
+  "x-dac-metabase-source-cards": {
+    "46": {
+      "id": 46,
+      "name": "Sales Summary Model",
+      "type": "model",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "native": "SELECT category, revenue FROM sales_summary"
+        }]
+      },
+      "result_metadata": [
+        {"name": "category", "base_type": "type/Text"},
+        {"name": "revenue", "base_type": "type/Decimal"}
+      ]
+    }
+  },
+  "x-dac-metabase-metrics": {
+    "200": {
+      "id": 200,
+      "name": "Official Revenue",
+      "type": "metric",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "aggregation": [["sum", {}, ["field", {"base-type": "type/Decimal"}, "revenue"]]]
+        }]
+      }
+    }
+  },
+  "dashcards": [{
+    "card": {
+      "id": 47,
+      "name": "Official Revenue by Category",
+      "display": "bar",
+      "dataset_query": {
+        "database": 2,
+        "stages": [{
+          "source-card": 46,
+          "breakout": [["field", {"base-type": "type/Text"}, "category"]],
+          "aggregation": [["metric", 200]]
+        }]
+      }
+    }
+  }]
+}`)
+
+	_, report, err := ConvertProject(input, Options{Semantic: true})
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if report.SemanticModelCount != 1 || report.SemanticWidgetCount != 1 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if containsWarning(report.Warnings, "Unrelated Metabase") {
+		t.Fatalf("expected unreferenced Metabase inventory to be ignored, got warnings %+v", report.Warnings)
+	}
+}
+
+func TestConvertStrictUnsupportedMBQLFails(t *testing.T) {
+	input := []byte(`{
+  "name": "Query Builder Dashboard",
+  "ordered_cards": [{
+    "card": {
+      "name": "Built with GUI",
+      "display": "bar",
+      "dataset_query": {"type": "query", "query": {"source-table": 1}}
+    }
+  }]
+}`)
+
+	_, _, err := Convert(input, Options{Strict: true})
+	if err == nil {
+		t.Fatal("expected strict conversion to fail")
+	}
+	if !strings.Contains(err.Error(), "Built with GUI") {
+		t.Fatalf("expected card name in error, got %v", err)
+	}
+}
+
+func containsWarning(warnings []string, needle string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/importer/metabase/semantic.go
+++ b/pkg/importer/metabase/semantic.go
@@ -1,0 +1,824 @@
+package metabase
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/bruin-data/dac/pkg/dashboard"
+	sem "github.com/bruin-data/dac/pkg/semantic"
+	"github.com/bruin-data/dac/schemas"
+)
+
+type Project struct {
+	Dashboard      *dashboard.Dashboard
+	SemanticModels []SemanticModelFile
+}
+
+type SemanticModelFile struct {
+	Filename string
+	Model    *sem.Model
+}
+
+type semanticInventory struct {
+	Files    []SemanticModelFile
+	Models   map[string]*semanticModelInfo
+	Metrics  map[string]semanticMetricInfo
+	Warnings []string
+}
+
+type semanticModelInfo struct {
+	ID         string
+	Name       string
+	Model      *sem.Model
+	FieldNames map[string]string
+	FieldTypes map[string]string
+}
+
+type semanticMetricInfo struct {
+	ID        string
+	Name      string
+	ModelID   string
+	ModelName string
+}
+
+func collectSemanticInventory(root, dashboardRoot map[string]any, modelSQL map[string]string) semanticInventory {
+	inventory := semanticInventory{
+		Models:  map[string]*semanticModelInfo{},
+		Metrics: map[string]semanticMetricInfo{},
+	}
+
+	seenModelNames := map[string]bool{}
+	for _, card := range collectSemanticModelCards(root, dashboardRoot) {
+		id := firstString(card, "id")
+		if id == "" {
+			continue
+		}
+		sql := modelSQL[id]
+		if strings.TrimSpace(sql) == "" {
+			inventory.Warnings = append(inventory.Warnings, fmt.Sprintf("Metabase model %q was not imported into DAC semantic models because its source SQL was unavailable", cardDisplayName(card, id)))
+			continue
+		}
+
+		modelName := uniqueSemanticName(normalizeName(cardDisplayName(card, id)), seenModelNames)
+		model := &sem.Model{
+			Schema:      schemas.SemanticModelV1ID,
+			Name:        modelName,
+			Label:       cardDisplayName(card, id),
+			Description: firstString(card, "description"),
+			Source: sem.Source{
+				Table: "(\n" + trimSQLTerminator(sql) + "\n) AS " + quoteIdent(modelName),
+			},
+		}
+		info := &semanticModelInfo{
+			ID:         id,
+			Name:       modelName,
+			Model:      model,
+			FieldNames: map[string]string{},
+			FieldTypes: map[string]string{},
+		}
+
+		seenFieldNames := map[string]bool{}
+		for i, col := range resultColumns(card) {
+			baseName := normalizeName(col.Name)
+			if baseName == "" {
+				baseName = fmt.Sprintf("dimension_%d", i+1)
+			}
+			dimName := uniqueSemanticName(baseName, seenFieldNames)
+			dimType := semanticDimensionType(col.Type)
+			dim := sem.Dimension{
+				Name:       dimName,
+				Label:      titleFromName(col.Name),
+				Type:       dimType,
+				Expression: quoteIdent(col.Name),
+			}
+			if dimType == "time" {
+				dim.Granularities = semanticTimeGranularities(col.Name)
+			}
+			model.Dimensions = append(model.Dimensions, dim)
+			info.FieldNames[col.Name] = dimName
+			info.FieldNames[normalizeName(col.Name)] = dimName
+			info.FieldTypes[dimName] = dimType
+		}
+
+		inventory.Models[id] = info
+		inventory.Files = append(inventory.Files, SemanticModelFile{
+			Filename: modelName + ".yml",
+			Model:    model,
+		})
+	}
+
+	for _, card := range collectSemanticMetricCards(root, dashboardRoot) {
+		id := firstString(card, "id")
+		if id == "" {
+			continue
+		}
+		stage, dataset, ok := firstQueryStage(card)
+		if !ok {
+			inventory.Warnings = append(inventory.Warnings, fmt.Sprintf("Metabase metric %q was not imported because its query stage was unavailable", cardDisplayName(card, id)))
+			continue
+		}
+		sourceID := sourceCardID(stage)
+		if sourceID == "" {
+			sourceID = sourceCardID(dataset)
+		}
+		modelInfo := inventory.Models[sourceID]
+		if modelInfo == nil {
+			inventory.Warnings = append(inventory.Warnings, fmt.Sprintf("Metabase metric %q was not imported because it is not based on an imported Metabase model", cardDisplayName(card, id)))
+			continue
+		}
+		expr, ok := semanticMetricExpression(stage["aggregation"])
+		if !ok {
+			inventory.Warnings = append(inventory.Warnings, fmt.Sprintf("Metabase metric %q was not imported because its aggregation is unsupported", cardDisplayName(card, id)))
+			continue
+		}
+		filterClauses, ok := mbqlFilterClauses(stage["filter"])
+		if !ok {
+			inventory.Warnings = append(inventory.Warnings, fmt.Sprintf("Metabase metric %q was not imported because its filter is unsupported", cardDisplayName(card, id)))
+			continue
+		}
+		seenNames := semanticModelUsedNames(modelInfo.Model)
+		metricName := uniqueSemanticName(normalizeName(cardDisplayName(card, id)), seenNames)
+		modelInfo.Model.Metrics = append(modelInfo.Model.Metrics, sem.Metric{
+			Name:        metricName,
+			Label:       cardDisplayName(card, id),
+			Description: firstString(card, "description"),
+			Expression:  expr,
+			Filter:      strings.Join(filterClauses, " AND "),
+		})
+		inventory.Metrics[id] = semanticMetricInfo{
+			ID:        id,
+			Name:      metricName,
+			ModelID:   sourceID,
+			ModelName: modelInfo.Name,
+		}
+	}
+
+	sort.Slice(inventory.Files, func(i, j int) bool {
+		return inventory.Files[i].Filename < inventory.Files[j].Filename
+	})
+	return inventory
+}
+
+func semanticWidgetForCard(cardRoot, card map[string]any, name, display string, _ map[string]any, ctx conversionContext) (dashboard.Widget, []string, bool, bool, string, error) {
+	stage, dataset, ok := firstQueryStage(card)
+	if !ok {
+		return dashboard.Widget{}, nil, false, false, "", nil
+	}
+	sourceID := sourceCardID(stage)
+	if sourceID == "" {
+		sourceID = sourceCardID(dataset)
+	}
+	if sourceID == "" {
+		return dashboard.Widget{}, nil, false, false, "", nil
+	}
+
+	modelInfo := ctx.semanticModels[sourceID]
+	if modelInfo == nil {
+		return dashboard.Widget{}, nil, false, true, fmt.Sprintf("source card %s is not an explicit imported Metabase model", sourceID), nil
+	}
+
+	breakouts, ok, reason := semanticDimensionRefs(stage["breakout"], modelInfo)
+	if !ok {
+		return dashboard.Widget{}, nil, false, true, reason, nil
+	}
+	metrics, ok, reason := semanticMetricRefs(stage["aggregation"], modelInfo, ctx)
+	if !ok {
+		return dashboard.Widget{}, nil, false, true, reason, nil
+	}
+	filters, ok, reason := semanticFiltersForCard(cardRoot, stage, modelInfo, ctx)
+	if !ok {
+		return dashboard.Widget{}, nil, false, true, reason, nil
+	}
+
+	chart := chartType(display)
+	limit := intField(stage, 0, "limit")
+	switch display {
+	case "scalar", "smartscalar":
+		if len(metrics) != 1 {
+			return dashboard.Widget{}, nil, false, true, "scalar cards require exactly one explicit Metabase metric", nil
+		}
+		return dashboard.Widget{
+			Name:      name,
+			Type:      dashboard.WidgetTypeMetric,
+			Col:       defaultWidthForDisplay(display),
+			Model:     modelInfo.Name,
+			MetricRef: metrics[0],
+			Filters:   filters,
+			Value:     &dashboard.ValueEncoding{Field: metrics[0], Type: "number"},
+		}, nil, true, true, "", nil
+
+	case "line", "area", "bar", "row", "combo":
+		if len(breakouts) != 1 {
+			return dashboard.Widget{}, nil, false, true, fmt.Sprintf("%s charts require exactly one semantic dimension", chart), nil
+		}
+		if len(metrics) == 0 {
+			return dashboard.Widget{}, nil, false, true, fmt.Sprintf("%s charts require at least one explicit Metabase metric", chart), nil
+		}
+		widget := dashboard.Widget{
+			Name:        name,
+			Type:        dashboard.WidgetTypeChart,
+			Chart:       chart,
+			Col:         defaultWidthForDisplay(display),
+			Model:       modelInfo.Name,
+			Dimension:   breakouts[0].Name,
+			Granularity: breakouts[0].Granularity,
+			MetricRefs:  metrics,
+			Filters:     filters,
+			Sort:        semanticSort(display, breakouts[0].Name, metrics),
+			Limit:       limit,
+		}
+		if display == "row" {
+			widget.Horizontal = true
+		}
+		if display == "combo" && len(metrics) > 1 {
+			widget.Lines = []string{metrics[len(metrics)-1]}
+		}
+		return widget, nil, true, true, "", nil
+
+	case "pie", "funnel", "treemap":
+		if len(breakouts) != 1 {
+			return dashboard.Widget{}, nil, false, true, fmt.Sprintf("%s charts require exactly one semantic dimension", display), nil
+		}
+		if len(metrics) != 1 {
+			return dashboard.Widget{}, nil, false, true, fmt.Sprintf("%s charts require exactly one explicit Metabase metric", display), nil
+		}
+		return dashboard.Widget{
+			Name:        name,
+			Type:        dashboard.WidgetTypeChart,
+			Chart:       display,
+			Col:         defaultWidthForDisplay(display),
+			Model:       modelInfo.Name,
+			Dimension:   breakouts[0].Name,
+			Granularity: breakouts[0].Granularity,
+			MetricRefs:  metrics,
+			Filters:     filters,
+			Sort:        semanticSort(display, breakouts[0].Name, metrics),
+			Limit:       limit,
+			Label:       breakouts[0].Name,
+			Value:       &dashboard.ValueEncoding{Field: metrics[0], Type: "number"},
+		}, nil, true, true, "", nil
+
+	case "table", "object", "pivot", "map":
+		if len(metrics) == 0 {
+			return dashboard.Widget{}, nil, false, true, "detail-row tables are left SQL-backed because DAC semantic queries aggregate by dimensions", nil
+		}
+		widget := dashboard.Widget{
+			Name:       name,
+			Type:       dashboard.WidgetTypeTable,
+			Col:        12,
+			Model:      modelInfo.Name,
+			Dimensions: breakouts,
+			MetricRefs: metrics,
+			Filters:    filters,
+			Limit:      limit,
+		}
+		widget.Columns = semanticTableColumns(widget.Dimensions, widget.MetricRefs, modelInfo)
+		return widget, nil, true, true, "", nil
+
+	default:
+		if display == "" {
+			return dashboard.Widget{}, nil, false, true, "missing Metabase display type", nil
+		}
+		return dashboard.Widget{}, nil, false, true, fmt.Sprintf("display type %q is not supported by semantic import", display), nil
+	}
+}
+
+func firstQueryStage(card map[string]any) (map[string]any, map[string]any, bool) {
+	dataset, ok := mapField(card, "dataset_query", "dataset-query")
+	if !ok {
+		return nil, nil, false
+	}
+	stages := mapList(dataset, "stages")
+	if len(stages) == 0 {
+		if query, ok := mapField(dataset, "query"); ok {
+			stages = []map[string]any{query}
+		}
+	}
+	if len(stages) == 0 {
+		return nil, dataset, false
+	}
+	return stages[0], dataset, true
+}
+
+func semanticDimensionRefs(raw any, modelInfo *semanticModelInfo) ([]dashboard.SemanticDimensionRef, bool, string) {
+	list, ok := raw.([]any)
+	if !ok || len(list) == 0 {
+		return nil, true, ""
+	}
+	out := make([]dashboard.SemanticDimensionRef, 0, len(list))
+	for _, item := range list {
+		name := fieldRefName(item)
+		if name == "" {
+			return nil, false, "uses a breakout that is not a field reference"
+		}
+		dim := modelInfo.FieldNames[name]
+		if dim == "" {
+			dim = modelInfo.FieldNames[normalizeName(name)]
+		}
+		if dim == "" {
+			return nil, false, fmt.Sprintf("breakout field %q is not present on Metabase model %q", name, modelInfo.Name)
+		}
+		ref := dashboard.SemanticDimensionRef{Name: dim}
+		if modelInfo.FieldTypes[dim] == "time" {
+			ref.Granularity = metabaseTemporalGranularity(item)
+		}
+		out = append(out, ref)
+	}
+	return out, true, ""
+}
+
+func semanticMetricRefs(raw any, modelInfo *semanticModelInfo, ctx conversionContext) ([]string, bool, string) {
+	list, ok := raw.([]any)
+	if !ok || len(list) == 0 {
+		return nil, true, ""
+	}
+	metrics := make([]string, 0, len(list))
+	for _, item := range list {
+		id := metricAggregationID(item)
+		if id == "" {
+			if aggregationLooksSupported(item) {
+				return nil, false, "uses unnamed Metabase aggregations; leaving SQL-backed instead of inventing DAC metric names"
+			}
+			return nil, false, "uses unsupported Metabase aggregations"
+		}
+		metric := ctx.semanticMetrics[id]
+		if metric.Name == "" {
+			return nil, false, fmt.Sprintf("references Metabase metric %s, but that metric was not imported", id)
+		}
+		if metric.ModelID != modelInfo.ID {
+			return nil, false, fmt.Sprintf("references Metabase metric %s from a different Metabase model", id)
+		}
+		metrics = append(metrics, metric.Name)
+	}
+	return metrics, true, ""
+}
+
+func semanticFiltersForCard(cardRoot, stage map[string]any, modelInfo *semanticModelInfo, ctx conversionContext) ([]dashboard.SemanticQueryFilter, bool, string) {
+	stageFilters, ok, reason := mbqlSemanticFilters(stage["filter"], modelInfo)
+	if !ok {
+		return nil, false, reason
+	}
+	dashboardFilters, ok, reason := dashboardSemanticFilters(cardRoot, modelInfo, ctx)
+	if !ok {
+		return nil, false, reason
+	}
+	return append(stageFilters, dashboardFilters...), true, ""
+}
+
+func mbqlSemanticFilters(raw any, modelInfo *semanticModelInfo) ([]dashboard.SemanticQueryFilter, bool, string) {
+	if raw == nil {
+		return nil, true, ""
+	}
+	parts, ok := raw.([]any)
+	if !ok || len(parts) == 0 {
+		return nil, false, "uses unsupported MBQL filters"
+	}
+	op, _ := parts[0].(string)
+	if op == "and" {
+		var filters []dashboard.SemanticQueryFilter
+		for _, child := range parts[1:] {
+			childFilters, ok, reason := mbqlSemanticFilters(child, modelInfo)
+			if !ok {
+				return nil, false, reason
+			}
+			filters = append(filters, childFilters...)
+		}
+		return filters, true, ""
+	}
+	if op == "is-null" || op == "not-null" {
+		if len(parts) < 2 {
+			return nil, false, "uses malformed MBQL null filters"
+		}
+		dim, ok := semanticDimensionName(parts[1], modelInfo)
+		if !ok {
+			return nil, false, "uses an MBQL filter field that is not present on the Metabase model"
+		}
+		operator := "is_null"
+		if op == "not-null" {
+			operator = "is_not_null"
+		}
+		return []dashboard.SemanticQueryFilter{{Dimension: dim, Operator: operator}}, true, ""
+	}
+	if len(parts) < 3 {
+		return nil, false, "uses malformed MBQL filters"
+	}
+	dim, ok := semanticDimensionName(parts[1], modelInfo)
+	if !ok {
+		return nil, false, "uses an MBQL filter field that is not present on the Metabase model"
+	}
+	operator := mapSemanticFilterOperator(op)
+	if operator == "" {
+		return nil, false, fmt.Sprintf("uses unsupported MBQL filter operator %q", op)
+	}
+	return []dashboard.SemanticQueryFilter{{
+		Dimension: dim,
+		Operator:  operator,
+		Value:     parts[2],
+	}}, true, ""
+}
+
+func dashboardSemanticFilters(cardRoot map[string]any, modelInfo *semanticModelInfo, ctx conversionContext) ([]dashboard.SemanticQueryFilter, bool, string) {
+	var filters []dashboard.SemanticQueryFilter
+	for _, mapping := range mapList(cardRoot, "parameter_mappings", "parameter-mappings") {
+		if !parameterMappingAppliesToCard(mapping, cardRoot) {
+			continue
+		}
+		filter, ok := filterForParameterMapping(mapping, ctx)
+		if !ok {
+			continue
+		}
+		field := targetFieldName(mapping["target"])
+		if field == "" {
+			return nil, false, fmt.Sprintf("dashboard filter %q is mapped to an unsupported target", filter.Name)
+		}
+		dim := modelInfo.FieldNames[field]
+		if dim == "" {
+			dim = modelInfo.FieldNames[normalizeName(field)]
+		}
+		if dim == "" {
+			return nil, false, fmt.Sprintf("dashboard filter %q targets field %q, which is not present on Metabase model %q", filter.Name, field, modelInfo.Name)
+		}
+		filters = append(filters, semanticFilterFromDashboardFilter(dim, filter))
+	}
+	return filters, true, ""
+}
+
+func semanticFilterFromDashboardFilter(dim string, filter dashboard.Filter) dashboard.SemanticQueryFilter {
+	name := filter.Name
+	switch filter.Type {
+	case "date-range":
+		return dashboard.SemanticQueryFilter{
+			Dimension: dim,
+			Operator:  "between",
+			Value: map[string]interface{}{
+				"start": "{{ filters." + name + ".start }}",
+				"end":   "{{ filters." + name + ".end }}",
+			},
+		}
+	case "date":
+		return dashboard.SemanticQueryFilter{Dimension: dim, Operator: "equals", Value: "{{ filters." + name + " }}"}
+	case "number":
+		return dashboard.SemanticQueryFilter{Dimension: dim, Operator: "equals", Value: "{{ filters." + name + " }}"}
+	case "select", "text":
+		if filter.Multiple {
+			return dashboard.SemanticQueryFilter{
+				Expression: "{" + dim + "} IN ('{{ filters." + name + " | join(\"','\") }}')",
+			}
+		}
+		return dashboard.SemanticQueryFilter{Dimension: dim, Operator: "equals", Value: "{{ filters." + name + " }}"}
+	default:
+		return dashboard.SemanticQueryFilter{Dimension: dim, Operator: "equals", Value: "{{ filters." + name + " }}"}
+	}
+}
+
+func semanticMetricExpression(raw any) (string, bool) {
+	list, ok := raw.([]any)
+	if !ok || len(list) != 1 {
+		return "", false
+	}
+	parts, ok := list[0].([]any)
+	if !ok || len(parts) == 0 {
+		return "", false
+	}
+	fn, _ := parts[0].(string)
+	field := ""
+	for _, part := range parts[1:] {
+		if name := fieldRefName(part); name != "" {
+			field = name
+			break
+		}
+	}
+	switch fn {
+	case "count":
+		if field == "" {
+			return "COUNT(*)", true
+		}
+		return "COUNT(" + quoteIdent(field) + ")", true
+	case "sum", "avg", "min", "max":
+		if field == "" {
+			return "", false
+		}
+		return strings.ToUpper(fn) + "(" + quoteIdent(field) + ")", true
+	case "distinct", "count-distinct":
+		if field == "" {
+			return "", false
+		}
+		return "COUNT(DISTINCT " + quoteIdent(field) + ")", true
+	default:
+		return "", false
+	}
+}
+
+func metricAggregationID(raw any) string {
+	switch item := raw.(type) {
+	case []any:
+		if len(item) == 0 {
+			return ""
+		}
+		fn, _ := item[0].(string)
+		if fn != "metric" {
+			return ""
+		}
+		for _, part := range item[1:] {
+			if id := metricIDValue(part); id != "" {
+				return id
+			}
+		}
+	case map[string]any:
+		if id := firstString(item, "metric_id", "metric-id", "id"); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func metricIDValue(raw any) string {
+	switch v := raw.(type) {
+	case string:
+		return strings.TrimSpace(strings.TrimPrefix(v, "metric__"))
+	case float64:
+		return strconv.FormatInt(int64(v), 10)
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case map[string]any:
+		return firstString(v, "metric_id", "metric-id", "id")
+	default:
+		return ""
+	}
+}
+
+func aggregationLooksSupported(raw any) bool {
+	parts, ok := raw.([]any)
+	if !ok || len(parts) == 0 {
+		return false
+	}
+	fn, _ := parts[0].(string)
+	switch fn {
+	case "count", "sum", "avg", "min", "max", "distinct", "count-distinct":
+		return true
+	default:
+		return false
+	}
+}
+
+func semanticDimensionName(raw any, modelInfo *semanticModelInfo) (string, bool) {
+	name := fieldRefName(raw)
+	if name == "" {
+		return "", false
+	}
+	dim := modelInfo.FieldNames[name]
+	if dim == "" {
+		dim = modelInfo.FieldNames[normalizeName(name)]
+	}
+	return dim, dim != ""
+}
+
+func mapSemanticFilterOperator(op string) string {
+	switch op {
+	case "=":
+		return "equals"
+	case "!=":
+		return "not_equals"
+	case "<":
+		return "lt"
+	case "<=":
+		return "lte"
+	case ">":
+		return "gt"
+	case ">=":
+		return "gte"
+	default:
+		return ""
+	}
+}
+
+func semanticSort(display, dimension string, metrics []string) []dashboard.SemanticSort {
+	if dimension != "" && chronologicalDisplay(display) {
+		return []dashboard.SemanticSort{{Name: dimension, Direction: "asc"}}
+	}
+	if len(metrics) > 0 {
+		return []dashboard.SemanticSort{{Name: metrics[0], Direction: "desc"}}
+	}
+	return nil
+}
+
+func semanticTableColumns(dimensions []dashboard.SemanticDimensionRef, metrics []string, modelInfo *semanticModelInfo) []dashboard.TableColumn {
+	names := make([]string, 0, len(dimensions)+len(metrics))
+	for _, dim := range dimensions {
+		names = append(names, dim.Name)
+	}
+	names = append(names, metrics...)
+	if len(names) == 0 {
+		for _, dim := range modelInfo.Model.Dimensions {
+			names = append(names, dim.Name)
+		}
+	}
+	out := make([]dashboard.TableColumn, 0, len(names))
+	for _, name := range names {
+		out = append(out, dashboard.TableColumn{Name: name, Label: titleFromName(name)})
+	}
+	return out
+}
+
+func collectSemanticModelCards(root, dashboardRoot map[string]any) []map[string]any {
+	var cards []map[string]any
+	add := func(card map[string]any) {
+		if firstString(card, "type") != "model" {
+			return
+		}
+		cards = append(cards, card)
+	}
+	collectMetabaseCards(root, dashboardRoot, []string{"x-dac-metabase-source-cards", "source_cards", "source-cards"}, add)
+	for _, dashcard := range extractCards(dashboardRoot) {
+		if card, ok := mapField(dashcard, "card", "question"); ok {
+			add(card)
+		}
+	}
+	return dedupeCards(cards)
+}
+
+func collectSemanticMetricCards(root, dashboardRoot map[string]any) []map[string]any {
+	var cards []map[string]any
+	addAny := func(card map[string]any) {
+		cards = append(cards, card)
+	}
+	collectMetabaseCards(root, dashboardRoot, []string{"x-dac-metabase-metrics", "metric_cards", "metric-cards"}, addAny)
+
+	addTyped := func(card map[string]any) {
+		if firstString(card, "type") == "metric" {
+			cards = append(cards, card)
+		}
+	}
+	collectMetabaseCards(root, dashboardRoot, []string{"x-dac-metabase-source-cards", "source_cards", "source-cards"}, addTyped)
+	for _, dashcard := range extractCards(dashboardRoot) {
+		if card, ok := mapField(dashcard, "card", "question"); ok {
+			addTyped(card)
+		}
+	}
+	return dedupeCards(cards)
+}
+
+func collectMetabaseCards(root, dashboardRoot map[string]any, keys []string, add func(map[string]any)) {
+	for _, source := range []map[string]any{root, dashboardRoot} {
+		for _, key := range keys {
+			if sourceCards, ok := mapField(source, key); ok {
+				ids := make([]string, 0, len(sourceCards))
+				for id := range sourceCards {
+					ids = append(ids, id)
+				}
+				sort.Strings(ids)
+				for _, id := range ids {
+					if card, ok := sourceCards[id].(map[string]any); ok {
+						add(card)
+					}
+				}
+			}
+			for _, card := range mapList(source, key) {
+				add(card)
+			}
+		}
+	}
+}
+
+func dedupeCards(cards []map[string]any) []map[string]any {
+	seen := map[string]bool{}
+	out := make([]map[string]any, 0, len(cards))
+	for _, card := range cards {
+		id := firstString(card, "id")
+		key := id
+		if key == "" {
+			key = cardDisplayName(card, "")
+		}
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, card)
+	}
+	return out
+}
+
+func cardDisplayName(card map[string]any, fallback string) string {
+	name := firstString(card, "name", "display_name", "display-name", "title")
+	if name != "" {
+		return name
+	}
+	if fallback != "" {
+		return "metabase_" + fallback
+	}
+	return "metabase"
+}
+
+func semanticDimensionType(sourceType string) string {
+	switch {
+	case isDateType(sourceType):
+		return "time"
+	case isNumericType(sourceType):
+		return "number"
+	case strings.Contains(strings.ToLower(sourceType), "bool"):
+		return "boolean"
+	default:
+		return "string"
+	}
+}
+
+func semanticTimeGranularities(field string) map[string]string {
+	expr := quoteIdent(field)
+	return map[string]string{
+		"day":     "date_trunc('day', " + expr + ")",
+		"week":    "date_trunc('week', " + expr + ")",
+		"month":   "date_trunc('month', " + expr + ")",
+		"quarter": "date_trunc('quarter', " + expr + ")",
+		"year":    "date_trunc('year', " + expr + ")",
+	}
+}
+
+func metabaseTemporalGranularity(raw any) string {
+	grain := ""
+	var walk func(any)
+	walk = func(v any) {
+		if grain != "" {
+			return
+		}
+		switch x := v.(type) {
+		case map[string]any:
+			for _, key := range []string{"temporal-unit", "temporal_unit", "unit"} {
+				if s, ok := x[key].(string); ok {
+					grain = normalizeTemporalGranularity(s)
+					if grain != "" {
+						return
+					}
+				}
+			}
+			for _, value := range x {
+				walk(value)
+			}
+		case []any:
+			for _, item := range x {
+				walk(item)
+			}
+		}
+	}
+	walk(raw)
+	return grain
+}
+
+func normalizeTemporalGranularity(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "day", "date":
+		return "day"
+	case "week":
+		return "week"
+	case "month":
+		return "month"
+	case "quarter":
+		return "quarter"
+	case "year":
+		return "year"
+	default:
+		return ""
+	}
+}
+
+func uniqueSemanticName(base string, seen map[string]bool) string {
+	if base == "" {
+		base = "metabase"
+	}
+	name := base
+	for i := 2; seen[name]; i++ {
+		name = fmt.Sprintf("%s_%d", base, i)
+	}
+	seen[name] = true
+	return name
+}
+
+func semanticModelUsedNames(model *sem.Model) map[string]bool {
+	seen := map[string]bool{}
+	for _, dim := range model.Dimensions {
+		seen[dim.Name] = true
+	}
+	for _, metric := range model.Metrics {
+		seen[metric.Name] = true
+	}
+	for _, segment := range model.Segments {
+		seen[segment.Name] = true
+	}
+	return seen
+}
+
+func attachSemanticModels(d *dashboard.Dashboard, files []SemanticModelFile) {
+	if len(files) == 0 {
+		return
+	}
+	models := make(map[string]*sem.Model, len(files))
+	for _, file := range files {
+		if file.Model != nil {
+			models[file.Model.Name] = file.Model
+		}
+	}
+	d.SetProjectContext("", models, map[string]error{})
+}


### PR DESCRIPTION
## Summary

Adds `dac import metabase` for saved and live Metabase dashboard imports, including native SQL/MBQL conversion, optional semantic model and metric generation, command wiring, tests, and docs.

## Testing

- [x] `make test`
- [x] `make build`
- [ ] relevant example or manual smoke test

## Checklist

- [x] scanned `docs/` and updated (or added) the relevant pages
- [ ] examples updated if the authoring model changed
- [ ] screenshots or recordings attached for UI changes
