### PR TITLE
feat(skills): auto-refresh installed skills on dac upgrade

### DIFF
--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -49,6 +49,7 @@ func skillsCmd() *cli.Command {
 			skillsListCmd(),
 			skillsInstallCmd(),
 			skillsUpdateCmd(),
+			skillsAutoUpdateCmd(),
 		},
 		Action: func(_ context.Context, _ *cli.Command) error {
 			return runSkillsList()
@@ -95,6 +96,25 @@ func skillsUpdateCmd() *cli.Command {
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			return runSkillsInstall(cmd.String("dir"), cmd.Args().Slice(), true)
+		},
+	}
+}
+
+// skillsAutoUpdateCmd is an internal command invoked by `dac upgrade` from the
+// freshly installed binary. It updates any installed-but-stale skills in place
+// and reports what changed. It is hidden because end users should reach this
+// behavior through `dac upgrade`, not run it directly.
+func skillsAutoUpdateCmd() *cli.Command {
+	return &cli.Command{
+		Name:   "auto-update",
+		Hidden: true,
+		Usage:  "Refresh installed skills to the bundled version (used by `dac upgrade`)",
+		Flags: []cli.Flag{
+			skillsDirFlag,
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			printSkillUpdates(cmd.String("dir"))
+			return nil
 		},
 	}
 }
