### PR TITLE
Add viewer export formats

### DIFF
--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -341,3 +341,27 @@ Divider widgets add visual separation between sections.
   type: divider
   col: 12
 ```
+
+## Exports
+
+The dashboard viewer can export widget data as CSV and rendered dashboard or widget views as PNG/PDF. In `dac serve`, exports use the currently applied filters. In static `dac build` dashboards, exports use the query results baked into the HTML at build time.
+
+### Per-widget Exports
+
+Chart and table widgets show an export menu in the widget header on hover or keyboard focus:
+
+- **CSV** downloads that widget's result set as `<widget-name>.csv` (RFC 4180 CSV with quoted cells).
+- **PNG** captures the rendered widget as `<widget-name>.png`.
+- **PDF** captures the rendered widget as `<widget-name>.pdf`.
+
+### Dashboard Exports
+
+The dashboard header has an **Export** menu:
+
+- **CSV** exports every data-bearing widget (metrics, charts, and tables) in one file. Each widget is written as a section introduced by a `# <widget-name>` divider line, followed by the column header and rows, with a blank line separating sections. The file is named `<dashboard-name>.csv`.
+- **PNG** captures the rendered dashboard view as `<dashboard-name>.png`.
+- **PDF** captures the rendered dashboard view as `<dashboard-name>.pdf`.
+
+In `dac serve`, CSV exports reflect the active filter values at the time of the click. Static dashboard CSV exports use the baked query results. Text, divider, and image widgets are skipped in CSV exports. Widgets with query errors or no rows are omitted from the dashboard CSV.
+
+PNG and PDF exports capture the visible rendered view, excluding viewer controls such as export buttons and YAML controls. For tabbed dashboards, they capture the currently active tab.

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,7 @@ rows:
 - **[Semantic layer](/dashboards/semantic-layer).** Define metrics and dimensions once in `semantic/`, reference them from any widget. DAC generates the SQL.
 - **Live reload.** Edit the file, save, see the change. No restart, no rebuild.
 - **Static export.** `dac build` produces self-contained HTML with query results baked in. Deploy to S3, GitHub Pages, anywhere — no runtime server needed.
+- **Data export.** Download chart and table data as CSV, or export dashboard and widget views as PNG/PDF directly from the viewer.
 - **[Google Slides export](/commands/export).** Render dashboards as slide decks with charts as images and data baked in.
 - **Validation in CI.** `dac validate` and `dac check` catch broken queries, missing columns, and schema violations before they reach production.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,8 @@
         "@tanstack/react-query": "^5.90.21",
         "d3-format": "^3.1.2",
         "d3-time-format": "^4.1.0",
+        "html-to-image": "^1.11.13",
+        "jspdf": "^4.2.1",
         "react": "^19.2.4",
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.4",
@@ -1615,11 +1617,24 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -1649,6 +1664,13 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2084,6 +2106,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
@@ -2171,6 +2203,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2305,6 +2357,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -2334,6 +2398,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2562,6 +2636,16 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2862,6 +2946,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2879,6 +2974,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3121,6 +3222,12 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -3139,6 +3246,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ignore": {
@@ -3201,6 +3322,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -3388,6 +3515,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -4475,6 +4619,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4564,6 +4724,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4658,6 +4825,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/react": {
@@ -4879,6 +5056,13 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -4970,6 +5154,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rolldown": {
@@ -5106,6 +5300,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -5182,6 +5386,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -5201,6 +5415,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -5467,6 +5691,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vfile": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
     "@tanstack/react-query": "^5.90.21",
     "d3-format": "^3.1.2",
     "d3-time-format": "^4.1.0",
+    "html-to-image": "^1.11.13",
+    "jspdf": "^4.2.1",
     "react": "^19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.4",

--- a/frontend/src/components/DashboardView.tsx
+++ b/frontend/src/components/DashboardView.tsx
@@ -1,11 +1,15 @@
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { useDashboard } from "../hooks/useDashboard";
 import { useWidgetQuery } from "../hooks/useWidgetQuery";
 import { useTemplate } from "../themes/TemplateProvider";
 import { resolvePreset } from "../themes/bruin/FilterBar";
 import { YamlPanel } from "./YamlPanel";
