### PR TITLE
feat(dashboards): resolve {{ bruin.user_email }} in widget SQL

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -871,6 +871,12 @@ WHERE created_at >= '{{ filters.date_range.start }}'
 {% endif %}
 ```
 
+**Current viewer (`bruin.user_email`)** — the email of the signed-in user viewing the dashboard. A Bruin Cloud runtime feature that resolves per viewer, so one dashboard shows each person only their own rows:
+```sql
+SELECT * FROM orders WHERE owner_email = '{{ bruin.user_email }}'
+```
+Locally there is no signed-in user, so the value comes from the `BRUIN_USER_EMAIL` environment variable (empty if unset) — pass it inline to preview as a specific person: `BRUIN_USER_EMAIL=someone@example.com dac dev`. In Bruin Cloud it becomes dynamic per signed-in viewer.
+
 ---
 
 ## TSX Dashboards (Code-Based)

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -125,6 +125,16 @@ Select filters support `multiple: true` for multi-select. The value is a list â€
 {% endif %}
 ```
 
+## Current Viewer (`bruin.user_email`)
+
+`{{ bruin.user_email }}` is the email of the signed-in user viewing the dashboard â€” a Bruin Cloud runtime feature that resolves per viewer, so one dashboard can show each person only their own rows:
+
+```sql
+SELECT * FROM orders WHERE owner_email = '{{ bruin.user_email }}'
+```
+
+Locally there is no signed-in user, so the value comes from the `BRUIN_USER_EMAIL` environment variable (empty if unset). To preview a user-scoped dashboard as a specific person, pass it inline: `BRUIN_USER_EMAIL=someone@example.com dac dev`. In Bruin Cloud this becomes dynamic per signed-in viewer.
+
 ## Named Queries
 
 Use named queries when multiple widgets share the same SQL or semantic query.

--- a/docs/dashboards/queries.md
+++ b/docs/dashboards/queries.md
@@ -175,6 +175,7 @@ Structured semantic filters target dimensions. Metric-specific predicates usuall
 | `filters.<name>` | Filter controls | Current filter value |
 | `filters.<date_range>.start` | Date range filter | Start date |
 | `filters.<date_range>.end` | Date range filter | End date |
+| `bruin.user_email` | Signed-in viewer | Email of the user viewing the dashboard. In Bruin Cloud this resolves per viewer at load time; locally it comes from the `BRUIN_USER_EMAIL` environment variable (empty if unset). |
 
 ## Connection Override
 

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -284,11 +284,12 @@ func ResolveWidgetJobs(d *dashboard.Dashboard, filters map[string]any) ([]Widget
 				continue
 			}
 
-			if len(filters) > 0 {
-				sql, err = tmpl.Render(sql, filters)
-				if err != nil {
-					return nil, fmt.Errorf("template error: %w", err)
-				}
+			// Always render: even with no filters, SQL may reference the
+			// `bruin` namespace (e.g. {{ bruin.user_email }}). Render()
+			// short-circuits templates with no placeholders.
+			sql, err = tmpl.Render(sql, filters)
+			if err != nil {
+				return nil, fmt.Errorf("template error: %w", err)
 			}
 			jobs = append(jobs, WidgetJob{ID: WidgetID(i, j), SQL: sql, Connection: conn})
 		}

--- a/pkg/server/semantic.go
+++ b/pkg/server/semantic.go
@@ -126,9 +126,11 @@ func renderSemanticQuery(query sem.Query, filters map[string]any) (sem.Query, er
 }
 
 func renderTemplateString(value string, filters map[string]any) (string, error) {
-	if value == "" || len(filters) == 0 {
+	if value == "" {
 		return value, nil
 	}
+	// Render even with no filters: SQL may reference the `bruin` namespace
+	// (e.g. {{ bruin.user_email }}). Render() short-circuits plain strings.
 	return tmpl.Render(value, filters)
 }
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -3,6 +3,7 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/nikolalohinski/gonja/v2"
@@ -22,6 +23,13 @@ func Render(templateStr string, filters map[string]any) (string, error) {
 
 	ctx := exec.NewContext(map[string]interface{}{
 		"filters": filters,
+		"bruin": map[string]any{
+			// In Bruin Cloud this is the signed-in viewer's email, injected
+			// per request. Locally there's no viewer, so it comes from
+			// BRUIN_USER_EMAIL (empty if unset) — set it to preview a
+			// dashboard as a specific user.
+			"user_email": os.Getenv("BRUIN_USER_EMAIL"),
+		},
 	})
 
 	var buf bytes.Buffer

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -101,6 +101,22 @@ func TestRender_MissingFilter(t *testing.T) {
 	})
 }
 
+func TestRender_BruinUserEmail(t *testing.T) {
+	t.Run("resolves from BRUIN_USER_EMAIL", func(t *testing.T) {
+		t.Setenv("BRUIN_USER_EMAIL", "viewer@example.com")
+		got, err := Render("WHERE owner = '{{ bruin.user_email }}'", map[string]any{})
+		assertNoErr(t, err)
+		assertEqual(t, got, "WHERE owner = 'viewer@example.com'")
+	})
+
+	t.Run("renders empty when unset", func(t *testing.T) {
+		t.Setenv("BRUIN_USER_EMAIL", "")
+		got, err := Render("owner={{ bruin.user_email }}", map[string]any{})
+		assertNoErr(t, err)
+		assertEqual(t, got, "owner=")
+	})
+}
+
 func TestRender_InvalidTemplate(t *testing.T) {
 	t.Run("malformed tag", func(t *testing.T) {
 		_, err := Render("{{ bad syntax !@ }}", map[string]any{})


### PR DESCRIPTION
## What

Adds a `bruin` Jinja namespace to dashboard SQL rendering, with `bruin.user_email` = the email of the signed-in user viewing the dashboard. Scopes rows to the current viewer:

```sql
SELECT * FROM orders WHERE owner_email = '{{ bruin.user_email }}'
```

**Bruin Cloud** injects the real viewer per request. **Locally** there's no signed-in user, so the value comes from the `BRUIN_USER_EMAIL` env var — pass it inline to preview as a specific person:

```
BRUIN_USER_EMAIL=someone@example.com dac dev
```

## Changes

- `pkg/template/template.go` — `Render()` injects `bruin.user_email` from `os.Getenv("BRUIN_USER_EMAIL")` (empty if unset) alongside `filters`.
- `pkg/server/api.go` + `pkg/server/semantic.go` — always render widget/semantic SQL instead of gating on `len(filters) > 0`, so `{{ bruin.* }}` resolves even on a filterless dashboard. `Render()` still short-circuits templates with no placeholders.
- `pkg/template/template_test.go` — covers env-set (resolves) and unset (empty) cases.
- `create-dashboard` skill (shipped template + repo `.claude` copy) and `docs/dashboards/queries.md` — document the variable.

## Companion PRs

- **cloud**: injects the real signed-in viewer's email into `query_params` at runtime.
- **agent-runner**: documents the variable in the dashboard prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)