### PR TITLE
Notify when a newer bundled skill is available

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -47,6 +47,7 @@ func serveCmd() *cli.Command {
 			if err != nil {
 				return err
 			}
+			printSkillUpdateNotices(dir)
 			configFile := resolveConfigOptional(cmd, dir)
 
 			srv, err := server.New(server.Config{

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -2,6 +2,7 @@
 name: create-dashboard
 description: Create DAC dashboards by writing YAML or TSX dashboard definition files. Use when the user wants to create, modify, review, or understand DAC dashboards, widgets, filters, SQL queries, semantic models, or CLI validation workflows.
 argument-hint: "[dashboard request]"
+version: 1
 ---
 
 # Create Dashboard

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -240,6 +241,83 @@ func selectSkills(names []string) ([]bundledSkill, error) {
 		seen[name] = true
 	}
 	return selected, nil
+}
+
+// skillUpdateNotices returns one-line notices for installed skills whose
+// bundled version is newer than the copy in the project. startDir is the
+// dashboard directory; the project root (the nearest ancestor containing a
+// .claude directory) is discovered by walking upward. Skills that are not
+// installed produce no notice — there is nothing to update.
+func skillUpdateNotices(startDir string) []string {
+	root, ok := findProjectRoot(startDir)
+	if !ok {
+		return nil
+	}
+
+	var notices []string
+	for _, skill := range dacSkills {
+		installedPath := filepath.Join(root, filepath.FromSlash(skill.ClaudePath))
+		data, err := os.ReadFile(installedPath)
+		if err != nil {
+			continue
+		}
+		if parseSkillVersion(skill.Content) > parseSkillVersion(string(data)) {
+			notices = append(notices, fmt.Sprintf("A newer %s skill is available with the latest authoring features and fixes.\nRun `dac skills update` to update your project's copy.", skill.Name))
+		}
+	}
+	return notices
+}
+
+// printSkillUpdateNotices writes skill staleness notices to stderr so they
+// stay out of any machine-readable stdout.
+func printSkillUpdateNotices(startDir string) {
+	for _, notice := range skillUpdateNotices(startDir) {
+		fmt.Fprintln(os.Stderr, notice)
+	}
+}
+
+// findProjectRoot walks upward from startDir looking for the nearest ancestor
+// that contains a .claude directory (where bundled skills are installed).
+func findProjectRoot(startDir string) (string, bool) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", false
+	}
+	for {
+		if info, err := os.Stat(filepath.Join(dir, ".claude")); err == nil && info.IsDir() {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// parseSkillVersion reads the integer "version" field from a skill's YAML
+// frontmatter. Skills without a version field (older installs) report 0.
+func parseSkillVersion(content string) int {
+	trimmed := strings.TrimLeft(content, "\uFEFF \t\r\n")
+	if !strings.HasPrefix(trimmed, "---") {
+		return 0
+	}
+	frontmatter, _, found := strings.Cut(trimmed[len("---"):], "\n---")
+	if !found {
+		return 0
+	}
+	for line := range strings.SplitSeq(frontmatter, "\n") {
+		value, ok := strings.CutPrefix(strings.TrimSpace(line), "version:")
+		if !ok {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return 0
 }
 
 func symlinkPointsTo(linkPath, targetPath string) bool {

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -43,10 +43,11 @@ var skillsDirFlag = &cli.StringFlag{
 func skillsCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "skills",
-		Usage: "List and install DAC agent skills",
+		Usage: "List, install, and update DAC agent skills",
 		Commands: []*cli.Command{
 			skillsListCmd(),
 			skillsInstallCmd(),
+			skillsUpdateCmd(),
 		},
 		Action: func(_ context.Context, _ *cli.Command) error {
 			return runSkillsList()
@@ -79,6 +80,20 @@ func skillsInstallCmd() *cli.Command {
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			return runSkillsInstall(cmd.String("dir"), cmd.Args().Slice(), cmd.Bool("force"))
+		},
+	}
+}
+
+func skillsUpdateCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "update",
+		Usage:     "Update installed DAC agent skills to the bundled version",
+		ArgsUsage: "[skill...]",
+		Flags: []cli.Flag{
+			skillsDirFlag,
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			return runSkillsInstall(cmd.String("dir"), cmd.Args().Slice(), true)
 		},
 	}
 }

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -156,6 +156,29 @@ func TestSkillsCommand_RegisteredWithApp(t *testing.T) {
 	}
 }
 
+func TestSkillsUpdate_OverwritesThroughCLI(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude", "skills", "create-dashboard", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("custom\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	app := NewApp(BuildInfo{Version: "test"})
+	if err := app.Run(context.Background(), []string{"dac", "skills", "update", "--dir", dir}); err != nil {
+		t.Fatalf("cli skills update failed: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read skill: %v", err)
+	}
+	if string(data) != createDashboardSkill {
+		t.Fatalf("expected skill updated to bundled content, got %q", data)
+	}
+}
+
 func TestSkillsCommand_RunsThroughCLI(t *testing.T) {
 	dir := t.TempDir()
 	app := NewApp(BuildInfo{Version: "test"})

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -156,6 +156,82 @@ func TestSkillsCommand_RegisteredWithApp(t *testing.T) {
 	}
 }
 
+func TestParseSkillVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"bundled skill", createDashboardSkill, 1},
+		{"explicit version", "---\nname: x\nversion: 7\n---\nbody", 7},
+		{"missing version", "---\nname: x\n---\nbody", 0},
+		{"no frontmatter", "# just a heading\n", 0},
+		{"non-integer version", "---\nversion: 1.2\n---\n", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseSkillVersion(tc.content); got != tc.want {
+				t.Fatalf("parseSkillVersion(%q) = %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSkillUpdateNotices_FlagsOlderInstall(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude", "skills", "create-dashboard", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	// An install with no version field reports version 0, older than bundled.
+	if err := os.WriteFile(path, []byte("---\nname: create-dashboard\n---\nold body"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	notices := skillUpdateNotices(dir)
+	if len(notices) != 1 {
+		t.Fatalf("expected 1 notice, got %d: %v", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "create-dashboard") || !strings.Contains(notices[0], "dac skills update") {
+		t.Fatalf("unexpected notice text: %q", notices[0])
+	}
+}
+
+func TestSkillUpdateNotices_SilentWhenCurrentOrAbsent(t *testing.T) {
+	// No .claude directory at all: no project root, no notices.
+	if notices := skillUpdateNotices(t.TempDir()); len(notices) != 0 {
+		t.Fatalf("expected no notices without an install, got %v", notices)
+	}
+
+	// Freshly installed skill is current with the bundled version.
+	dir := t.TempDir()
+	if err := runSkillsInstall(dir, nil, false); err != nil {
+		t.Fatalf("skills install failed: %v", err)
+	}
+	if notices := skillUpdateNotices(dir); len(notices) != 0 {
+		t.Fatalf("expected no notices for a current install, got %v", notices)
+	}
+}
+
+func TestSkillUpdateNotices_DiscoversRootFromSubdir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude", "skills", "create-dashboard", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("---\nname: create-dashboard\n---\nold"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sub := filepath.Join(dir, "dashboards")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("create subdir: %v", err)
+	}
+
+	if notices := skillUpdateNotices(sub); len(notices) != 1 {
+		t.Fatalf("expected notice discovered from subdir, got %v", notices)
+	}
+}
+
 func TestSkillsUpdate_OverwritesThroughCLI(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".claude", "skills", "create-dashboard", "SKILL.md")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -37,6 +37,7 @@ func validateCmd() *cli.Command {
 			if err != nil {
 				return err
 			}
+			printSkillUpdateNotices(dir)
 			withDatabase := cmd.Bool("with-database")
 
 			var backend query.Backend

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -24,7 +24,7 @@ These flags apply to all commands:
 | [`ls`](/commands/ls) | List discovered dashboards |
 | [`query`](/commands/query) | Run SQL against a connection |
 | [`connections`](/commands/connections) | Test database connections |
-| [`skills`](/commands/skills) | List and install DAC agent skills |
+| [`skills`](/commands/skills) | List, install, and update DAC agent skills |
 | [`import`](/commands/import) | Import dashboards from external tools |
 | [`export`](/commands/export) | Export dashboards to external formats |
 | [`upgrade`](/commands/upgrade) | Upgrade the DAC CLI in place (alias: `update`) |

--- a/docs/commands/skills.md
+++ b/docs/commands/skills.md
@@ -4,7 +4,7 @@ List and install DAC agent skills into a project.
 
 Agent skills are local instructions that help coding agents create and modify DAC dashboards correctly. DAC currently ships a bundled `create-dashboard` skill for dashboard authoring.
 
-`dac init` installs bundled skills automatically for new projects. Use `dac skills install` for existing projects or to refresh a skill with `--force`.
+`dac init` installs bundled skills automatically for new projects. Use `dac skills install` for existing projects, or `dac skills update` to refresh installed skills to the version bundled with your current `dac` binary.
 
 ## List Skills
 
@@ -43,12 +43,28 @@ dac skills install create-dashboard --dir . --force
 
 Restart your agent session after installing skills so the agent can discover the new local instructions.
 
+## Update Skills
+
+When you upgrade `dac`, the binary may ship a newer skill than the copy already installed in your project. Refresh installed skills to the bundled version:
+
+```shell
+dac skills update --dir .
+```
+
+Update a specific skill:
+
+```shell
+dac skills update create-dashboard --dir .
+```
+
+`update` overwrites the installed skill files (equivalent to `install --force`), so any local customizations are replaced.
+
 ## Flags
 
 | Flag | Alias | Description |
 |------|-------|-------------|
 | `--dir` | `-d` | Target project directory |
-| `--force` | `-f` | Overwrite existing skill files |
+| `--force` | `-f` | Overwrite existing skill files (`install` only; `update` always overwrites) |
 
 ## Notes
 

--- a/docs/commands/skills.md
+++ b/docs/commands/skills.md
@@ -45,7 +45,14 @@ Restart your agent session after installing skills so the agent can discover the
 
 ## Update Skills
 
-When you upgrade `dac`, the binary may ship a newer skill than the copy already installed in your project. Refresh installed skills to the bundled version:
+Each bundled skill carries a version. When you upgrade `dac`, the binary may ship a newer skill than the copy already installed in your project. `dac serve` and `dac validate` print a one-line notice when a newer skill is available:
+
+```text
+A newer create-dashboard skill is available with the latest authoring features and fixes.
+Run `dac skills update` to update your project's copy.
+```
+
+The notice never modifies files on its own — updating is always an explicit action. Refresh installed skills to the bundled version:
 
 ```shell
 dac skills update --dir .


### PR DESCRIPTION
## Summary

Adds a passive staleness notice for bundled agent skills, plus `dac skills update` to refresh them.

- Bundled skills now carry a `version` field in their frontmatter (`create-dashboard` starts at `version: 1`).
- `dac serve` and `dac validate` compare the installed skill against the bundled one and, if the bundled version is newer, print a single line to **stderr**:

  > A newer create-dashboard skill is available — run `dac skills update`.

- The notice **never modifies files** — updating is always explicit.
- `dac skills update [skill...]` refreshes installed skills to the bundled version (equivalent to `install --force`).
- Skills with no version field (older installs) are treated as version 0, so existing projects get nudged after upgrading `dac`.
- The project root (where `.claude/` lives) is discovered by walking up from the dashboard directory, so the notice works whether you run from the root or a subdirectory.

## Testing

- [x] `make test` (new tests cover version parsing, notice generation, root discovery, and the update command)
- [x] `make build`
- [x] manual smoke test: stale install → notice on `validate`; `skills update` overwrites and stamps the version; no notice afterward

## Checklist

- [x] scanned `docs/` and updated the relevant pages (`commands/skills.md`, `commands/overview.md`)
- [ ] examples updated if the authoring model changed (n/a)
- [ ] screenshots or recordings attached for UI changes (n/a)