-import type { Filter, Widget } from "../types/dashboard";
+import { ExportMenuButton, type ExportMenuItem } from "./ExportMenuButton";
+import { fetchDashboardData } from "../api/client";
+import { dashboardToCSV, downloadTextFile, slugify } from "../lib/csv";
+import { exportElementAsPDF, exportElementAsPNG } from "../lib/renderExport";
+import type { Filter, Widget, WidgetData } from "../types/dashboard";
 import type { WidgetFrameProps } from "../types/template";
 
 function buildDefaultFilters(dashboard: { filters?: Filter[] }): Record<string, unknown> {
@@ -26,6 +30,7 @@ function buildDefaultFilters(dashboard: { filters?: Filter[] }): Record<string, 
 }
 
 const isStaticMode = window.__DAC_STATIC__ !== undefined;
+type DashboardExportFormat = "csv" | "png" | "pdf";
 
 // Non-data widget types that don't need a query.
 const STATIC_WIDGET_TYPES = new Set(["text", "divider", "image"]);
@@ -81,12 +86,13 @@ function DataWidgetInner({
   filters?: Record<string, unknown>;
   WidgetFrame: React.ComponentType<WidgetFrameProps>;
 }) {
-  const { data, isLoading } = useWidgetQuery(dashboardName, widgetId, filters, true);
-  return <WidgetFrame widget={widget} data={data} isLoading={isLoading} />;
+  const { data, isLoading, isPlaceholderData } = useWidgetQuery(dashboardName, widgetId, filters, true);
+  return <WidgetFrame widget={widget} data={data} isLoading={isLoading || isPlaceholderData} />;
 }
 
 export function DashboardView() {
   const { name } = useParams<{ name: string }>();
+  const dashboardExportRef = useRef<HTMLDivElement>(null);
 
   const { data: dashboard, isLoading: dashLoading, error: dashError } = useDashboard(name || "");
   const [yamlOpen, _setYamlOpen] = useState(_yamlOpen);
@@ -107,6 +113,7 @@ export function DashboardView() {
     });
   }, []);
   const [isResizing, setIsResizing] = useState(false);
