### PR TITLE
feat(dashboard): inline static data widgets

### DIFF
--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -2,7 +2,7 @@
 name: create-dashboard
 description: Create DAC dashboards by writing YAML or TSX dashboard definition files. Use when the user wants to create, modify, review, or understand DAC dashboards, widgets, filters, SQL queries, semantic models, or CLI validation workflows.
 argument-hint: "[dashboard request]"
-version: 1
+version: 2
 ---
 
 # Create Dashboard
@@ -152,6 +152,37 @@ A chart's `x` and `y` are axis encoding objects with a required `field` (bare co
 
 Every query is an inline `sql:` block or a named `query:` reference — YAML widgets do not take file paths. In TSX, `include("queries/revenue.sql")` reads a `.sql` file into an inline query at load time.
 
+## Inline (Static) Data
+
+A `metric`, `chart`, or `table` widget can carry its values inline with `data` instead of a query. A widget with `data` renders **without a connection or SQL** — `columns` are the column names and `rows` is one positional list per row. The encoding fields (`x`, `y`, `value`, `label`, `columns`) reference the column names.
+
+```yaml
+rows:
+  - widgets:
+      - name: Revenue by Quarter
+        type: chart
+        chart: bar
+        col: 6
+        data:
+          columns: [quarter, revenue]
+          rows:
+            - [Q1, 12000]
+            - [Q2, 15500]
+            - [Q3, 14200]
+            - [Q4, 18900]
+        x: { field: quarter, type: category }
+        y: { field: [revenue], type: number, format: "$,.0f" }
+```
+
+**Use this only when there is genuinely no data connection** — e.g. a brand-new project where `.bruin.yml` has no connections, a hardcoded illustrative example, or a layout mockup. **When a connection exists, always use `sql:`, `query:`, or a semantic widget instead.** Inline data is frozen: it never refreshes, ignores filters, and goes stale. Do not paste real query results into `data` to "cache" them, and do not present made-up numbers as real — tell the user inline values are illustrative until a warehouse is connected.
+
+Rules:
+
+- `data` is mutually exclusive with `sql`, `query`, and semantic fields (`model`, `dimension`, `metrics`, …). Setting both fails validation.
+- Every row must have exactly one value per column.
+- Not valid on `text`, `image`, or `divider` widgets.
+- A dashboard built entirely from `data` widgets needs no top-level `connection`.
+
 ## Semantic Models
 
 Semantic models live in `semantic/*.yml`.
@@ -292,6 +323,7 @@ These fields were removed from the DAC schema. Never emit them in new dashboards
 - Keep dashboard files focused on presentation and query intent.
 - Prefer semantic widgets when metrics or dimensions are reused.
 - Use direct SQL for one-off custom queries or non-semantic dashboards.
