### PR TITLE
Document deprecated dashboard fields in the create-dashboard skill

### DIFF
--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -142,12 +142,14 @@ rows:
         type: chart
         chart: bar
         query: revenue_by_region
-        x: region
-        y: [revenue]
+        x: { field: region }
+        y: { field: [revenue] }
         col: 6
 ```
 
-SQL files can be referenced with `file: queries/revenue.sql`, relative to the dashboard file.
+A chart's `x` and `y` are axis encoding objects with a required `field` (bare column names like `x: region` are invalid). `field` may be a single column or a list.
+
+Every query is an inline `sql:` block or a named `query:` reference — YAML widgets do not take file paths. In TSX, `include("queries/revenue.sql")` reads a `.sql` file into an inline query at load time.
 
 ## Semantic Models
 
@@ -272,6 +274,17 @@ export default (
 ```
 
 TSX supports the same dashboard model as YAML. Keep semantic logic declarative; do not manually compile semantic metrics to SQL in TSX.
+
+## Deprecated Fields
+
+These fields were removed from the DAC schema. Never emit them in new dashboards. **If you encounter any of them while reading or editing an existing dashboard, refactor them to the current form** — preserving the original column, formatting, and labels — and re-run `dac validate` to confirm the dashboard still loads.
+
+| Deprecated | Replacement |
+|---|---|
+| Chart `x: col` / `y: [col]` (bare column names) | `x: { field: col }` / `y: { field: [col] }` — axis encoding objects with a required `field` |
+| Widget or named-query `file: path.sql` | Inline `sql:` or a named `query:` reference. In TSX, `include("path.sql")` reads a `.sql` file into inline SQL at load time |
+| Metric widget `column`, `prefix`, `suffix`, `format` (flat fields) | `value: { field: <column>, type: number, format: "<d3-format>" }` |
+| Dashboard inline `semantic:` block (`source` / `metrics` / `dimensions`) | Define the model in `semantic/*.yml` and reference it with `model:` |
 
 ## Authoring Rules
 


### PR DESCRIPTION
## Summary

The bundled `create-dashboard` skill had drifted behind the schema-unification breaking changes. It still taught two authoring forms that no longer validate:

- Chart `x: region` / `y: [revenue]` (bare column names) — `x`/`y` now require axis encoding objects (`{ field: ... }`).
- `file: queries/revenue.sql` query references — removed; queries are inline `sql:` or a named `query:` (TSX `include()` still works).

This PR:

1. **Fixes the stale chart example** to use `x: { field: region }` / `y: { field: [revenue] }` and corrects the query-reference guidance.
2. **Adds a "Deprecated Fields" section** mapping every removed field to its current replacement and instructing the agent to **refactor any of them it encounters** in an existing dashboard (preserving column/formatting/labels, then re-validating).

### Deprecated → replacement

| Deprecated | Replacement |
|---|---|
| Chart `x: col` / `y: [col]` | `x: { field: col }` / `y: { field: [col] }` |
| `file: path.sql` | inline `sql:` or named `query:` (TSX `include()`) |
| Metric `column`/`prefix`/`suffix`/`format` | `value: { field, type, format }` |
| Dashboard inline `semantic:` block | separate `semantic/*.yml` + `model:` |

Grounded in the actual schema/loaders, not assumptions — confirmed `include()` is still supported (`pkg/dashboard/jsloader.go`), so it is **not** listed as deprecated.

## Testing

- [x] `make test`
- [x] validated the corrected chart example with `dac validate` (passes)
- [x] confirmed `docs/` already teaches the correct forms (no stale docs)

## Checklist

- [x] scanned `docs/` — already current; no changes needed
- [ ] examples updated if the authoring model changed (n/a — fixing skill to match existing model)