+  const [exporting, setExporting] = useState<DashboardExportFormat | null>(null);
 
   const handleYamlResize = useCallback((delta: number) => {
     setYamlWidth((w: number) => Math.max(280, Math.min(800, w + delta)));
@@ -153,6 +160,43 @@ export function DashboardView() {
     setActiveTab(null);
   }, [dashboard]);
 
+  const handleExport = useCallback(async (format: DashboardExportFormat) => {
+    if (!dashboard) return;
+    setExporting(format);
+    try {
+      const filename = `${slugify(dashboard.name)}.${format}`;
+      if (format === "csv") {
+        const widgetData = await fetchDashboardData(name || "", activeFilters ?? undefined);
+        const sections: { name: string; data: WidgetData }[] = [];
+        dashboard.rows.forEach((row, i) => {
+          row.widgets.forEach((widget, j) => {
+            if (widget.type === "text" || widget.type === "divider" || widget.type === "image") return;
+            const data = widgetData[`r${i}-w${j}`];
+            if (data && !data.error && data.rows && data.rows.length > 0) {
+              sections.push({ name: widget.name, data });
+            }
+          });
+        });
+        if (sections.length === 0) return;
+        const csv = dashboardToCSV(sections);
+        downloadTextFile(filename, csv, "text/csv;charset=utf-8");
+        return;
+      }
+
+      const element = dashboardExportRef.current;
+      if (!element) return;
+      if (format === "png") {
+        await exportElementAsPNG(element, filename);
+      } else {
+        await exportElementAsPDF(element, filename);
+      }
+    } catch (err) {
+      console.error("Dashboard export failed", err);
+    } finally {
+      setExporting(null);
+    }
+  }, [dashboard, name, activeFilters]);
+
   if (dashLoading) {
     return (
       <div className="max-w-[1400px] mx-auto px-4 sm:px-6 py-6 sm:py-8">
@@ -188,22 +232,37 @@ export function DashboardView() {
     />
   ) : null;
 
-  const headerActions = isStaticMode ? null : (
-    <div className="flex items-center gap-1.5">
-      <button
-        onClick={() => setYamlOpen(!yamlOpen)}
-        className={`inline-flex items-center gap-1.5 h-7 px-2 rounded-sm border text-[13px] transition-all duration-100 ${
-          yamlOpen
-            ? "border-[var(--dac-accent)] text-[var(--dac-accent)] hover:bg-[color-mix(in_srgb,var(--dac-accent)_8%,transparent)]"
-            : "border-[var(--dac-border)] bg-[var(--dac-background)] text-[var(--dac-text-secondary)] hover:text-[var(--dac-text-primary)] hover:border-[var(--dac-text-muted)] hover:bg-[var(--dac-surface-hover)]"
-        }`}
-        title="View YAML"
-      >
-        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M5.5 4L2 8L5.5 12" />
-          <path d="M10.5 4L14 8L10.5 12" />
-        </svg>
-      </button>
+  const exportItems: ExportMenuItem[] = [
+    { key: "csv", label: "CSV", onSelect: () => handleExport("csv") },
+    { key: "png", label: "PNG", onSelect: () => handleExport("png") },
+    { key: "pdf", label: "PDF", onSelect: () => handleExport("pdf") },
+  ];
+
+  const headerActions = (
+    <div data-dac-export-control className="flex items-center gap-1.5">
+      <ExportMenuButton
+        label={exporting ? "Exporting" : "Export"}
+        ariaLabel="Export dashboard"
+        title="Export dashboard"
+        items={exportItems}
+        disabled={exporting !== null}
+      />
+      {!isStaticMode && (
+        <button
+          onClick={() => setYamlOpen(!yamlOpen)}
+          className={`inline-flex items-center gap-1.5 h-7 px-2 rounded-sm border text-[13px] transition-all duration-100 ${
+            yamlOpen
+              ? "border-[var(--dac-accent)] text-[var(--dac-accent)] hover:bg-[color-mix(in_srgb,var(--dac-accent)_8%,transparent)]"
+              : "border-[var(--dac-border)] bg-[var(--dac-background)] text-[var(--dac-text-secondary)] hover:text-[var(--dac-text-primary)] hover:border-[var(--dac-text-muted)] hover:bg-[var(--dac-surface-hover)]"
+          }`}
+          title="View YAML"
+        >
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M5.5 4L2 8L5.5 12" />
+            <path d="M10.5 4L14 8L10.5 12" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 
@@ -231,63 +290,65 @@ export function DashboardView() {
       style={{ gridTemplateColumns: gridColumns }}
     >
       <div className="overflow-y-auto min-w-0">
-        <DashboardLayout dashboard={dashboard} filterBar={filterBar} headerActions={headerActions}>
-          {/* Rows without a tab — always visible */}
-          {dashboard.rows.map((row, rowIdx) => {
-            if (row.tab) return null;
-            return (
-              <div
-                key={rowIdx}
-                className="animate-in"
-                style={{ animationDelay: `${50 + rowIdx * 30}ms` }}
-              >
-                <Row height={row.height}>
-                  {row.widgets.map((widget, widgetIdx) =>
-                    renderWidget(widget, rowIdx, widgetIdx, row.widgets.length),
-                  )}
-                </Row>
-              </div>
-            );
-          })}
+        <div ref={dashboardExportRef}>
+          <DashboardLayout dashboard={dashboard} filterBar={filterBar} headerActions={headerActions}>
+            {/* Rows without a tab — always visible */}
+            {dashboard.rows.map((row, rowIdx) => {
+              if (row.tab) return null;
+              return (
+                <div
+                  key={rowIdx}
+                  className="animate-in"
+                  style={{ animationDelay: `${50 + rowIdx * 30}ms` }}
+                >
+                  <Row height={row.height}>
+                    {row.widgets.map((widget, widgetIdx) =>
+                      renderWidget(widget, rowIdx, widgetIdx, row.widgets.length),
+                    )}
+                  </Row>
+                </div>
+              );
+            })}
 
-          {/* Tab bar + tab content */}
-          {hasTabs && (
-            <>
-              <div className="flex overflow-x-auto scrollbar-hide border-b border-[var(--dac-border)]">
-                {tabNames.map((tab) => (
-                  <button
-                    key={tab}
-                    onClick={() => setActiveTab(tab)}
-                    className={`shrink-0 px-4 py-2 text-[13px] font-medium transition-colors duration-100 border-b-2 -mb-px ${
-                      currentTab === tab
-                        ? "border-[var(--dac-accent)] text-[var(--dac-text-primary)]"
-                        : "border-transparent text-[var(--dac-text-muted)] hover:text-[var(--dac-text-secondary)]"
-                    }`}
-                  >
-                    {tab}
-                  </button>
-                ))}
-              </div>
+            {/* Tab bar + tab content */}
+            {hasTabs && (
+              <>
+                <div className="flex overflow-x-auto scrollbar-hide border-b border-[var(--dac-border)]">
+                  {tabNames.map((tab) => (
+                    <button
+                      key={tab}
+                      onClick={() => setActiveTab(tab)}
+                      className={`shrink-0 px-4 py-2 text-[13px] font-medium transition-colors duration-100 border-b-2 -mb-px ${
+                        currentTab === tab
+                          ? "border-[var(--dac-accent)] text-[var(--dac-text-primary)]"
+                          : "border-transparent text-[var(--dac-text-muted)] hover:text-[var(--dac-text-secondary)]"
+                      }`}
+                    >
+                      {tab}
+                    </button>
+                  ))}
+                </div>
 
-              {dashboard.rows.map((row, rowIdx) => {
-                if (row.tab !== currentTab) return null;
-                return (
-                  <div
-                    key={rowIdx}
-                    className="animate-in"
-                    style={{ animationDelay: `${50 + rowIdx * 30}ms` }}
-                  >
-                    <Row height={row.height}>
-                      {row.widgets.map((widget, widgetIdx) =>
-                        renderWidget(widget, rowIdx, widgetIdx, row.widgets.length),
-                      )}
-                    </Row>
-                  </div>
-                );
-              })}
-            </>
-          )}
-        </DashboardLayout>
+                {dashboard.rows.map((row, rowIdx) => {
+                  if (row.tab !== currentTab) return null;
+                  return (
+                    <div
+                      key={rowIdx}
+                      className="animate-in"
+                      style={{ animationDelay: `${50 + rowIdx * 30}ms` }}
+                    >
+                      <Row height={row.height}>
+                        {row.widgets.map((widget, widgetIdx) =>
+                          renderWidget(widget, rowIdx, widgetIdx, row.widgets.length),
+                        )}
+                      </Row>
+                    </div>
+                  );
+                })}
+              </>
+            )}
+          </DashboardLayout>
+        </div>
       </div>
       <YamlPanel
         dashboardName={name || ""}

--- a/frontend/src/components/ExportMenuButton.tsx
+++ b/frontend/src/components/ExportMenuButton.tsx
@@ -1,0 +1,105 @@
+import { createPortal } from "react-dom";
+import { popoverPortalTarget, usePopover } from "../hooks/usePopover";
+
+export interface ExportMenuItem {
+  key: string;
+  label: string;
+  onSelect: (trigger: HTMLButtonElement) => void | Promise<void>;
+  disabled?: boolean;
+}
+
+interface Props {
+  label: string;
+  ariaLabel: string;
+  title: string;
+  items: ExportMenuItem[];
+  disabled?: boolean;
+  variant?: "header" | "widget";
+}
+
+function DownloadIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  );
+}
+
+const headerButtonClass =
+  "inline-flex items-center gap-1.5 h-7 px-2 rounded-sm border text-[13px] transition-all duration-100 border-[var(--dac-border)] bg-[var(--dac-background)] text-[var(--dac-text-secondary)] hover:text-[var(--dac-text-primary)] hover:border-[var(--dac-text-muted)] hover:bg-[var(--dac-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed";
+
+const widgetButtonClass =
+  "inline-flex items-center justify-center w-4 h-4 rounded opacity-0 group-hover:opacity-40 hover:!opacity-80 focus:opacity-80 focus-visible:!opacity-80 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-[var(--dac-accent)] transition-opacity duration-150 cursor-pointer disabled:cursor-not-allowed";
+
+export function ExportMenuButton({
+  label,
+  ariaLabel,
+  title,
+  items,
+  disabled = false,
+  variant = "header",
+}: Props) {
+  const { open, setOpen, popoverRef, triggerRef, position } = usePopover(false);
+  const isWidget = variant === "widget";
+
+  const handleSelect = async (item: ExportMenuItem) => {
+    const trigger = triggerRef.current;
+    if (!trigger || item.disabled) return;
+
+    setOpen(false);
+    try {
+      await item.onSelect(trigger);
+    } catch (err) {
+      console.error("Export failed", err);
+    }
+  };
+
+  const menuLeft = Math.max(8, Math.min(position.left, window.innerWidth - 112));
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        data-dac-export-control
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={title}
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className={isWidget ? widgetButtonClass : headerButtonClass}
+        style={{ color: isWidget ? "var(--dac-text-muted)" : undefined }}
+      >
+        <span aria-hidden="true"><DownloadIcon /></span>
+        {!isWidget && <span>{label}</span>}
+      </button>
+
+      {open && createPortal(
+        <div
+          ref={popoverRef}
+          data-dac-export-control
+          role="menu"
+          className="fixed z-[9999] min-w-24 rounded-sm border border-[var(--dac-border)] bg-[var(--dac-surface)] shadow-lg py-1"
+          style={{ top: position.top, left: menuLeft }}
+        >
+          {items.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              role="menuitem"
+              disabled={item.disabled}
+              onClick={() => { void handleSelect(item); }}
+              className="block w-full px-2.5 py-1.5 text-left text-[12px] text-[var(--dac-text-secondary)] hover:text-[var(--dac-text-primary)] hover:bg-[var(--dac-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>,
+        popoverPortalTarget(),
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/widgets/QueryInfo.tsx
+++ b/frontend/src/components/widgets/QueryInfo.tsx
@@ -118,6 +118,7 @@ export function QueryInfo({ query }: Props) {
       <button
         ref={buttonRef}
         type="button"
+        data-dac-export-control
         onMouseEnter={handleButtonEnter}
         onMouseLeave={handleButtonLeave}
         className="inline-flex items-center justify-center w-4 h-4 rounded-full text-[9px] font-medium leading-none opacity-0 group-hover:opacity-30 hover:!opacity-60 transition-opacity duration-150 cursor-default select-none"

--- a/frontend/src/components/widgets/WidgetExportButton.tsx
+++ b/frontend/src/components/widgets/WidgetExportButton.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import type { Widget, WidgetData } from "../../types/dashboard";
+import { widgetDataToCSV, downloadTextFile, slugify } from "../../lib/csv";
+import { exportElementAsPDF, exportElementAsPNG } from "../../lib/renderExport";
+import { ExportMenuButton, type ExportMenuItem } from "../ExportMenuButton";
+
+interface Props {
+  widget: Widget;
+  data?: WidgetData;
+}
+
+function widgetFrameFor(trigger: HTMLButtonElement): HTMLElement {
+  const frame = trigger.closest("[data-dac-widget-frame]");
+  if (!(frame instanceof HTMLElement)) {
+    throw new Error("Widget frame not found");
+  }
+  return frame;
+}
+
+/** Per-widget export menu. Renders nothing when there is no data. */
+export function WidgetExportButton({ widget, data }: Props) {
+  const [exporting, setExporting] = useState(false);
+
+  if (!data || data.error || !data.rows || data.rows.length === 0) return null;
+
+  const exportCSV = () => {
+    const csv = widgetDataToCSV(data);
+    downloadTextFile(`${slugify(widget.name)}.csv`, csv, "text/csv;charset=utf-8");
+  };
+
+  const exportVisual = async (trigger: HTMLButtonElement, format: "png" | "pdf") => {
+    const frame = widgetFrameFor(trigger);
+    const filename = `${slugify(widget.name)}.${format}`;
+    setExporting(true);
+    try {
+      if (format === "png") {
+        await exportElementAsPNG(frame, filename);
+      } else {
+        await exportElementAsPDF(frame, filename);
+      }
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const items: ExportMenuItem[] = [
+    { key: "csv", label: "CSV", onSelect: exportCSV },
+    { key: "png", label: "PNG", onSelect: (trigger) => exportVisual(trigger, "png") },
+    { key: "pdf", label: "PDF", onSelect: (trigger) => exportVisual(trigger, "pdf") },
+  ];
+
+  return (
+    <ExportMenuButton
+      label="Export"
+      ariaLabel={`Export ${widget.name}`}
+      title="Export widget"
+      items={items}
+      disabled={exporting}
+      variant="widget"
+    />
+  );
+}

--- a/frontend/src/lib/csv.ts
+++ b/frontend/src/lib/csv.ts
@@ -1,0 +1,74 @@
+import type { WidgetData } from "../types/dashboard";
+
+/** Render a non-string scalar in a CSV-friendly way. */
+function formatScalar(value: unknown): string {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : "";
+  }
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (value instanceof Date) return value.toISOString();
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Quote a cell per RFC 4180 when it contains a comma, quote, or newline. */
+function escapeCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const s = typeof value === "string" ? value : formatScalar(value);
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/** Convert a single widget's result set to RFC 4180 CSV. */
+export function widgetDataToCSV(data: WidgetData): string {
+  const header = data.columns.map((c) => escapeCell(c.name)).join(",");
+  const lines = [header];
+  for (const row of data.rows) {
+    lines.push(row.map(escapeCell).join(","));
+  }
+  return lines.join("\r\n");
+}
+
+export interface WidgetSection {
+  name: string;
+  data: WidgetData;
+}
+
+/**
+ * Combine multiple widget result sets into one CSV. Each widget is a section
+ * introduced by a `# <name>` divider line followed by its header and rows,
+ * separated from the next section by a blank line.
+ */
+export function dashboardToCSV(sections: WidgetSection[]): string {
+  const blocks: string[] = [];
+  for (const section of sections) {
+    blocks.push(escapeCell(`# ${section.name}`));
+    blocks.push(widgetDataToCSV(section.data));
+    blocks.push("");
+  }
+  return blocks.join("\r\n");
+}
+
+/** Trigger a browser download of a text file. */
+export function downloadTextFile(filename: string, content: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/** Sanitize a name into a filename-safe slug. */
+export function slugify(name: string): string {
+  const slug = name.trim().replace(/[^\w.-]+/g, "_").replace(/_+/g, "_");
+  return slug || "export";
+}

--- a/frontend/src/lib/renderExport.ts
+++ b/frontend/src/lib/renderExport.ts
@@ -1,0 +1,102 @@
+const EXPORT_CONTROL_SELECTOR = "[data-dac-export-control]";
+
+function exportFilter(node: HTMLElement): boolean {
+  if (!(node instanceof Element)) return true;
+  return !node.closest(EXPORT_CONTROL_SELECTOR);
+}
+
+function elementBackground(element: HTMLElement): string {
+  const elementBg = getComputedStyle(element).backgroundColor;
+  if (elementBg && elementBg !== "rgba(0, 0, 0, 0)" && elementBg !== "transparent") {
+    return elementBg;
+  }
+
+  const tokenBg = getComputedStyle(document.documentElement)
+    .getPropertyValue("--dac-background")
+    .trim();
+  return tokenBg || "#ffffff";
+}
+
+function elementSize(element: HTMLElement): { width: number; height: number } {
+  const rect = element.getBoundingClientRect();
+  const width = Math.ceil(Math.max(element.scrollWidth, rect.width));
+  const height = Math.ceil(Math.max(element.scrollHeight, rect.height));
+  if (width <= 0 || height <= 0) {
+    throw new Error("Cannot export an empty element");
+  }
+  return { width, height };
+}
+
+async function waitForFonts(): Promise<void> {
+  if ("fonts" in document) {
+    await document.fonts.ready;
+  }
+}
+
+async function elementToPNGDataURL(element: HTMLElement): Promise<string> {
+  await waitForFonts();
+
+  const { toPng } = await import("html-to-image");
+  const { width, height } = elementSize(element);
+  return toPng(element, {
+    width,
+    height,
+    backgroundColor: elementBackground(element),
+    cacheBust: true,
+    imagePlaceholder: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==",
+    pixelRatio: Math.min(2, Math.max(1, window.devicePixelRatio || 1)),
+    filter: exportFilter,
+  });
+}
+
+function downloadDataURL(filename: string, dataURL: string): void {
+  const a = document.createElement("a");
+  a.href = dataURL;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("Failed to load exported image"));
+    img.src = src;
+  });
+}
+
+export async function exportElementAsPNG(element: HTMLElement, filename: string): Promise<void> {
+  const dataURL = await elementToPNGDataURL(element);
+  downloadDataURL(filename, dataURL);
+}
+
+export async function exportElementAsPDF(element: HTMLElement, filename: string): Promise<void> {
+  const [{ jsPDF }, dataURL] = await Promise.all([
+    import("jspdf"),
+    elementToPNGDataURL(element),
+  ]);
+  const image = await loadImage(dataURL);
+  const orientation = image.width >= image.height ? "landscape" : "portrait";
+  const pdf = new jsPDF({ orientation, unit: "pt", format: "a4", compress: true });
+
+  const margin = 24;
+  const pageWidth = pdf.internal.pageSize.getWidth();
+  const pageHeight = pdf.internal.pageSize.getHeight();
+  const printableWidth = pageWidth - margin * 2;
+  const printableHeight = pageHeight - margin * 2;
+  const renderedWidth = printableWidth;
+  const renderedHeight = (image.height * renderedWidth) / image.width;
+
+  let offsetY = 0;
+  while (offsetY < renderedHeight) {
+    if (offsetY > 0) {
+      pdf.addPage();
+    }
+    pdf.addImage(dataURL, "PNG", margin, margin - offsetY, renderedWidth, renderedHeight, "dac-export", "FAST");
+    offsetY += printableHeight;
+  }
+
+  await pdf.save(filename, { returnPromise: true });
+}

--- a/frontend/src/themes/bruin/WidgetFrame.tsx
+++ b/frontend/src/themes/bruin/WidgetFrame.tsx
@@ -3,6 +3,7 @@ import type { WidgetFrameProps } from "../../types/template";
 import { useTemplate } from "../TemplateProvider";
 import { RowHeightContext } from "../RowContext";
 import { QueryInfo } from "../../components/widgets/QueryInfo";
+import { WidgetExportButton } from "../../components/widgets/WidgetExportButton";
 
 const containerClass: Record<string, string> = {
   metric: "py-3 px-4 h-full dac-metric-border flex flex-col",
@@ -46,15 +47,18 @@ export function BruinWidgetFrame({ widget, data, isLoading }: WidgetFrameProps) 
   }
 
   const isTable = widget.type === "table";
+  const isExportable = widget.type === "chart" || widget.type === "table";
+  const canExport = isExportable && !isLoading;
 
   return (
-    <div className={`group ${containerClass[widget.type] ?? containerClass.text}`}>
+    <div data-dac-widget-frame className={`group ${containerClass[widget.type] ?? containerClass.text}`}>
       {widget.type !== "text" && (
         <div className={`flex items-center text-[11px] font-medium uppercase tracking-wider text-[var(--dac-text-muted)] ${widget.description ? "mb-0.5" : "mb-1.5"} ${isTable ? "px-4" : ""}`}>
           <span>{widget.name}</span>
-          {data?.query && (
-            <span className="ml-auto">
-              <QueryInfo query={data.query} />
+          {(canExport || data?.query) && (
+            <span className="ml-auto inline-flex items-center gap-1">
+              {canExport && <WidgetExportButton widget={widget} data={data} />}
+              {data?.query && <QueryInfo query={data.query} />}
             </span>
           )}
         </div>


### PR DESCRIPTION
## Summary

Adds viewer exports for dashboard and widget data/views: CSV for data, PNG/PDF for rendered dashboard and widget captures.

## Testing

- [x] `make test`
- [x] `make build`
- [x] relevant example or manual smoke test

## Checklist

- [x] scanned `docs/` and updated (or added) the relevant pages
- [x] examples updated if the authoring model changed
- [ ] screenshots or recordings attached for UI changes