+- Use inline `data` only when there is no connection; prefer `sql`/`query`/semantic whenever one exists, since inline data never refreshes.
 - Validate both YAML and TSX dashboards after changes.
 - Do not require semantic models for regular SQL dashboards.
 - Do not put secrets in dashboard files; use Bruin connection config.

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -162,7 +162,7 @@ func TestParseSkillVersion(t *testing.T) {
 		content string
 		want    int
 	}{
-		{"bundled skill", createDashboardSkill, 1},
+		{"bundled skill", createDashboardSkill, 2},
 		{"explicit version", "---\nname: x\nversion: 7\n---\nbody", 7},
 		{"missing version", "---\nname: x\n---\nbody", 0},
 		{"no frontmatter", "# just a heading\n", 0},

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -11,7 +11,7 @@ Widgets are the visual building blocks of a dashboard. Each widget occupies a nu
 | `col` | integer | No | Column span from 1 to 12 |
 | `description` | string | No | Optional tooltip or subtitle |
 
-Data-backed widgets (`metric`, `chart`, `table`) also need a query source: `query` (named query reference), `sql` (inline), `file` (external `.sql` path), or a semantic reference (`metric:` for metric widgets, `dimension:` + `metrics:` for charts). See [Queries & Templating](/dashboards/queries) for the full reference, including the `connection` override.
+Data-backed widgets (`metric`, `chart`, `table`) also need a query source: `query` (named query reference), `sql` (inline), `file` (external `.sql` path), a semantic reference (`metric:` for metric widgets, `dimension:` + `metrics:` for charts), or `data` (inline static values — see [Inline data](#inline-data)). See [Queries & Templating](/dashboards/queries) for the full reference, including the `connection` override.
 
 ## Metric
 
@@ -256,6 +256,40 @@ Table column fields:
 | `name` | string | Result column name (must match the SQL output) |
 | `label` | string | Display header (defaults to `name`) |
 | `format` | string | `number` or `currency` |
+
+## Inline data
+
+`metric`, `chart`, and `table` widgets can carry their data inline instead of a
+query source. A widget with `data` renders without a connection or SQL — useful
+for hardcoded numbers, sample dashboards, or building a dashboard before a
+warehouse is connected. The encoding fields (`x`, `y`, `value`, `label`,
+`columns`) reference the column names declared in `data.columns`.
+
+```yaml
+- name: Revenue by Quarter
+  type: chart
+  chart: bar
+  col: 6
+  data:
+    columns: [quarter, revenue]
+    rows:
+      - [Q1, 12000]
+      - [Q2, 15500]
+      - [Q3, 14200]
+      - [Q4, 18900]
+  x: { field: quarter, type: category }
+  y: { field: [revenue], type: number, format: "$,.0f" }
+```
+
+`data` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `columns` | list of strings | Column names; referenced by the encoding fields |
+| `rows` | list of lists | One list per row, positional — each must have one value per column |
+
+`data` is mutually exclusive with `sql` and `query`. It is not valid on `text`,
+`image`, or `divider` widgets.
 
 ## Text
 

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -80,7 +80,7 @@ type Row struct {
 }
 
 // Widget represents a single dashboard widget.
-// Query resolution priority: query (named ref) > sql (inline).
+// Query resolution priority: query (named ref) > sql (inline) > data (static).
 type Widget struct {
 	ID          string `yaml:"id,omitempty" json:"id,omitempty"`
 	Name        string `yaml:"name" json:"name"`
@@ -93,6 +93,12 @@ type Widget struct {
 	SQL       string `yaml:"sql,omitempty" json:"sql,omitempty"`
 	MetricRef string `yaml:"metric,omitempty" json:"metric,omitempty"` // reference to metrics map key
 	Model     string `yaml:"model,omitempty" json:"model,omitempty"`
+
+	// Inline static data — an alternative to a query source. A widget with
+	// Data renders without a connection or SQL; encoding fields (x/y/value/
+	// label/columns) reference the column names in Data. Used for hardcoded
+	// or sample dashboards, e.g. before a warehouse is connected.
+	Data *WidgetData `yaml:"data,omitempty" json:"data,omitempty"`
 
 	// Connection override for inline queries
 	Connection string `yaml:"connection,omitempty" json:"connection,omitempty"`
@@ -144,6 +150,15 @@ type TableColumn struct {
 	Name   string `yaml:"name" json:"name"`
 	Label  string `yaml:"label,omitempty" json:"label,omitempty"`
 	Format string `yaml:"format,omitempty" json:"format,omitempty"`
+}
+
+// WidgetData holds inline result data for a widget so it can render without a
+// connection. Columns are column names; each entry in Rows is positional and
+// must have one value per column. This mirrors the {columns, rows} shape the
+// frontend uses for executed query results.
+type WidgetData struct {
+	Columns []string `yaml:"columns" json:"columns"`
+	Rows    [][]any  `yaml:"rows" json:"rows"`
 }
 
 type SemanticDimensionRef struct {
@@ -304,6 +319,11 @@ func (q *Query) IsSemantic() bool {
 		q.Limit > 0
 }
 
+// HasInlineData reports whether the widget carries static inline data.
+func (w *Widget) HasInlineData() bool {
+	return w.Data != nil && len(w.Data.Columns) > 0
+}
+
 func (w *Widget) IsSemantic() bool {
 	return w.Model != "" ||
 		len(w.Dimensions) > 0 ||
@@ -328,6 +348,10 @@ func FindByName(dashboards []*Dashboard, name string) *Dashboard {
 // ResolvedQuery returns the SQL and connection for this widget, resolving named query references.
 // Widgets with MetricRef are handled separately and should not call this method.
 func (w *Widget) ResolvedQuery(dashboard *Dashboard) (sql, connection string, err error) {
+	if w.HasInlineData() {
+		return "", "", nil // static widgets carry their data inline; nothing to execute
+	}
+
 	if w.MetricRef != "" || len(w.MetricRefs) > 0 {
 		return "", "", nil // metric-based widgets are resolved via the metrics system
 	}

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -89,6 +89,8 @@ func Validate(d *Dashboard) error {
 				errs = append(errs, fmt.Sprintf("%s: unknown widget type %q (expected metric, chart, table, text, divider, or image)", prefix, w.Type))
 			}
 
+			errs = append(errs, validateInlineData(prefix, &w)...)
+
 			if w.Col < 0 || w.Col > 12 {
 				errs = append(errs, fmt.Sprintf("%s: col must be between 1 and 12, got %d", prefix, w.Col))
 			}
@@ -169,6 +171,50 @@ func ValidateAll(dashboards []*Dashboard) error {
 	return &ValidationSetError{Errors: errs}
 }
 
+// validateInlineData checks a widget's static inline data, when present: it is
+// only valid on data-bearing widget types, cannot be combined with a query
+// source, and every row must line up with the declared columns.
+func validateInlineData(prefix string, w *Widget) []string {
+	if w.Data == nil {
+		return nil
+	}
+
+	var errs []string
+
+	switch w.Type {
+	case WidgetTypeMetric, WidgetTypeChart, WidgetTypeTable:
+	default:
+		return append(errs, fmt.Sprintf("%s: data is only valid on metric, chart, or table widgets", prefix))
+	}
+
+	if w.SQL != "" || w.QueryRef != "" || w.IsSemantic() {
+		errs = append(errs, fmt.Sprintf("%s: data cannot be combined with sql, query, or semantic fields", prefix))
+	}
+
+	if len(w.Data.Columns) == 0 {
+		errs = append(errs, fmt.Sprintf("%s: data.columns is required and must be non-empty", prefix))
+		return errs
+	}
+
+	seen := make(map[string]bool, len(w.Data.Columns))
+	for _, c := range w.Data.Columns {
+		if c == "" {
+			errs = append(errs, fmt.Sprintf("%s: data.columns must not contain empty column names", prefix))
+		} else if seen[c] {
+			errs = append(errs, fmt.Sprintf("%s: data.columns has duplicate column %q", prefix, c))
+		}
+		seen[c] = true
+	}
+
+	for i, row := range w.Data.Rows {
+		if len(row) != len(w.Data.Columns) {
+			errs = append(errs, fmt.Sprintf("%s: data.rows[%d] has %d value(s), expected %d to match columns", prefix, i, len(row), len(w.Data.Columns)))
+		}
+	}
+
+	return errs
+}
+
 func validateQuerySource(prefix string, w *Widget, d *Dashboard) []string {
 	var errs []string
 	if job, handled, err := d.ResolveWidgetSemanticJob(w); err != nil {
@@ -180,8 +226,8 @@ func validateQuerySource(prefix string, w *Widget, d *Dashboard) []string {
 		}
 		return errs
 	}
-	if w.QueryRef == "" && w.SQL == "" {
-		errs = append(errs, fmt.Sprintf("%s: one of query or sql is required", prefix))
+	if w.QueryRef == "" && w.SQL == "" && !w.HasInlineData() {
+		errs = append(errs, fmt.Sprintf("%s: one of query, sql, or data is required", prefix))
 	}
 	if w.QueryRef != "" {
 		if _, ok := d.Queries[w.QueryRef]; !ok {

--- a/pkg/dashboard/validator_test.go
+++ b/pkg/dashboard/validator_test.go
@@ -260,6 +260,108 @@ metrics:
 }
 
 // ---------------------------------------------------------------------------
+// Inline data widgets
+// ---------------------------------------------------------------------------
+
+func TestValidate_InlineDataTableNoQuery(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "Recent", Type: WidgetTypeTable, Col: 12,
+				Data: &WidgetData{
+					Columns: []string{"id", "amount"},
+					Rows:    [][]any{{1, 10.5}, {2, 20}},
+				},
+			}}},
+		},
+	}
+	assertNoErr(t, Validate(d))
+}
+
+func TestValidate_InlineDataChart(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "Revenue", Type: WidgetTypeChart, Chart: "bar", Col: 6,
+				Data: &WidgetData{
+					Columns: []string{"quarter", "revenue"},
+					Rows:    [][]any{{"Q1", 100}, {"Q2", 200}},
+				},
+				X: newAxisField("quarter"),
+				Y: newAxisFields([]string{"revenue"}),
+			}}},
+		},
+	}
+	assertNoErr(t, Validate(d))
+}
+
+func TestValidate_InlineDataRowArityMismatch(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "Recent", Type: WidgetTypeTable, Col: 12,
+				Data: &WidgetData{
+					Columns: []string{"id", "amount"},
+					Rows:    [][]any{{1}},
+				},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "expected 2 to match columns")
+}
+
+func TestValidate_InlineDataConflictsWithSQL(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "Recent", Type: WidgetTypeTable, Col: 12,
+				SQL:  "SELECT 1",
+				Data: &WidgetData{Columns: []string{"id"}, Rows: [][]any{{1}}},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "data cannot be combined with sql")
+}
+
+func TestValidate_InlineDataInvalidOnText(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "Notes", Type: WidgetTypeText, Content: "hi",
+				Data: &WidgetData{Columns: []string{"id"}, Rows: [][]any{{1}}},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "data is only valid on metric, chart, or table widgets")
+}
+
+func TestValidate_InlineDataEmptyColumns(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "Recent", Type: WidgetTypeTable, Col: 12,
+				Data: &WidgetData{Columns: []string{}, Rows: [][]any{}},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "data.columns is required and must be non-empty")
+}
+
+// ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -19,6 +19,9 @@ type WidgetJob struct {
 	ID         string
 	SQL        string
 	Connection string