@@ -247,7 +267,8 @@ func selectSkills(names []string) ([]bundledSkill, error) {
 // bundled version is newer than the copy in the project. startDir is the
 // dashboard directory; the project root (the nearest ancestor containing a
 // .claude directory) is discovered by walking upward. Skills that are not
-// installed produce no notice — there is nothing to update.
+// installed produce no notice — there is nothing to update. This is passive:
+// it never modifies files. `dac upgrade` performs the actual update.
 func skillUpdateNotices(startDir string) []string {
 	root, ok := findProjectRoot(startDir)
 	if !ok {
@@ -262,7 +283,7 @@ func skillUpdateNotices(startDir string) []string {
 			continue
 		}
 		if parseSkillVersion(skill.Content) > parseSkillVersion(string(data)) {
-			notices = append(notices, fmt.Sprintf("A newer %s skill is available with the latest authoring features and fixes.\nRun `dac skills update` to update your project's copy.", skill.Name))
+			notices = append(notices, fmt.Sprintf("A newer %s skill is available with the latest authoring features and fixes.\nRun `dac upgrade` to update the CLI and refresh your project's copy.", skill.Name))
 		}
 	}
 	return notices
@@ -272,6 +293,48 @@ func skillUpdateNotices(startDir string) []string {
 // stay out of any machine-readable stdout.
 func printSkillUpdateNotices(startDir string) {
 	for _, notice := range skillUpdateNotices(startDir) {
+		fmt.Fprintln(os.Stderr, notice)
+	}
+}
+
+// autoUpdateStaleSkills rewrites installed skills whose bundled version is newer
+// than the copy in the project, then returns a one-line report for each skill it
+// touched. startDir is the dashboard directory; the project root (the nearest
+// ancestor containing a .claude directory) is discovered by walking upward.
+// Skills that are not installed or already current are left untouched — there is
+// nothing to update. The Codex path is a symlink back into the Claude skill
+// directory, so rewriting the SKILL.md updates both agents at once.
+func autoUpdateStaleSkills(startDir string) []string {
+	root, ok := findProjectRoot(startDir)
+	if !ok {
+		return nil
+	}
+
+	var notices []string
+	for _, skill := range dacSkills {
+		installedPath := filepath.Join(root, filepath.FromSlash(skill.ClaudePath))
+		data, err := os.ReadFile(installedPath)
+		if err != nil {
+			continue
+		}
+		to := parseSkillVersion(skill.Content)
+		from := parseSkillVersion(string(data))
+		if to <= from {
+			continue
+		}
+		if err := os.WriteFile(installedPath, []byte(skill.Content), 0o644); err != nil {
+			notices = append(notices, fmt.Sprintf("Could not auto-update the %s skill (v%d -> v%d): %v\nRun `dac skills update` to update it manually.", skill.Name, from, to, err))
+			continue
+		}
+		notices = append(notices, fmt.Sprintf("Updated the %s skill to the latest version (v%d -> v%d). Restart your agent session to pick it up.", skill.Name, from, to))
+	}
+	return notices
+}
+
+// printSkillUpdates auto-updates any stale installed skills and writes what
+// changed to stderr so it stays out of any machine-readable stdout.
+func printSkillUpdates(startDir string) {
+	for _, notice := range autoUpdateStaleSkills(startDir) {
 		fmt.Fprintln(os.Stderr, notice)
 	}
 }

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -177,7 +177,37 @@ func TestParseSkillVersion(t *testing.T) {
 	}
 }
 
-func TestSkillUpdateNotices_FlagsOlderInstall(t *testing.T) {
+func TestSkillUpdateNotices_FlagsButDoesNotModify(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude", "skills", "create-dashboard", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	// An install with no version field reports version 0, older than bundled.
+	original := "---\nname: create-dashboard\n---\nold body"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	notices := skillUpdateNotices(dir)
+	if len(notices) != 1 {
+		t.Fatalf("expected 1 notice, got %d: %v", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "create-dashboard") || !strings.Contains(notices[0], "dac upgrade") {
+		t.Fatalf("unexpected notice text: %q", notices[0])
+	}
+
+	// The notice is passive: the installed file is left untouched.
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read skill after notice: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("skillUpdateNotices modified the skill file")
+	}
+}
+
+func TestAutoUpdateStaleSkills_RewritesOlderInstall(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".claude", "skills", "create-dashboard", "SKILL.md")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -188,18 +218,32 @@ func TestSkillUpdateNotices_FlagsOlderInstall(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	notices := skillUpdateNotices(dir)
+	notices := autoUpdateStaleSkills(dir)
 	if len(notices) != 1 {
 		t.Fatalf("expected 1 notice, got %d: %v", len(notices), notices)
 	}
-	if !strings.Contains(notices[0], "create-dashboard") || !strings.Contains(notices[0], "dac skills update") {
+	if !strings.Contains(notices[0], "create-dashboard") || !strings.Contains(notices[0], "Updated") {
 		t.Fatalf("unexpected notice text: %q", notices[0])
+	}
+
+	// The stale file is rewritten in place with the bundled content.
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read updated skill: %v", err)
+	}
+	if string(got) != createDashboardSkill {
+		t.Fatalf("skill file was not updated to the bundled content")
+	}
+
+	// A second run is a no-op now that the install is current.
+	if notices := autoUpdateStaleSkills(dir); len(notices) != 0 {
+		t.Fatalf("expected no notices after update, got %v", notices)
 	}
 }
 
-func TestSkillUpdateNotices_SilentWhenCurrentOrAbsent(t *testing.T) {
-	// No .claude directory at all: no project root, no notices.
-	if notices := skillUpdateNotices(t.TempDir()); len(notices) != 0 {
+func TestAutoUpdateStaleSkills_SilentWhenCurrentOrAbsent(t *testing.T) {
+	// No .claude directory at all: no project root, nothing to update.
+	if notices := autoUpdateStaleSkills(t.TempDir()); len(notices) != 0 {
 		t.Fatalf("expected no notices without an install, got %v", notices)
 	}
 
@@ -208,12 +252,12 @@ func TestSkillUpdateNotices_SilentWhenCurrentOrAbsent(t *testing.T) {
 	if err := runSkillsInstall(dir, nil, false); err != nil {
 		t.Fatalf("skills install failed: %v", err)
 	}
-	if notices := skillUpdateNotices(dir); len(notices) != 0 {
+	if notices := autoUpdateStaleSkills(dir); len(notices) != 0 {
 		t.Fatalf("expected no notices for a current install, got %v", notices)
 	}
 }
 
-func TestSkillUpdateNotices_DiscoversRootFromSubdir(t *testing.T) {
+func TestAutoUpdateStaleSkills_DiscoversRootFromSubdir(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".claude", "skills", "create-dashboard", "SKILL.md")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -227,8 +271,15 @@ func TestSkillUpdateNotices_DiscoversRootFromSubdir(t *testing.T) {
 		t.Fatalf("create subdir: %v", err)
 	}
 
-	if notices := skillUpdateNotices(sub); len(notices) != 1 {
-		t.Fatalf("expected notice discovered from subdir, got %v", notices)
+	if notices := autoUpdateStaleSkills(sub); len(notices) != 1 {
+		t.Fatalf("expected the skill updated from subdir, got %v", notices)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read updated skill: %v", err)
+	}
+	if string(got) != createDashboardSkill {
+		t.Fatalf("skill file was not updated to the bundled content")
 	}
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -102,7 +102,29 @@ func runUpgrade(ctx context.Context, cmd *cli.Command, build BuildInfo) error {
 	if err := bash.Wait(); err != nil {
 		return fmt.Errorf("installer failed: %w", err)
 	}
+
+	refreshSkillsAfterUpgrade(ctx, bindir)
 	return nil
+}
+
+// refreshSkillsAfterUpgrade brings the current project's installed skills up to
+// the version bundled with the freshly installed binary. It must run the NEW
+// binary — the running process still embeds the old skill content — so it
+// re-execs `dac skills auto-update` from bindir against the current directory.
+// It is best-effort: a failure here never fails the upgrade itself.
+func refreshSkillsAfterUpgrade(ctx context.Context, bindir string) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	newBin := filepath.Join(bindir, "dac")
+	if _, err := os.Stat(newBin); err != nil {
+		return
+	}
+	refresh := exec.CommandContext(ctx, newBin, "skills", "auto-update", "--dir", cwd)
+	refresh.Stdout = os.Stderr
+	refresh.Stderr = os.Stderr
+	_ = refresh.Run()
 }
 
 // inferChannel picks a default channel from the running binary's version

--- a/docs/commands/skills.md
+++ b/docs/commands/skills.md
@@ -45,14 +45,24 @@ Restart your agent session after installing skills so the agent can discover the
 
 ## Update Skills
 
-Each bundled skill carries a version. When you upgrade `dac`, the binary may ship a newer skill than the copy already installed in your project. `dac serve` and `dac validate` print a one-line notice when a newer skill is available:
+Each bundled skill carries a version. When you upgrade `dac`, the binary may ship a newer skill than the copy already installed in your project.
+
+`dac serve` and `dac validate` detect this and print a one-line notice — they never modify files:
 
 ```text
 A newer create-dashboard skill is available with the latest authoring features and fixes.
-Run `dac skills update` to update your project's copy.
+Run `dac upgrade` to update the CLI and refresh your project's copy.
 ```
 
-The notice never modifies files on its own — updating is always an explicit action. Refresh installed skills to the bundled version:
+`dac upgrade` performs the refresh automatically: after installing the new binary it brings any installed-but-stale skills in the current project up to the bundled version and reports what changed:
+
+```text
+Updated the create-dashboard skill to the latest version (v2 -> v3). Restart your agent session to pick it up.
+```
+
+This runs only for skills that are already installed and only bumps them to the version bundled with the newly installed binary — it never installs new skills. Because the refresh overwrites the installed files, any local edits to a skill are replaced.
+
+You can also refresh installed skills manually to the bundled version:
 
 ```shell
 dac skills update --dir .

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -10,6 +10,16 @@ dac upgrade [tag] [flags]
 
 `dac update` is an alias.
 
+## Skill refresh
+
+After the new binary is installed, `dac upgrade` refreshes your project's bundled agent skills to match it: any skill already installed in the current project (under `.claude/skills/`) whose bundled version is now newer is updated in place, and a one-line notice reports what changed.
+
+```text
+Updated the create-dashboard skill to the latest version (v2 -> v3). Restart your agent session to pick it up.
+```
+
+This runs from the newly installed binary and only touches skills that are already installed — it never installs new skills and never creates project directories. If you run `dac upgrade` outside a DAC project, nothing is refreshed. The refresh is best-effort: a failure never fails the upgrade. See [`dac skills`](skills.md) for manual control.
+
 ## Flags
 
 | Flag | Type | Default | Description |


### PR DESCRIPTION
## What

`dac upgrade` (alias `dac update`) now refreshes a project's installed skills to the version bundled with the freshly installed binary. `dac serve` / `dac validate` go back to being passive — they warn but never modify files.

## Why

Previously the only signal that a skill was out of date was a notice on `serve`/`validate` telling the user to run `dac skills update` by hand. Tying the refresh to the binary upgrade makes it automatic: upgrade the CLI, and your project's skills come along with it.

## How

- After the install script succeeds, `refreshSkillsAfterUpgrade` re-execs the **newly installed** binary (`dac skills auto-update --dir <cwd>`). This matters: the running upgrade process still embeds the *old* skill content, so the update has to run from the new binary to write the new version.
- `skills auto-update` is a hidden command. It walks up from the given dir to find the project root, and updates only skills that are **already installed** and whose bundled version is newer. It never installs new skills and never creates directories.
- The refresh is best-effort: a failure there never fails the upgrade.
- `serve` / `validate` keep printing a one-line notice pointing at `dac upgrade`.

## Behavior

| Command | Stale skill detected |
|---|---|
| `dac serve` / `dac validate` | Prints a notice, **no file changes** |
| `dac upgrade` / `dac update` | Refreshes installed skills, reports `Updated the create-dashboard skill to the latest version (v2 -> v3)...` |

## Testing

Unit tests cover the passive notice (asserts the file is left untouched) and the in-place refresh (asserts the file is rewritten to bundled content and repeat runs are no-ops).

Also verified locally against the built binary (bundled skill v3):
- `validate` on a v2 install → warns, file stays v2.
- `skills auto-update` → v2→v3, byte-for-byte match with the bundled template, second run is a no-op.
- Outside a project / `.claude` present but skill not installed → no output, nothing created.
- Full re-exec simulation (`cd project && $BINDIR/dac skills auto-update --dir $PWD`) → v1→v3.

`make build` and `make test` pass.

## Docs

Updated `docs/commands/upgrade.md` (new skill-refresh section) and `docs/commands/skills.md` (serve/validate now passive; upgrade does the refresh).