### PR TITLE
Add VS Code webview embed support to the dac frontend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}
+
+      # Build the relative-path embed variant for the Bruin VS Code extension
+      # and attach it as a release asset (separate from the binary's base:"/" build).
+      - name: Build & upload embed frontend for the VS Code extension
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DAC_EMBED: "1"
+        run: |
+          npm --prefix frontend run build -- --outDir dist-embed --emptyOutDir
+          tar -czf dac-frontend.tar.gz -C frontend/dist-embed .
+          gh release upload "${{ github.ref_name }}" dac-frontend.tar.gz --clobber

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-embed
 dist-ssr
 *.local
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from "react";
 import { BrowserRouter, HashRouter, Navigate, Routes, Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { TemplateProvider } from "./themes/TemplateProvider";
@@ -9,7 +10,9 @@ import { Admin } from "./components/Admin";
 import { useLiveReload } from "./hooks/useLiveReload";
 
 const staticPayload = getStaticPayload();
-const Router = staticPayload ? HashRouter : BrowserRouter;
+// HashRouter for embed/static mode (no server-side routing).
+const isEmbedded = !!window.__DAC_API_BASE__;
+const Router = staticPayload || isEmbedded ? HashRouter : BrowserRouter;
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,13 +23,21 @@ const queryClient = new QueryClient({
   },
 });
 
+// Dashboard the embed asked to open first, if any.
+const initialDashboard = window.__DAC_INITIAL_DASHBOARD__;
+
 function DashboardContent() {
   useLiveReload();
 
-  // In static mode, skip the list and go straight to the baked dashboard.
-  const home = staticPayload
-    ? <Navigate to={`/d/${encodeURIComponent(staticPayload.dashboard.name)}`} replace />
-    : <DashboardList />;
+  // Static → baked dashboard; embed → requested one; else the list.
+  let home: ReactElement;
+  if (staticPayload) {
+    home = <Navigate to={`/d/${encodeURIComponent(staticPayload.dashboard.name)}`} replace />;
+  } else if (isEmbedded && initialDashboard) {
+    home = <Navigate to={`/d/${encodeURIComponent(initialDashboard)}`} replace />;
+  } else {
+    home = <DashboardList />;
+  }
 
   return (
     <Routes>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,7 +1,8 @@
 import type { DashboardSummary, Dashboard, BatchDataResponse, WidgetData } from "../types/dashboard";
 import type { Theme } from "../types/theme";
 
-const BASE = "/api/v1";
+// Embed injects the dac-serve URL; else relative.
+const BASE = (window.__DAC_API_BASE__ || "") + "/api/v1";
 
 // --- Static payload detection ---
 

--- a/frontend/src/hooks/useDashboardData.ts
+++ b/frontend/src/hooks/useDashboardData.ts
@@ -2,6 +2,9 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { streamDashboardData } from "../api/client";
 import type { WidgetData } from "../types/dashboard";
 
+// Embed injects the dac-serve URL; else relative.
+const API_BASE = (window.__DAC_API_BASE__ || "") + "/api/v1";
+
 interface StreamState {
   /** Accumulated widget results, updated as each arrives. */
   data: Record<string, WidgetData> | undefined;
@@ -24,7 +27,7 @@ function onReloadTick(fn: () => void) {
 
 // Single SSE listener (module scope, starts once).
 if (typeof window !== "undefined" && !window.__DAC_STATIC__) {
-  const es = new EventSource("/api/v1/events");
+  const es = new EventSource(`${API_BASE}/events`);
   es.onmessage = (event) => {
     try {
       const data = JSON.parse(event.data);

--- a/frontend/src/hooks/useLiveReload.ts
+++ b/frontend/src/hooks/useLiveReload.ts
@@ -1,6 +1,9 @@
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
+// Embed injects the dac-serve URL; else relative.
+const API_BASE = (window.__DAC_API_BASE__ || "") + "/api/v1";
+
 export function useLiveReload() {
   const queryClient = useQueryClient();
 
@@ -8,7 +11,7 @@ export function useLiveReload() {
     // No server to connect to in static mode.
     if (window.__DAC_STATIC__) return;
 
-    const es = new EventSource("/api/v1/events");
+    const es = new EventSource(`${API_BASE}/events`);
 
     es.onmessage = (event) => {
       try {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -5,6 +5,9 @@ import type { StaticPayload } from "./api/client";
 declare global {
   interface Window {
     __DAC_STATIC__?: StaticPayload;
+    // Injected by the Bruin VS Code embed: dac-serve URL + initial dashboard.
+    __DAC_API_BASE__?: string;
+    __DAC_INITIAL_DASHBOARD__?: string;
   }
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,12 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
+// Read the build-time env flag without pulling in @types/node.
+declare const process: { env: Record<string, string | undefined> };
+
 export default defineConfig({
+  // Relative paths only for the webview embed; standalone dac keeps base "/".
+  base: process.env.DAC_EMBED ? "./" : "/",
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -197,6 +197,20 @@ func spaHandler(fsys fs.FS) http.Handler {
 	})
 }
 
+// corsMiddleware lets the VS Code webview embed (a different origin) reach the server.
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Cache-Control, Accept")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // Start begins listening and serving.
 // It tries the configured port first, then increments until it finds an available one.
 func (s *Server) Start() error {
@@ -213,6 +227,8 @@ func (s *Server) Start() error {
 		go s.watcher.Run()
 	}
 
+	handler := corsMiddleware(s.mux)
+
 	port := s.config.Port
 	maxAttempts := 50
 	for i := 0; i < maxAttempts; i++ {
@@ -224,7 +240,7 @@ func (s *Server) Start() error {
 			continue
 		}
 		log.Printf("dac server listening on http://%s", addr)
-		return http.Serve(ln, s.mux)
+		return http.Serve(ln, handler)
 	}
 
 	return fmt.Errorf("no available port found in range %d-%d", s.config.Port, s.config.Port+maxAttempts-1)


### PR DESCRIPTION
Lets the Bruin VS Code extension embed dac's built frontend in a webview.

- gate asset `base` behind `DAC_EMBED` so only the embed build uses relative paths (the standalone binary keeps `base:"/"`)
- read the dac-serve URL + initial dashboard from injected globals; use HashRouter when embedded
- CORS so the webview (a different origin) can reach the local server
- surface config-load failures instead of a blank screen, plus an error boundary
- `axisField`/`axisFields` now tolerate the bare string/array axis shorthand — fixes blank charts for semantic dashboards (also affects standalone)
- release workflow builds the frontend with `DAC_EMBED=1` and attaches `dac-frontend.tar.gz` to the release