+	// InlineData, when set, is returned directly without executing SQL — the
+	// widget carries static data and needs no connection.
+	InlineData *dashboard.WidgetData
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
@@ -254,6 +257,11 @@ func ResolveWidgetJobs(d *dashboard.Dashboard, filters map[string]any) ([]Widget
 				continue
 			}
 
+			if widget.HasInlineData() {
+				jobs = append(jobs, WidgetJob{ID: WidgetID(i, j), InlineData: widget.Data})
+				continue
+			}
+
 			var sql, conn string
 			var err error
 
@@ -290,7 +298,22 @@ func ResolveWidgetJobs(d *dashboard.Dashboard, filters map[string]any) ([]Widget
 }
 
 // ExecuteWidgetQuery runs a single widget SQL query against the given backend.
+// Widgets carrying inline static data are returned directly without a backend call.
 func ExecuteWidgetQuery(ctx context.Context, backend query.Backend, j WidgetJob) *WidgetQueryResult {
+	if j.InlineData != nil {
+		wr := &WidgetQueryResult{Rows: j.InlineData.Rows}
+		for _, name := range j.InlineData.Columns {
+			wr.Columns = append(wr.Columns, struct {
+				Name string `json:"name"`
+				Type string `json:"type,omitempty"`
+			}{Name: name})
+		}
+		if wr.Rows == nil {
+			wr.Rows = [][]any{}
+		}
+		return wr
+	}
+
 	qr, err := backend.Execute(ctx, j.Connection, j.SQL)
 	if err != nil {
 		return &WidgetQueryResult{Query: j.SQL, Error: err.Error()}

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -87,6 +87,44 @@ func TestResolveWidgetJobs_SkipsTextDividerImage(t *testing.T) {
 	}
 }
 
+func TestResolveWidgetJobs_InlineDataNoBackend(t *testing.T) {
+	d := &dashboard.Dashboard{
+		Name: "test",
+		Rows: []dashboard.Row{{
+			Widgets: []dashboard.Widget{{
+				Name: "Static",
+				Type: "table",
+				Data: &dashboard.WidgetData{
+					Columns: []string{"region", "revenue"},
+					Rows:    [][]any{{"EU", 100}, {"US", 200}},
+				},
+			}},
+		}},
+	}
+
+	jobs, err := ResolveWidgetJobs(d, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	assertEqual(t, jobs[0].SQL, "")
+	if jobs[0].InlineData == nil {
+		t.Fatal("expected job to carry inline data")
+	}
+
+	// A nil backend would panic if executed — inline data must short-circuit.
+	wr := ExecuteWidgetQuery(context.Background(), nil, jobs[0])
+	assertEqual(t, wr.Error, "")
+	if len(wr.Columns) != 2 || wr.Columns[0].Name != "region" {
+		t.Fatalf("unexpected columns: %+v", wr.Columns)
+	}
+	if len(wr.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(wr.Rows))
+	}
+}
+
 func TestResolveWidgetJobs_JinjaFiltersRendered(t *testing.T) {
 	d := &dashboard.Dashboard{
 		Name:       "test",

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -211,6 +211,21 @@
         "sql": {
           "type": "string"
         },
+        "data": {
+          "type": "object",
+          "required": ["columns", "rows"],
+          "properties": {
+            "columns": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "rows": {
+              "type": "array",
+              "items": { "type": "array" }
+            }
+          },
+          "additionalProperties": false
+        },
         "metric": {
           "type": "string"
         },


### PR DESCRIPTION
## What

Adds an inline **`data`** source for `metric` / `chart` / `table` widgets, so a dashboard can render **without a warehouse connection or SQL**. The data is baked into the widget config.

```yaml
- name: Revenue by Quarter
  type: chart
  chart: bar
  col: 6
  data:
    columns: [quarter, revenue]
    rows:
      - [Q1, 12000]
      - [Q2, 15500]
      - [Q3, 14200]
      - [Q4, 18900]
  x: { field: quarter, type: category }
  y: { field: [revenue], type: number, format: "$,.0f" }
```

## Why

Before this, the only connection-free widget types were `text`, `divider`, and `image` — none of which carry data. Every data-bearing widget (`chart`/`metric`/`table`) *required* a `sql`/`query`/semantic source. New users who haven't connected a warehouse yet had no way to get the agent to build a real dashboard. `data` closes that gap; later the value can be swapped for `sql:` once a connection exists.

## Changes

- `Widget.Data` + `WidgetData{columns, rows}` type + `HasInlineData()` (`pkg/dashboard/model.go`). `ResolvedQuery` short-circuits — inline-data widgets have nothing to execute.
- `validateInlineData` (`pkg/dashboard/validator.go`): valid only on metric/chart/table, mutually exclusive with `sql`/`query`/semantic fields, and every row must match the declared columns. `validateQuerySource` now accepts `data` as a source for tables.
- Preview server (`pkg/server/api.go`): inline-data widgets are returned directly through the result channel without a backend call (`WidgetJob.InlineData`).
- JSON schema `v1` + `docs/dashboards/widgets.md`.
- Tests: validator + server.

`go build ./...`, `go test ./...`, and `go vet` all pass.

## Downstream

`agent-runner` and `bruin-data/cloud` consume this. agent-runner imports `bruin-data/dac` and uses `Data`/`WidgetData`/`HasInlineData`, so it needs a `go get` bump **after** this merges and tags. Cloud's frontend already renders inline `data`; a companion cloud PR makes the refresh endpoints tolerate a missing connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)