### PR TITLE
feat(dashboards): table conditional formatting

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -763,6 +763,40 @@ Data table with optional column configuration.
 
 If `columns` is omitted, all result columns are shown with their SQL names as headers.
 
+**Conditional formatting** comes in two spreadsheet-style modes — a **colour scale** (gradient) and/or **single colour** (threshold rules).
+
+*Colour scale* — shade cells by value across up to three stops:
+
+```yaml
+  columns:
+    - name: revenue
+      format: currency
+      colorScale:
+        min: { type: min,        color: "#E67C73" }        # min | number | percent | percentile (NOT max)
+        mid: { type: percentile, value: 50, color: "#FFFFFF" }  # number | percent | percentile
+        max: { type: number,     value: 1000, color: "#57BB8A" } # max | number | percent | percentile (NOT min)
+```
+
+Each stop is `{ type, value, color }`; a bare string is shorthand for the color, and `colorScale: {}` gives the default red→white→green. Omit `mid` for a 2-color scale. `value` is required for `number`/`percent`/`percentile` (0–100 for the latter two) and disallowed for `min`/`max`. Defaults: min stop→`min`, max stop→`max`, mid→`percentile` 50.
+
+*Single colour* — apply a fixed style to cells matching a condition (first match wins):
+
+```yaml
+  columns:
+    - name: status
+      singleColor:
+        - if: text_is_exactly
+          value: overdue
+          background: "#FEE2E2"
+          textColor: "#991B1B"
+          bold: true            # also: italic, underline, strikethrough
+        - if: is_between
+          value: [10, 20]       # two-element list for is_between / is_not_between
+          background: "#FEF9C3"
+```
+
+Operators: `is_empty`, `is_not_empty`, `text_contains`, `text_does_not_contain`, `text_starts_with`, `text_ends_with`, `text_is_exactly`, `date_is`, `date_before`, `date_after`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `is_equal_to`, `is_not_equal_to`, `is_between`, `is_not_between`. Each rule needs ≥1 style (`background`, `textColor`, `bold`, `italic`, `underline`, `strikethrough`). Date operators compare by day for date-only values (`"2026-07-22"`) or by exact instant when the value includes a time (`"2026-07-22T12:00"`).
+
 ### Text Widget
 
 Static content with markdown formatting. No query needed.

--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -763,61 +763,18 @@ Data table with optional column configuration.
 
 If `columns` is omitted, all result columns are shown with their SQL names as headers.
 
-**Conditional formatting.** A column sets value display with `number` and coloring with `format`. `number` is `currency`, `number`, or a d3-format string. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**.
+**Conditional formatting.** A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**.
 
-A layer's `if` is optional: with `if`, the layer styles only the cells that match; without `if`, the layer styles every cell, so put it **last** as the fallback.
+- With `if` (+ `value`), the layer styles only the cells that match. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
+- With no `if`, the layer styles every cell — a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put it last as the fallback.
+- Styles on any layer: `backgroundColor`, `textColor`, `bold`, `italic`, `underline`, `strikethrough`.
+- `like`: mirror another column's coloring, driven by that column's per-row value, while keeping this column's own `number`.
 
-**Column keys**
+Each layer is a YAML object, so `- { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }` and the same keys written as an indented block are identical — use whichever reads better.
 
-| Key | What it does |
-|-----|--------------|
-| `number` | Value display: `currency`, `number`, or a d3-format string. |
-| `like` | Mirror another column's coloring, driven by that column's per-row value (keeps own `number`). |
-| `format` | Ordered list of style layers; first match wins. |
+Colors are **named** (`red green blue indigo cyan purple pink amber`, plus `white`/`black`, aliases `positive`/`negative`/`warning`) or hex. Named colors adapt to light and dark.
 
-**Layer keys** (the `Group` column shows which keys belong together):
-
-| Group | Key | What it does |
-|-------|-----|--------------|
-| Condition | `if` | The operator (below). Omit to apply the layer to every cell. |
-| Condition | `value` | What `if` compares against: scalar, `[low, high]` for between, `{ column: X }` for cross-column, omitted for empty checks. |
-| Fill | `backgroundColor` | **string** = flat/single fill. **list** = gradient (at least 2 colors). |
-| Fill | `range` + `unit` | Gradient only. `range` is a list of numbers; `unit` is `absolute`, `percent`, or `percentile`. Omit `range` for an auto min/max gradient. |
-| Text | `textColor` | Text color. |
-| Text | `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
-
-Each layer is a YAML object, so these two forms are identical — use whichever reads better:
-
-```yaml
-- { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }   # compact (flow)
-
-- backgroundColor: [red, white, green]                                            # block
-  range: [-25, 0, 25]
-  unit: absolute
-```
-
-**Colors** (any color field)
-
-| Kind | Values |
-|------|--------|
-| Named | `red` `green` `blue` `indigo` `cyan` `purple` `pink` `amber` |
-| Fixed | `white` `black` |
-| Aliases | `positive` (green), `negative` (red), `warning` (amber) |
-| Hex | any `"#rrggbb"` |
-
-Named colors match the chart palette and adapt to light/dark; `white` and `black` are fixed literals. Named fills are softened toward the theme surface.
-
-**Operators** (a layer's `if`)
-
-| Group | Operators |
-|-------|-----------|
-| Empty | `is_empty`, `is_not_empty` |
-| Text (case insensitive) | `text_contains`, `text_does_not_contain`, `text_starts_with`, `text_ends_with`, `text_is_exactly` |
-| Number | `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `is_equal_to`, `is_not_equal_to` |
-| Range | `is_between`, `is_not_between` |
-| Date | `date_is`, `date_before`, `date_after` (by day for a date, or exact instant if the value has a time) |
-
-**Worked example** (every feature):
+Worked example:
 
 ```yaml
 name: Regions
@@ -832,70 +789,47 @@ rows:
           - name: region
             format:
               - { backgroundColor: "#F8FAFC", bold: true }              # flat fill + text style
-
           - name: revenue
             number: currency
             format:
               - { backgroundColor: [red, white, green] }                # gradient, auto min→max
-
           - name: growth
             number: number
             format:
               - { backgroundColor: [blue, white, amber], range: [-25, 0, 25], unit: absolute }   # 0 = neutral
-
           - name: margin
             number: ".0%"
             format:
               - { backgroundColor: [red, amber, green], range: [0, 50, 100], unit: percentile }  # midpoint = median
-
           - name: score
             number: number
             format:                                                     # conditions, first match wins
               - { if: greater_than_or_equal, value: 80, backgroundColor: green }
               - { if: is_between, value: [50, 79], backgroundColor: amber }
               - { if: less_than, value: 50, textColor: red, strikethrough: true }
-
           - name: status
-            format:                                                     # text conditions
+            format:
               - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
               - { if: text_is_exactly, value: overdue, backgroundColor: red }
               - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }
-
           - name: actual
             number: number
             format:                                                     # cross-column, same row
               - { if: less_than, value: { column: target }, backgroundColor: red }
               - { if: greater_than, value: { column: target }, backgroundColor: green }
-
           - name: bonus
             number: currency
             like: score                                                 # mirror score's colors, keep own number
-
           - name: due
-            format:                                                     # date conditions
+            format:
               - { if: date_before, value: "2026-07-22", textColor: red }
               - { if: date_after, value: "2026-07-22", textColor: green }
-
           - name: health
             number: number
             format:                                                     # a condition wins over the gradient base below
               - { if: is_equal_to, value: 0, backgroundColor: red, bold: true }
-              - { backgroundColor: [red, white, green] }                # gradient base, last (always matches)
+              - { backgroundColor: [red, white, green] }
 ```
-
-How it reads:
-- `region`: one flat fill, bold (a single base layer).
-- `revenue`: currency, auto min→max gradient.
-- `growth`: gradient with `range` + `unit: absolute`, neutral pinned to 0.
-- `margin`: gradient anchored by `percentile` (midpoint = median).
-- `score`: numeric conditions, first match wins (a scalar, a `[low, high]` range, and a text style).
-- `status`: text conditions, first match wins.
-- `actual`: cross-column conditions vs `target` in the same row.
-- `bonus`: `like: score`, takes score's colors, keeps its own currency.
-- `due`: date conditions.
-- `health`: a condition checked first, then a gradient base as the fallback for every other value.
-
-Cross-column: in `{ if: less_than, value: { column: target }, backgroundColor: red }`, the `actual` cell compares to that row's `target` (not a constant), so each row uses its own target. `target` can be a column you do not display; its data is still available. (`value: 100` would compare against the constant 100.)
 
 ### Text Widget
 

--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -763,20 +763,28 @@ Data table with optional column configuration.
 
 If `columns` is omitted, all result columns are shown with their SQL names as headers.
 
-**Conditional formatting** lives in the column's `format`. The object handles the number format **and** coloring together. The keys and options are below; a full worked example follows at the end.
+**Conditional formatting.** A column sets value display with `number` and coloring with `format`. `number` is `currency`, `number`, or a d3-format string. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**.
 
-**`format` keys**
+A layer is either a **condition** (`if` set), or a **base** with no `if` that always applies: a **gradient** (`backgroundColor` list, optional `range`/`unit`) or a **flat fill** (`backgroundColor` string). A base always matches, so put it **last** as the fallback.
+
+**Column keys**
 
 | Key | What it does |
 |-----|--------------|
 | `number` | Value display: `currency`, `number`, or a d3-format string. |
-| `backgroundColor` | **string** = flat fill for the whole column. **array** = gradient (at least 2 colors). |
-| `domain` | Gradient anchors. A raw array `[-25, 0, 25]`, or `{ unit, anchors }` where `unit` is `value` (default) / `percent` / `percentile`. Omit for auto min/max; omit `anchors` to spread evenly (percentile puts the midpoint at the median). |
-| `scheme` | A built-in gradient by name instead of listing colors. |
+| `like` | Mirror another column's coloring, driven by that column's per-row value (keeps own `number`). |
+| `format` | Ordered list of style layers; first match wins. |
+
+**Layer keys**
+
+| Key | What it does |
+|-----|--------------|
+| `if` | Condition operator (below). Omit for a base layer (gradient or flat fill) that always applies. |
+| `value` | Comparison value: scalar, `[low, high]` for between, `{ column: X }` for cross-column, omitted for empty checks. |
+| `backgroundColor` | **string** = flat/single fill. **list** = gradient (at least 2 colors). |
+| `range` + `unit` | Gradient anchors. `range` is a list of numbers; `unit` is `absolute`, `percent`, or `percentile`. Omit `range` for an auto min/max gradient. |
 | `textColor` | Text color. |
 | `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
-| `rules` | Conditional styling, evaluated in order, first match wins. |
-| `like` | Copy another column's coloring, driven by that column's value. |
 
 **Colors** (any color field)
 
@@ -787,20 +795,9 @@ If `columns` is omitted, all result columns are shown with their SQL names as he
 | Aliases | `positive` (green), `negative` (red), `warning` (amber) |
 | Hex | any `"#rrggbb"` |
 
-Named colors match the chart palette and adapt to light/dark; `white` and `black` are fixed literals that stay the same in both themes.
+Named colors match the chart palette and adapt to light/dark; `white` and `black` are fixed literals. Named fills are softened toward the theme surface.
 
-**Built in `scheme`s:** `red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`.
-
-**Rule fields** (each rule = one condition + one or more styles)
-
-| Field | What it does |
-|-------|--------------|
-| `if` | Operator (required). See the table below. |
-| `value` | Scalar to compare against. Use `[low, high]` for between, `{ column: X }` for cross column, omit for empty checks. |
-| `backgroundColor` / `textColor` | Cell colors. |
-| `bold` / `italic` / `underline` / `strikethrough` | Text styling. At least one style is required. |
-
-**Operators**
+**Operators** (a layer's `if`)
 
 | Group | Operators |
 |-------|-----------|
@@ -810,7 +807,7 @@ Named colors match the chart palette and adapt to light/dark; `white` and `black
 | Range | `is_between`, `is_not_between` |
 | Date | `date_is`, `date_before`, `date_after` (by day for a date, or exact instant if the value has a time) |
 
-**Worked example** (a full dashboard exercising every feature above):
+**Worked example** (every feature):
 
 ```yaml
 name: Regions
@@ -823,75 +820,72 @@ rows:
         sql: SELECT region, revenue, growth, margin, score, status, actual, target, bonus, due FROM regions
         columns:
           - name: region
-            format: { backgroundColor: "#F8FAFC", bold: true }          # flat fill + text style
+            format:
+              - { backgroundColor: "#F8FAFC", bold: true }              # flat fill + text style
 
           - name: revenue
+            number: currency
             format:
-              number: currency                                          # value display: currency
-              scheme: red-white-green                                   # built-in gradient
+              - { backgroundColor: [red, white, green] }                # gradient, auto min→max
 
           - name: growth
+            number: number
             format:
-              number: number
-              domain: [-25, 0, 25]                                      # raw anchors (0 = neutral middle)
-              backgroundColor: [blue, white, amber]                     # custom gradient colors
+              - { backgroundColor: [blue, white, amber], range: [-25, 0, 25], unit: absolute }   # 0 = neutral
 
           - name: margin
+            number: ".0%"
             format:
-              number: ".0%"                                             # d3-format string
-              scheme: red-amber-green                                   # built-in scheme
-              domain: { unit: percentile }                              # anchor by percentile (midpoint = median)
+              - { backgroundColor: [red, amber, green], range: [0, 50, 100], unit: percentile }  # midpoint = median
 
           - name: score
-            format:
-              number: number
-              rules:                                                    # numeric rules, first match wins
-                - { if: greater_than_or_equal, value: 80, backgroundColor: green }    # scalar value
-                - { if: is_between, value: [50, 79], backgroundColor: amber }          # [low, high] for between
-                - { if: less_than, value: 50, textColor: red, strikethrough: true }    # text style
+            number: number
+            format:                                                     # conditions, first match wins
+              - { if: greater_than_or_equal, value: 80, backgroundColor: green }
+              - { if: is_between, value: [50, 79], backgroundColor: amber }
+              - { if: less_than, value: 50, textColor: red, strikethrough: true }
 
           - name: status
-            format:
-              rules:                                                    # text rules
-                - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
-                - { if: text_is_exactly, value: overdue, backgroundColor: red }
-                - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }           # no value for empty checks
+            format:                                                     # text conditions
+              - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
+              - { if: text_is_exactly, value: overdue, backgroundColor: red }
+              - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }
 
           - name: actual
-            format:
-              number: number
-              rules:
-                - { if: less_than, value: { column: target }, backgroundColor: red }    # cross-column, same row
-                - { if: greater_than, value: { column: target }, backgroundColor: green }
+            number: number
+            format:                                                     # cross-column, same row
+              - { if: less_than, value: { column: target }, backgroundColor: red }
+              - { if: greater_than, value: { column: target }, backgroundColor: green }
 
           - name: bonus
-            format: { number: currency, like: score }                  # mirror score's colors, keep own number
+            number: currency
+            like: score                                                 # mirror score's colors, keep own number
 
           - name: due
-            format:
-              rules:                                                    # date rules
-                - { if: date_before, value: "2026-07-22", textColor: red }
-                - { if: date_after, value: "2026-07-22", textColor: green }
+            format:                                                     # date conditions
+              - { if: date_before, value: "2026-07-22", textColor: red }
+              - { if: date_after, value: "2026-07-22", textColor: green }
+
+          - name: health
+            number: number
+            format:                                                     # a condition wins over the gradient base below
+              - { if: is_equal_to, value: 0, backgroundColor: red, bold: true }
+              - { backgroundColor: [red, white, green] }                # gradient base, last (always matches)
 ```
 
-How the example reads, column by column:
-- `region`: one flat color on every cell, bold text (a plain string fill plus a text style).
-- `revenue`: currency, colored by the built-in `red-white-green` gradient.
-- `growth`: a custom blue/white/amber gradient with the neutral point pinned to 0 via a raw `domain`.
-- `margin`: a percentage, colored by the built-in `red-amber-green` scheme, anchored by `percentile` so the midpoint sits at the median.
-- `score`: numeric rules covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`), plus a text style (`< 50` struck through in red).
-- `status`: text rules checked in order, first match wins (contains "urgent", exactly "overdue", or empty).
-- `actual`: cross-column rules, compared to `target` in the same row (explained next).
-- `bonus`: `like: score`, so it takes score's colors per row but keeps its own currency display.
-- `due`: date rules, before or after a cutoff day.
+How it reads:
+- `region`: one flat fill, bold (a single base layer).
+- `revenue`: currency, auto min→max gradient.
+- `growth`: gradient with `range` + `unit: absolute`, neutral pinned to 0.
+- `margin`: gradient anchored by `percentile` (midpoint = median).
+- `score`: numeric conditions, first match wins (a scalar, a `[low, high]` range, and a text style).
+- `status`: text conditions, first match wins.
+- `actual`: cross-column conditions vs `target` in the same row.
+- `bonus`: `like: score`, takes score's colors, keeps its own currency.
+- `due`: date conditions.
+- `health`: a condition checked first, then a gradient base as the fallback for every other value.
 
-Cross column, step by step. Look at the `actual` rule:
-
-```yaml
-{ if: less_than, value: { column: target }, backgroundColor: red }
-```
-
-The cell being colored is `actual`. `value: { column: target }` means "compare it to the `target` column in the same row", not to a fixed number. So for every row independently: if that row's `actual` is less than that row's `target`, the `actual` cell turns red. Row 1 uses row 1's target, row 2 uses row 2's target, and so on. `target` can even be a column you do not display in the table, because its data is still available for the comparison. (Writing `value: 100` instead would compare against the constant 100.)
+Cross-column: in `{ if: less_than, value: { column: target }, backgroundColor: red }`, the `actual` cell compares to that row's `target` (not a constant), so each row uses its own target. `target` can be a column you do not display; its data is still available. (`value: 100` would compare against the constant 100.)
 
 ### Text Widget
 

--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -765,7 +765,7 @@ If `columns` is omitted, all result columns are shown with their SQL names as he
 
 **Conditional formatting.** A column sets value display with `number` and coloring with `format`. `number` is `currency`, `number`, or a d3-format string. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**.
 
-A layer is either a **condition** (`if` set), or a **base** with no `if` that always applies: a **gradient** (`backgroundColor` list, optional `range`/`unit`) or a **flat fill** (`backgroundColor` string). A base always matches, so put it **last** as the fallback.
+A layer's `if` is optional: with `if`, the layer styles only the cells that match; without `if`, the layer styles every cell, so put it **last** as the fallback.
 
 **Column keys**
 
@@ -775,16 +775,26 @@ A layer is either a **condition** (`if` set), or a **base** with no `if` that al
 | `like` | Mirror another column's coloring, driven by that column's per-row value (keeps own `number`). |
 | `format` | Ordered list of style layers; first match wins. |
 
-**Layer keys**
+**Layer keys** (the `Group` column shows which keys belong together):
 
-| Key | What it does |
-|-----|--------------|
-| `if` | Condition operator (below). Omit for a base layer (gradient or flat fill) that always applies. |
-| `value` | Comparison value: scalar, `[low, high]` for between, `{ column: X }` for cross-column, omitted for empty checks. |
-| `backgroundColor` | **string** = flat/single fill. **list** = gradient (at least 2 colors). |
-| `range` + `unit` | Gradient anchors. `range` is a list of numbers; `unit` is `absolute`, `percent`, or `percentile`. Omit `range` for an auto min/max gradient. |
-| `textColor` | Text color. |
-| `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
+| Group | Key | What it does |
+|-------|-----|--------------|
+| Condition | `if` | The operator (below). Omit to apply the layer to every cell. |
+| Condition | `value` | What `if` compares against: scalar, `[low, high]` for between, `{ column: X }` for cross-column, omitted for empty checks. |
+| Fill | `backgroundColor` | **string** = flat/single fill. **list** = gradient (at least 2 colors). |
+| Fill | `range` + `unit` | Gradient only. `range` is a list of numbers; `unit` is `absolute`, `percent`, or `percentile`. Omit `range` for an auto min/max gradient. |
+| Text | `textColor` | Text color. |
+| Text | `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
+
+Each layer is a YAML object, so these two forms are identical — use whichever reads better:
+
+```yaml
+- { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }   # compact (flow)
+
+- backgroundColor: [red, white, green]                                            # block
+  range: [-25, 0, 25]
+  unit: absolute
+```
 
 **Colors** (any color field)
 

--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -772,7 +772,7 @@ If `columns` is omitted, all result columns are shown with their SQL names as he
 | `number` | Value display: `currency`, `number`, or a d3-format string. |
 | `backgroundColor` | **string** = flat fill for the whole column. **array** = gradient (at least 2 colors). |
 | `domain` | Gradient anchors. A raw array `[-25, 0, 25]`, or `{ unit, anchors }` where `unit` is `value` (default) / `percent` / `percentile`. Omit for auto min/max; omit `anchors` to spread evenly (percentile puts the midpoint at the median). |
-| `scheme` | A gradient by name instead of listing colors: a built-in, or a custom `palettes` entry (see below). |
+| `scheme` | A built-in gradient by name instead of listing colors. |
 | `textColor` | Text color. |
 | `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
 | `rules` | Conditional styling, evaluated in order, first match wins. |
@@ -790,16 +790,6 @@ If `columns` is omitted, all result columns are shown with their SQL names as he
 Named colors match the chart palette and adapt to light/dark; `white` and `black` are fixed literals that stay the same in both themes.
 
 **Built in `scheme`s:** `red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`.
-
-**Custom palettes:** define reusable gradients at the dashboard top level under `palettes` (name → 2+ colors), then reference one by name with `scheme`. A palette name must not collide with a built-in.
-
-```yaml
-palettes:
-  risk: [red, amber, green]
-columns:
-  - name: growth
-    format: { scheme: risk }        # the palette, by name
-```
 
 **Rule fields** (each rule = one condition + one or more styles)
 
@@ -825,9 +815,6 @@ columns:
 ```yaml
 name: Regions
 
-palettes:
-  risk: [red, amber, green]                                       # custom palette, reused by name via `scheme`
-
 rows:
   - widgets:
       - name: Regions
@@ -852,7 +839,7 @@ rows:
           - name: margin
             format:
               number: ".0%"                                             # d3-format string
-              scheme: risk                                              # custom palette, by name
+              scheme: red-amber-green                                   # built-in scheme
               domain: { unit: percentile }                              # anchor by percentile (midpoint = median)
 
           - name: score
@@ -891,7 +878,7 @@ How the example reads, column by column:
 - `region`: one flat color on every cell, bold text (a plain string fill plus a text style).
 - `revenue`: currency, colored by the built-in `red-white-green` gradient.
 - `growth`: a custom blue/white/amber gradient with the neutral point pinned to 0 via a raw `domain`.
-- `margin`: a percentage, colored by the custom `risk` palette, anchored by `percentile` so the midpoint sits at the median.
+- `margin`: a percentage, colored by the built-in `red-amber-green` scheme, anchored by `percentile` so the midpoint sits at the median.
 - `score`: numeric rules covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`), plus a text style (`< 50` struck through in red).
 - `status`: text rules checked in order, first match wins (contains "urgent", exactly "overdue", or empty).
 - `actual`: cross-column rules, compared to `target` in the same row (explained next).

--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -763,39 +763,148 @@ Data table with optional column configuration.
 
 If `columns` is omitted, all result columns are shown with their SQL names as headers.
 
-**Conditional formatting** comes in two spreadsheet-style modes — a **colour scale** (gradient) and/or **single colour** (threshold rules).
+**Conditional formatting** lives in the column's `format`. The object handles the number format **and** coloring together. The keys and options are below; a full worked example follows at the end.
 
-*Colour scale* — shade cells by value across up to three stops:
+**`format` keys**
+
+| Key | What it does |
+|-----|--------------|
+| `number` | Value display: `currency`, `number`, or a d3-format string. |
+| `backgroundColor` | **string** = flat fill for the whole column. **array** = gradient (at least 2 colors). |
+| `domain` | Gradient anchors. A raw array `[-25, 0, 25]`, or `{ unit, anchors }` where `unit` is `value` (default) / `percent` / `percentile`. Omit for auto min/max; omit `anchors` to spread evenly (percentile puts the midpoint at the median). |
+| `scheme` | A gradient by name instead of listing colors: a built-in, or a custom `palettes` entry (see below). |
+| `textColor` | Text color. |
+| `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
+| `rules` | Conditional styling, evaluated in order, first match wins. |
+| `like` | Copy another column's coloring, driven by that column's value. |
+
+**Colors** (any color field)
+
+| Kind | Values |
+|------|--------|
+| Named | `red` `green` `blue` `indigo` `cyan` `purple` `pink` `amber` |
+| Fixed | `white` `black` |
+| Aliases | `positive` (green), `negative` (red), `warning` (amber) |
+| Hex | any `"#rrggbb"` |
+
+Named colors match the chart palette and adapt to light/dark; `white` and `black` are fixed literals that stay the same in both themes.
+
+**Built in `scheme`s:** `red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`.
+
+**Custom palettes:** define reusable gradients at the dashboard top level under `palettes` (name → 2+ colors), then reference one by name with `scheme`. A palette name must not collide with a built-in.
 
 ```yaml
-  columns:
-    - name: revenue
-      format: currency
-      colorScale:
-        min: { type: min,        color: "#E67C73" }        # min | number | percent | percentile (NOT max)
-        mid: { type: percentile, value: 50, color: "#FFFFFF" }  # number | percent | percentile
-        max: { type: number,     value: 1000, color: "#57BB8A" } # max | number | percent | percentile (NOT min)
+palettes:
+  risk: [red, amber, green]
+columns:
+  - name: growth
+    format: { scheme: risk }        # the palette, by name
 ```
 
-Each stop is `{ type, value, color }`; a bare string is shorthand for the color, and `colorScale: {}` gives the default red→white→green. Omit `mid` for a 2-color scale. `value` is required for `number`/`percent`/`percentile` (0–100 for the latter two) and disallowed for `min`/`max`. Defaults: min stop→`min`, max stop→`max`, mid→`percentile` 50.
+**Rule fields** (each rule = one condition + one or more styles)
 
-*Single colour* — apply a fixed style to cells matching a condition (first match wins):
+| Field | What it does |
+|-------|--------------|
+| `if` | Operator (required). See the table below. |
+| `value` | Scalar to compare against. Use `[low, high]` for between, `{ column: X }` for cross column, omit for empty checks. |
+| `backgroundColor` / `textColor` | Cell colors. |
+| `bold` / `italic` / `underline` / `strikethrough` | Text styling. At least one style is required. |
+
+**Operators**
+
+| Group | Operators |
+|-------|-----------|
+| Empty | `is_empty`, `is_not_empty` |
+| Text (case insensitive) | `text_contains`, `text_does_not_contain`, `text_starts_with`, `text_ends_with`, `text_is_exactly` |
+| Number | `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `is_equal_to`, `is_not_equal_to` |
+| Range | `is_between`, `is_not_between` |
+| Date | `date_is`, `date_before`, `date_after` (by day for a date, or exact instant if the value has a time) |
+
+**Worked example** (a full dashboard exercising every feature above):
 
 ```yaml
-  columns:
-    - name: status
-      singleColor:
-        - if: text_is_exactly
-          value: overdue
-          background: "#FEE2E2"
-          textColor: "#991B1B"
-          bold: true            # also: italic, underline, strikethrough
-        - if: is_between
-          value: [10, 20]       # two-element list for is_between / is_not_between
-          background: "#FEF9C3"
+name: Regions
+
+palettes:
+  risk: [red, amber, green]                                       # custom palette, reused by name via `scheme`
+
+rows:
+  - widgets:
+      - name: Regions
+        type: table
+        col: 12
+        sql: SELECT region, revenue, growth, margin, score, status, actual, target, bonus, due FROM regions
+        columns:
+          - name: region
+            format: { backgroundColor: "#F8FAFC", bold: true }          # flat fill + text style
+
+          - name: revenue
+            format:
+              number: currency                                          # value display: currency
+              scheme: red-white-green                                   # built-in gradient
+
+          - name: growth
+            format:
+              number: number
+              domain: [-25, 0, 25]                                      # raw anchors (0 = neutral middle)
+              backgroundColor: [blue, white, amber]                     # custom gradient colors
+
+          - name: margin
+            format:
+              number: ".0%"                                             # d3-format string
+              scheme: risk                                              # custom palette, by name
+              domain: { unit: percentile }                              # anchor by percentile (midpoint = median)
+
+          - name: score
+            format:
+              number: number
+              rules:                                                    # numeric rules, first match wins
+                - { if: greater_than_or_equal, value: 80, backgroundColor: green }    # scalar value
+                - { if: is_between, value: [50, 79], backgroundColor: amber }          # [low, high] for between
+                - { if: less_than, value: 50, textColor: red, strikethrough: true }    # text style
+
+          - name: status
+            format:
+              rules:                                                    # text rules
+                - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
+                - { if: text_is_exactly, value: overdue, backgroundColor: red }
+                - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }           # no value for empty checks
+
+          - name: actual
+            format:
+              number: number
+              rules:
+                - { if: less_than, value: { column: target }, backgroundColor: red }    # cross-column, same row
+                - { if: greater_than, value: { column: target }, backgroundColor: green }
+
+          - name: bonus
+            format: { number: currency, like: score }                  # mirror score's colors, keep own number
+
+          - name: due
+            format:
+              rules:                                                    # date rules
+                - { if: date_before, value: "2026-07-22", textColor: red }
+                - { if: date_after, value: "2026-07-22", textColor: green }
 ```
 
-Operators: `is_empty`, `is_not_empty`, `text_contains`, `text_does_not_contain`, `text_starts_with`, `text_ends_with`, `text_is_exactly`, `date_is`, `date_before`, `date_after`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `is_equal_to`, `is_not_equal_to`, `is_between`, `is_not_between`. Each rule needs ≥1 style (`background`, `textColor`, `bold`, `italic`, `underline`, `strikethrough`). Date operators compare by day for date-only values (`"2026-07-22"`) or by exact instant when the value includes a time (`"2026-07-22T12:00"`).
+How the example reads, column by column:
+- `region`: one flat color on every cell, bold text (a plain string fill plus a text style).
+- `revenue`: currency, colored by the built-in `red-white-green` gradient.
+- `growth`: a custom blue/white/amber gradient with the neutral point pinned to 0 via a raw `domain`.
+- `margin`: a percentage, colored by the custom `risk` palette, anchored by `percentile` so the midpoint sits at the median.
+- `score`: numeric rules covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`), plus a text style (`< 50` struck through in red).
+- `status`: text rules checked in order, first match wins (contains "urgent", exactly "overdue", or empty).
+- `actual`: cross-column rules, compared to `target` in the same row (explained next).
+- `bonus`: `like: score`, so it takes score's colors per row but keeps its own currency display.
+- `due`: date rules, before or after a cutoff day.
+
+Cross column, step by step. Look at the `actual` rule:
+
+```yaml
+{ if: less_than, value: { column: target }, backgroundColor: red }
+```
+
+The cell being colored is `actual`. `value: { column: target }` means "compare it to the `target` column in the same row", not to a fixed number. So for every row independently: if that row's `actual` is less than that row's `target`, the `actual` cell turns red. Row 1 uses row 1's target, row 2 uses row 2's target, and so on. `target` can even be a column you do not display in the table, because its data is still available for the comparison. (Writing `value: 100` instead would compare against the constant 100.)
 
 ### Text Widget
 

--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -784,11 +784,8 @@ rows:
       - name: Regions
         type: table
         col: 12
-        sql: SELECT region, revenue, growth, margin, score, status, actual, target, bonus, due FROM regions
+        sql: SELECT revenue, growth, score, status, actual, target, bonus, health FROM regions
         columns:
-          - name: region
-            format:
-              - { backgroundColor: "#F8FAFC", bold: true }              # flat fill + text style
           - name: revenue
             number: currency
             format:
@@ -796,11 +793,7 @@ rows:
           - name: growth
             number: number
             format:
-              - { backgroundColor: [blue, white, amber], range: [-25, 0, 25], unit: absolute }   # 0 = neutral
-          - name: margin
-            number: ".0%"
-            format:
-              - { backgroundColor: [red, amber, green], range: [0, 50, 100], unit: percentile }  # midpoint = median
+              - { backgroundColor: [blue, white, amber], range: [-25, 0, 25], unit: absolute }   # fixed anchors; unit also percent/percentile
           - name: score
             number: number
             format:                                                     # conditions, first match wins
@@ -810,25 +803,19 @@ rows:
           - name: status
             format:
               - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
-              - { if: text_is_exactly, value: overdue, backgroundColor: red }
-              - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }
+              - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }   # flat fill (string)
           - name: actual
             number: number
-            format:                                                     # cross-column, same row
-              - { if: less_than, value: { column: target }, backgroundColor: red }
+            format:                                                     # cross-column, same row (target need not be displayed)
               - { if: greater_than, value: { column: target }, backgroundColor: green }
           - name: bonus
             number: currency
             like: score                                                 # mirror score's colors, keep own number
-          - name: due
-            format:
-              - { if: date_before, value: "2026-07-22", textColor: red }
-              - { if: date_after, value: "2026-07-22", textColor: green }
           - name: health
             number: number
             format:                                                     # a condition wins over the gradient base below
               - { if: is_equal_to, value: 0, backgroundColor: red, bold: true }
-              - { backgroundColor: [red, white, green] }
+              - { backgroundColor: [red, white, green] }                # base, last (always matches)
 ```
 
 ### Text Widget

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -445,7 +445,7 @@ __INIT_CTE_WIDGET__
             label: Channel
           - name: amount
             label: Amount
-            format: currency
+            number: currency
 `)
 
 const initSemanticModel = `name: sales
@@ -639,10 +639,10 @@ rows:
             label: Channel
           - name: revenue
             label: Revenue
-            format: currency
+            number: currency
           - name: sales_count
             label: Sales
-            format: number
+            number: number
         col: 12
 `
 

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -103,13 +103,11 @@ rows:
 
 Widget types are `metric`, `chart`, `table`, `text`, `divider`, and `image`.
 
-A `table` column takes `name`, `label`, and `format`. `format` is a string (number format: `number`, `currency`, or a d3-format string), or an object combining number format and conditional coloring:
+A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**.
 
-- `number`: the value format string.
-- `backgroundColor`: a **string** is a flat whole-column fill; an **array** is a gradient (2+ colors). `domain` pins gradient anchors: a raw array `[-25, 0, 25]`, or `{ unit, anchors }` where `unit` is `value` (default), `percent`, or `percentile` (0 to 100). Omit `domain` for auto min/max; omit `anchors` to spread evenly (percentile puts the midpoint at the median).
-- `scheme`: a built-in gradient by name instead of listing colors (`red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`). Works with `domain` too.
-- `textColor`, `bold`, `italic`, `underline`, `strikethrough`: whole-column text styling.
-- `rules`: a list of `{ if, value, ...styles }`; first match wins. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day for a date, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
+- A **condition** layer has `if` (+ `value`) and one or more styles. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
+- A **base** layer has no `if` and always applies: a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put the base last as the fallback.
+- Styles on any layer: `backgroundColor`, `textColor`, `bold`, `italic`, `underline`, `strikethrough`.
 - `like`: mirror another column's coloring, driven by that column's per-row value, while keeping this column's own `number`.
 
 Colors are **named** (`red green blue indigo cyan purple pink amber`, plus `white`/`black`, aliases `positive`/`negative`/`warning`) or hex. Named colors adapt to light and dark.
@@ -127,42 +125,48 @@ rows:
         sql: SELECT region, revenue, growth, margin, score, status, actual, target, bonus, due FROM regions
         columns:
           - name: region
-            format: { backgroundColor: "#F8FAFC", bold: true }          # flat fill + text style
+            format:
+              - { backgroundColor: "#F8FAFC", bold: true }              # flat fill + text style
           - name: revenue
-            format: { number: currency, scheme: red-white-green }       # built-in gradient
+            number: currency
+            format:
+              - { backgroundColor: [red, white, green] }                # gradient, auto min→max
           - name: growth
+            number: number
             format:
-              number: number
-              domain: [-25, 0, 25]                                      # raw anchors (0 = neutral)
-              backgroundColor: [blue, white, amber]                     # custom gradient colors
+              - { backgroundColor: [blue, white, amber], range: [-25, 0, 25], unit: absolute }   # 0 = neutral
           - name: margin
-            format: { number: ".0%", scheme: red-amber-green, domain: { unit: percentile } }   # built-in scheme + percentile domain
-          - name: score
+            number: ".0%"
             format:
-              number: number
-              rules:
-                - { if: greater_than_or_equal, value: 80, backgroundColor: green }   # scalar
-                - { if: is_between, value: [50, 79], backgroundColor: amber }         # [low, high]
-                - { if: less_than, value: 50, textColor: red, strikethrough: true }   # text style
+              - { backgroundColor: [red, amber, green], range: [0, 50, 100], unit: percentile }  # midpoint = median
+          - name: score
+            number: number
+            format:                                                     # conditions, first match wins
+              - { if: greater_than_or_equal, value: 80, backgroundColor: green }
+              - { if: is_between, value: [50, 79], backgroundColor: amber }
+              - { if: less_than, value: 50, textColor: red, strikethrough: true }
           - name: status
             format:
-              rules:
-                - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
-                - { if: text_is_exactly, value: overdue, backgroundColor: red }
-                - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }          # no value
+              - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
+              - { if: text_is_exactly, value: overdue, backgroundColor: red }
+              - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }
           - name: actual
-            format:
-              number: number
-              rules:
-                - { if: less_than, value: { column: target }, backgroundColor: red }    # cross-column
-                - { if: greater_than, value: { column: target }, backgroundColor: green }
+            number: number
+            format:                                                     # cross-column, same row
+              - { if: less_than, value: { column: target }, backgroundColor: red }
+              - { if: greater_than, value: { column: target }, backgroundColor: green }
           - name: bonus
-            format: { number: currency, like: score }                  # mirror score's colors, keep own number
+            number: currency
+            like: score                                                 # mirror score's colors, keep own number
           - name: due
             format:
-              rules:
-                - { if: date_before, value: "2026-07-22", textColor: red }
-                - { if: date_after, value: "2026-07-22", textColor: green }
+              - { if: date_before, value: "2026-07-22", textColor: red }
+              - { if: date_after, value: "2026-07-22", textColor: green }
+          - name: health
+            number: number
+            format:                                                     # a condition wins over the gradient base below
+              - { if: is_equal_to, value: 0, backgroundColor: red, bold: true }
+              - { backgroundColor: [red, white, green] }
 ```
 
 ## Filters

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -103,6 +103,11 @@ rows:
 
 Widget types are `metric`, `chart`, `table`, `text`, `divider`, and `image`.
 
+A `table` column takes `name`, `label`, `format` (`number` or `currency`), and optional spreadsheet-style conditional formatting:
+
+- `colorScale` — gradient across `min`/`mid`/`max` stops, each `{ type, value, color }` (bare string = color; `colorScale: {}` = default red→white→green). Stop types: `min | max | number | percent | percentile`; the `min` stop can't be `max` and vice versa, `mid` is `number`/`percent`/`percentile` only, and `value` is required for number/percent/percentile (not min/max).
+- `singleColor` — list of threshold rules `{ if, value, background, textColor, bold, italic, underline, strikethrough }`; first match wins. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (compare by day for date-only values, or exact instant when the value includes a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between` (value is `[low, high]`).
+
 ## Filters
 
 Dashboard filters are UI controls. SQL dashboards use filter values through Jinja templates.

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -2,7 +2,7 @@
 name: create-dashboard
 description: Create DAC dashboards by writing YAML or TSX dashboard definition files. Use when the user wants to create, modify, review, or understand DAC dashboards, widgets, filters, SQL queries, semantic models, or CLI validation workflows.
 argument-hint: "[dashboard request]"
-version: 3
+version: 5
 ---
 
 # Create Dashboard
@@ -103,10 +103,70 @@ rows:
 
 Widget types are `metric`, `chart`, `table`, `text`, `divider`, and `image`.
 
-A `table` column takes `name`, `label`, `format` (`number` or `currency`), and optional spreadsheet-style conditional formatting:
+A `table` column takes `name`, `label`, and `format`. `format` is a string (number format: `number`, `currency`, or a d3-format string), or an object combining number format and conditional coloring:
 
-- `colorScale` — gradient across `min`/`mid`/`max` stops, each `{ type, value, color }` (bare string = color; `colorScale: {}` = default red→white→green). Stop types: `min | max | number | percent | percentile`; the `min` stop can't be `max` and vice versa, `mid` is `number`/`percent`/`percentile` only, and `value` is required for number/percent/percentile (not min/max).
-- `singleColor` — list of threshold rules `{ if, value, background, textColor, bold, italic, underline, strikethrough }`; first match wins. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (compare by day for date-only values, or exact instant when the value includes a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between` (value is `[low, high]`).
+- `number`: the value format string.
+- `backgroundColor`: a **string** is a flat whole-column fill; an **array** is a gradient (2+ colors). `domain` pins gradient anchors: a raw array `[-25, 0, 25]`, or `{ unit, anchors }` where `unit` is `value` (default), `percent`, or `percentile` (0 to 100). Omit `domain` for auto min/max; omit `anchors` to spread evenly (percentile puts the midpoint at the median).
+- `scheme`: a gradient by name instead of listing colors. Either a built-in (`red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`) or a custom palette defined once at the dashboard top level under `palettes` (name to 2+ colors, reused by name, must not collide with a built-in). Works with `domain` too.
+- `textColor`, `bold`, `italic`, `underline`, `strikethrough`: whole-column text styling.
+- `rules`: a list of `{ if, value, ...styles }`; first match wins. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day for a date, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
+- `like`: mirror another column's coloring, driven by that column's per-row value, while keeping this column's own `number`.
+
+Colors are **named** (`red green blue indigo cyan purple pink amber`, plus `white`/`black`, aliases `positive`/`negative`/`warning`) or hex. Named colors adapt to light and dark.
+
+Worked example:
+
+```yaml
+name: Regions
+
+palettes:
+  risk: [red, amber, green]                                       # custom palette, reused by name
+
+rows:
+  - widgets:
+      - name: Regions
+        type: table
+        col: 12
+        sql: SELECT region, revenue, growth, margin, score, status, actual, target, bonus, due FROM regions
+        columns:
+          - name: region
+            format: { backgroundColor: "#F8FAFC", bold: true }          # flat fill + text style
+          - name: revenue
+            format: { number: currency, scheme: red-white-green }       # built-in gradient
+          - name: growth
+            format:
+              number: number
+              domain: [-25, 0, 25]                                      # raw anchors (0 = neutral)
+              backgroundColor: [blue, white, amber]                     # custom gradient colors
+          - name: margin
+            format: { number: ".0%", scheme: risk, domain: { unit: percentile } }   # palette + percentile domain
+          - name: score
+            format:
+              number: number
+              rules:
+                - { if: greater_than_or_equal, value: 80, backgroundColor: green }   # scalar
+                - { if: is_between, value: [50, 79], backgroundColor: amber }         # [low, high]
+                - { if: less_than, value: 50, textColor: red, strikethrough: true }   # text style
+          - name: status
+            format:
+              rules:
+                - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
+                - { if: text_is_exactly, value: overdue, backgroundColor: red }
+                - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }          # no value
+          - name: actual
+            format:
+              number: number
+              rules:
+                - { if: less_than, value: { column: target }, backgroundColor: red }    # cross-column
+                - { if: greater_than, value: { column: target }, backgroundColor: green }
+          - name: bonus
+            format: { number: currency, like: score }                  # mirror score's colors, keep own number
+          - name: due
+            format:
+              rules:
+                - { if: date_before, value: "2026-07-22", textColor: red }
+                - { if: date_after, value: "2026-07-22", textColor: green }
+```
 
 ## Filters
 

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -2,7 +2,7 @@
 name: create-dashboard
 description: Create DAC dashboards by writing YAML or TSX dashboard definition files. Use when the user wants to create, modify, review, or understand DAC dashboards, widgets, filters, SQL queries, semantic models, or CLI validation workflows.
 argument-hint: "[dashboard request]"
-version: 5
+version: 6
 ---
 
 # Create Dashboard
@@ -105,10 +105,12 @@ Widget types are `metric`, `chart`, `table`, `text`, `divider`, and `image`.
 
 A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**.
 
-- A **condition** layer has `if` (+ `value`) and one or more styles. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
-- A **base** layer has no `if` and always applies: a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put the base last as the fallback.
+- With `if` (+ `value`), the layer styles only the cells that match. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
+- With no `if`, the layer styles every cell — a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put it last as the fallback.
 - Styles on any layer: `backgroundColor`, `textColor`, `bold`, `italic`, `underline`, `strikethrough`.
 - `like`: mirror another column's coloring, driven by that column's per-row value, while keeping this column's own `number`.
+
+Each layer is a YAML object, so `- { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }` and the same keys written as an indented block are identical — use whichever reads better.
 
 Colors are **named** (`red green blue indigo cyan purple pink amber`, plus `white`/`black`, aliases `positive`/`negative`/`warning`) or hex. Named colors adapt to light and dark.
 

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -107,7 +107,7 @@ A `table` column takes `name`, `label`, and `format`. `format` is a string (numb
 
 - `number`: the value format string.
 - `backgroundColor`: a **string** is a flat whole-column fill; an **array** is a gradient (2+ colors). `domain` pins gradient anchors: a raw array `[-25, 0, 25]`, or `{ unit, anchors }` where `unit` is `value` (default), `percent`, or `percentile` (0 to 100). Omit `domain` for auto min/max; omit `anchors` to spread evenly (percentile puts the midpoint at the median).
-- `scheme`: a gradient by name instead of listing colors. Either a built-in (`red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`) or a custom palette defined once at the dashboard top level under `palettes` (name to 2+ colors, reused by name, must not collide with a built-in). Works with `domain` too.
+- `scheme`: a built-in gradient by name instead of listing colors (`red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`). Works with `domain` too.
 - `textColor`, `bold`, `italic`, `underline`, `strikethrough`: whole-column text styling.
 - `rules`: a list of `{ if, value, ...styles }`; first match wins. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day for a date, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
 - `like`: mirror another column's coloring, driven by that column's per-row value, while keeping this column's own `number`.
@@ -118,9 +118,6 @@ Worked example:
 
 ```yaml
 name: Regions
-
-palettes:
-  risk: [red, amber, green]                                       # custom palette, reused by name
 
 rows:
   - widgets:
@@ -139,7 +136,7 @@ rows:
               domain: [-25, 0, 25]                                      # raw anchors (0 = neutral)
               backgroundColor: [blue, white, amber]                     # custom gradient colors
           - name: margin
-            format: { number: ".0%", scheme: risk, domain: { unit: percentile } }   # palette + percentile domain
+            format: { number: ".0%", scheme: red-amber-green, domain: { unit: percentile } }   # built-in scheme + percentile domain
           - name: score
             format:
               number: number

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -124,11 +124,8 @@ rows:
       - name: Regions
         type: table
         col: 12
-        sql: SELECT region, revenue, growth, margin, score, status, actual, target, bonus, due FROM regions
+        sql: SELECT revenue, growth, score, status, actual, target, bonus, health FROM regions
         columns:
-          - name: region
-            format:
-              - { backgroundColor: "#F8FAFC", bold: true }              # flat fill + text style
           - name: revenue
             number: currency
             format:
@@ -136,11 +133,7 @@ rows:
           - name: growth
             number: number
             format:
-              - { backgroundColor: [blue, white, amber], range: [-25, 0, 25], unit: absolute }   # 0 = neutral
-          - name: margin
-            number: ".0%"
-            format:
-              - { backgroundColor: [red, amber, green], range: [0, 50, 100], unit: percentile }  # midpoint = median
+              - { backgroundColor: [blue, white, amber], range: [-25, 0, 25], unit: absolute }   # fixed anchors; unit also percent/percentile
           - name: score
             number: number
             format:                                                     # conditions, first match wins
@@ -150,25 +143,19 @@ rows:
           - name: status
             format:
               - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
-              - { if: text_is_exactly, value: overdue, backgroundColor: red }
-              - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }
+              - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }   # flat fill (string)
           - name: actual
             number: number
-            format:                                                     # cross-column, same row
-              - { if: less_than, value: { column: target }, backgroundColor: red }
+            format:                                                     # cross-column, same row (target need not be displayed)
               - { if: greater_than, value: { column: target }, backgroundColor: green }
           - name: bonus
             number: currency
             like: score                                                 # mirror score's colors, keep own number
-          - name: due
-            format:
-              - { if: date_before, value: "2026-07-22", textColor: red }
-              - { if: date_after, value: "2026-07-22", textColor: green }
           - name: health
             number: number
             format:                                                     # a condition wins over the gradient base below
               - { if: is_equal_to, value: 0, backgroundColor: red, bold: true }
-              - { backgroundColor: [red, white, green] }
+              - { backgroundColor: [red, white, green] }                # base, last (always matches)
 ```
 
 ## Filters

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -2,7 +2,7 @@
 name: create-dashboard
 description: Create DAC dashboards by writing YAML or TSX dashboard definition files. Use when the user wants to create, modify, review, or understand DAC dashboards, widgets, filters, SQL queries, semantic models, or CLI validation workflows.
 argument-hint: "[dashboard request]"
-version: 6
+version: 5
 ---
 
 # Create Dashboard

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -162,7 +162,7 @@ func TestParseSkillVersion(t *testing.T) {
 		content string
 		want    int
 	}{
-		{"bundled skill", createDashboardSkill, 5},
+		{"bundled skill", createDashboardSkill, 6},
 		{"explicit version", "---\nname: x\nversion: 7\n---\nbody", 7},
 		{"missing version", "---\nname: x\n---\nbody", 0},
 		{"no frontmatter", "# just a heading\n", 0},

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -162,7 +162,7 @@ func TestParseSkillVersion(t *testing.T) {
 		content string
 		want    int
 	}{
-		{"bundled skill", createDashboardSkill, 3},
+		{"bundled skill", createDashboardSkill, 5},
 		{"explicit version", "---\nname: x\nversion: 7\n---\nbody", 7},
 		{"missing version", "---\nname: x\n---\nbody", 0},
 		{"no frontmatter", "# just a heading\n", 0},

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -162,7 +162,7 @@ func TestParseSkillVersion(t *testing.T) {
 		content string
 		want    int
 	}{
-		{"bundled skill", createDashboardSkill, 6},
+		{"bundled skill", createDashboardSkill, 5},
 		{"explicit version", "---\nname: x\nversion: 7\n---\nbody", 7},
 		{"missing version", "---\nname: x\n---\nbody", 0},
 		{"no frontmatter", "# just a heading\n", 0},

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -227,7 +227,7 @@ func TestValidateCommandAcceptsPositionalDirectory(t *testing.T) {
 		}
 	})
 
-	if !strings.Contains(output, "7 dashboard(s) validated successfully") {
+	if !strings.Contains(output, "8 dashboard(s) validated successfully") {
 		t.Fatalf("expected testdata dashboards to validate, got %q", output)
 	}
 	if strings.Contains(output, "No dashboard files found in .") {

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -278,7 +278,7 @@ format:                   # object: number format + coloring
 | `number` | Value display: `currency`, `number`, or a d3-format string. |
 | `backgroundColor` | **string** = flat fill for the whole column. **array** = gradient (at least 2 colors). |
 | `domain` | Gradient anchors. A raw array `[-25, 0, 25]`, or `{ unit, anchors }` where `unit` is `value` (default) / `percent` / `percentile`. Omit for auto min/max; omit `anchors` to spread evenly (percentile puts the midpoint at the median). |
-| `scheme` | A gradient by name instead of listing colors: a built-in, or a custom `palettes` entry (see below). |
+| `scheme` | A built-in gradient by name instead of listing colors. |
 | `textColor` | Text color. |
 | `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
 | `rules` | Conditional styling, evaluated in order, first match wins. |
@@ -296,16 +296,6 @@ format:                   # object: number format + coloring
 Named colors match the chart palette and adapt to light/dark; `white` and `black` are fixed literals that stay the same in both themes.
 
 **Built-in `scheme`s:** `red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`.
-
-**Custom palettes:** define reusable gradients at the dashboard top level under `palettes` (name to 2+ colors), then reference one by name with `scheme`. A palette name must not collide with a built-in.
-
-```yaml
-palettes:
-  risk: [red, amber, green]
-columns:
-  - name: growth
-    format: { scheme: risk }        # the palette, by name
-```
 
 **Rule fields** (each rule = one condition + one or more styles)
 
@@ -331,9 +321,6 @@ columns:
 ```yaml
 name: Regions
 
-palettes:
-  risk: [red, amber, green]                                       # custom palette, reused by name via `scheme`
-
 rows:
   - widgets:
       - name: Regions
@@ -358,7 +345,7 @@ rows:
           - name: margin
             format:
               number: ".0%"                                             # d3-format string
-              scheme: risk                                              # custom palette, by name
+              scheme: red-amber-green                                   # built-in scheme
               domain: { unit: percentile }                              # anchor by percentile (midpoint = median)
 
           - name: score
@@ -397,7 +384,7 @@ How the example reads, column by column:
 - `region`: one flat color on every cell, bold text (a plain string fill plus a text style).
 - `revenue`: currency, colored by the built-in `red-white-green` gradient.
 - `growth`: a custom blue/white/amber gradient with the neutral point pinned to 0 via a raw `domain`.
-- `margin`: a percentage, colored by the custom `risk` palette, anchored by `percentile` so the midpoint sits at the median.
+- `margin`: a percentage, colored by the built-in `red-amber-green` scheme, anchored by `percentile` so the midpoint sits at the median.
 - `score`: numeric rules covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`), plus a text style (`< 50` struck through in red).
 - `status`: text rules checked in order, first match wins (contains "urgent", exactly "overdue", or empty).
 - `actual`: cross-column rules, compared to `target` in the same row (explained next).

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -259,30 +259,42 @@ Table column fields:
 
 ## Conditional formatting
 
-A column's `format` handles the number format **and** coloring together. It is
-either a **string** (shorthand for the number format) or an **object**. The keys
-and options are below; a full worked example follows at the end.
+A column sets value display with `number` and coloring with `format`. `number`
+is `currency`, `number`, or a d3-format string. `format` is an **ordered list of
+layers**, and for each cell the **first layer that matches wins**.
+
+A layer is one of two kinds:
+- a **condition** (`if` is set), applied to the cells that satisfy it, or
+- a **base** (no `if`), which always applies: a **gradient** (`backgroundColor`
+  is a list, with optional `range`/`unit`) or a **flat fill** (`backgroundColor`
+  is a string). A base always matches, so put it **last** as the fallback.
 
 ```yaml
-format: currency          # shorthand: just the number format
-
-format:                   # object: number format + coloring
-  number: "$,.2f"
-  backgroundColor: [red, white, green]
+- name: score
+  number: number
+  format:
+    - { if: greater_than_or_equal, value: 80, backgroundColor: green }   # condition, checked first
+    - { backgroundColor: [red, white, green] }                           # gradient base, last
 ```
 
-**`format` keys**
+**Column keys**
 
 | Key | What it does |
 |-----|--------------|
 | `number` | Value display: `currency`, `number`, or a d3-format string. |
-| `backgroundColor` | **string** = flat fill for the whole column. **array** = gradient (at least 2 colors). |
-| `domain` | Gradient anchors. A raw array `[-25, 0, 25]`, or `{ unit, anchors }` where `unit` is `value` (default) / `percent` / `percentile`. Omit for auto min/max; omit `anchors` to spread evenly (percentile puts the midpoint at the median). |
-| `scheme` | A built-in gradient by name instead of listing colors. |
+| `like` | Mirror another column's coloring, driven by that column's per-row value (keeps own `number`). |
+| `format` | Ordered list of style layers; first match wins. |
+
+**Layer keys**
+
+| Key | What it does |
+|-----|--------------|
+| `if` | Condition operator (see below). Omit for a base layer (gradient or flat fill) that always applies. |
+| `value` | Comparison value: a scalar, `[low, high]` for between, `{ column: X }` for cross-column, omitted for empty checks. |
+| `backgroundColor` | **string** = flat/single fill. **list** = gradient (at least 2 colors). |
+| `range` + `unit` | Gradient anchors. `range` is a list of numbers; `unit` is `absolute`, `percent`, or `percentile`. Omit `range` for an auto min/max gradient. |
 | `textColor` | Text color. |
 | `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
-| `rules` | Conditional styling, evaluated in order, first match wins. |
-| `like` | Copy another column's coloring, driven by that column's value. |
 
 **Colors** (any color field)
 
@@ -293,20 +305,9 @@ format:                   # object: number format + coloring
 | Aliases | `positive` (green), `negative` (red), `warning` (amber) |
 | Hex | any `"#rrggbb"` |
 
-Named colors match the chart palette and adapt to light/dark; `white` and `black` are fixed literals that stay the same in both themes.
+Named colors match the chart palette and adapt to light/dark; `white` and `black` are fixed literals that stay the same in both themes. Named fills are softened toward the theme surface so the theme text stays legible.
 
-**Built-in `scheme`s:** `red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`.
-
-**Rule fields** (each rule = one condition + one or more styles)
-
-| Field | What it does |
-|-------|--------------|
-| `if` | Operator (required). See the table below. |
-| `value` | Scalar to compare against. Use `[low, high]` for between, `{ column: X }` for cross column, omit for empty checks. |
-| `backgroundColor` / `textColor` | Cell colors. |
-| `bold` / `italic` / `underline` / `strikethrough` | Text styling. At least one style is required. |
-
-**Operators**
+**Operators** (used by a layer's `if`)
 
 | Group | Operators |
 |-------|-----------|
@@ -329,67 +330,74 @@ rows:
         sql: SELECT region, revenue, growth, margin, score, status, actual, target, bonus, due FROM regions
         columns:
           - name: region
-            format: { backgroundColor: "#F8FAFC", bold: true }          # flat fill + text style
+            format:
+              - { backgroundColor: "#F8FAFC", bold: true }              # flat fill + text style
 
           - name: revenue
+            number: currency                                            # value display: currency
             format:
-              number: currency                                          # value display: currency
-              scheme: red-white-green                                   # built-in gradient
+              - { backgroundColor: [red, white, green] }                # gradient, auto min→max
 
           - name: growth
+            number: number
             format:
-              number: number
-              domain: [-25, 0, 25]                                      # raw anchors (0 = neutral middle)
-              backgroundColor: [blue, white, amber]                     # custom gradient colors
+              - backgroundColor: [blue, white, amber]                   # gradient colors
+                range: [-25, 0, 25]                                     # pinned anchors, 0 = neutral middle
+                unit: absolute
 
           - name: margin
+            number: ".0%"                                               # d3-format string
             format:
-              number: ".0%"                                             # d3-format string
-              scheme: red-amber-green                                   # built-in scheme
-              domain: { unit: percentile }                              # anchor by percentile (midpoint = median)
+              - backgroundColor: [red, amber, green]
+                range: [0, 50, 100]
+                unit: percentile                                        # anchor by percentile (midpoint = median)
 
           - name: score
-            format:
-              number: number
-              rules:                                                    # numeric rules, first match wins
-                - { if: greater_than_or_equal, value: 80, backgroundColor: green }    # scalar value
-                - { if: is_between, value: [50, 79], backgroundColor: amber }          # [low, high] for between
-                - { if: less_than, value: 50, textColor: red, strikethrough: true }    # text style
+            number: number
+            format:                                                     # conditions, first match wins
+              - { if: greater_than_or_equal, value: 80, backgroundColor: green }    # scalar value
+              - { if: is_between, value: [50, 79], backgroundColor: amber }         # [low, high] for between
+              - { if: less_than, value: 50, textColor: red, strikethrough: true }   # text style
 
           - name: status
-            format:
-              rules:                                                    # text rules
-                - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
-                - { if: text_is_exactly, value: overdue, backgroundColor: red }
-                - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }           # no value for empty checks
+            format:                                                     # text conditions
+              - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
+              - { if: text_is_exactly, value: overdue, backgroundColor: red }
+              - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }          # no value for empty checks
 
           - name: actual
+            number: number
             format:
-              number: number
-              rules:
-                - { if: less_than, value: { column: target }, backgroundColor: red }    # cross-column, same row
-                - { if: greater_than, value: { column: target }, backgroundColor: green }
+              - { if: less_than, value: { column: target }, backgroundColor: red }   # cross-column, same row
+              - { if: greater_than, value: { column: target }, backgroundColor: green }
 
           - name: bonus
-            format: { number: currency, like: score }                  # mirror score's colors, keep own number
+            number: currency
+            like: score                                                 # mirror score's colors, keep own number
 
           - name: due
-            format:
-              rules:                                                    # date rules
-                - { if: date_before, value: "2026-07-22", textColor: red }
-                - { if: date_after, value: "2026-07-22", textColor: green }
+            format:                                                     # date conditions
+              - { if: date_before, value: "2026-07-22", textColor: red }
+              - { if: date_after, value: "2026-07-22", textColor: green }
+
+          - name: health
+            number: number
+            format:                                                     # a condition wins over the gradient base below it
+              - { if: is_equal_to, value: 0, backgroundColor: red, bold: true }
+              - { backgroundColor: [red, white, green] }                # gradient base, last (always matches)
 ```
 
 How the example reads, column by column:
-- `region`: one flat color on every cell, bold text (a plain string fill plus a text style).
-- `revenue`: currency, colored by the built-in `red-white-green` gradient.
-- `growth`: a custom blue/white/amber gradient with the neutral point pinned to 0 via a raw `domain`.
-- `margin`: a percentage, colored by the built-in `red-amber-green` scheme, anchored by `percentile` so the midpoint sits at the median.
-- `score`: numeric rules covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`), plus a text style (`< 50` struck through in red).
-- `status`: text rules checked in order, first match wins (contains "urgent", exactly "overdue", or empty).
-- `actual`: cross-column rules, compared to `target` in the same row (explained next).
+- `region`: one flat color on every cell, bold text (a single base layer with a string fill plus a text style).
+- `revenue`: currency, colored by an auto min→max gradient.
+- `growth`: a blue/white/amber gradient with the neutral point pinned to 0 via `range` + `unit: absolute`.
+- `margin`: a percentage, colored by a gradient anchored by `percentile` so the midpoint sits at the median.
+- `score`: numeric conditions covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`), plus a text style (`< 50` struck through in red).
+- `status`: text conditions checked in order, first match wins (contains "urgent", exactly "overdue", or empty).
+- `actual`: cross-column conditions, compared to `target` in the same row (explained next).
 - `bonus`: `like: score`, so it takes score's colors per row but keeps its own currency display.
-- `due`: date rules, before or after a cutoff day.
+- `due`: date conditions, before or after a cutoff day.
+- `health`: a condition (`= 0` turns red) checked first, then a gradient base last as the fallback for every other value.
 
 Cross column, step by step. Look at the `actual` rule:
 

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -256,6 +256,104 @@ Table column fields:
 | `name` | string | Result column name (must match the SQL output) |
 | `label` | string | Display header (defaults to `name`) |
 | `format` | string | `number` or `currency` |
+| `colorScale` | object | Gradient conditional formatting — see below |
+| `singleColor` | array | Threshold-based conditional formatting — see below |
+
+Conditional formatting comes in two modes: a **colour scale**
+(gradient) or **single colour** (threshold rules). A column may use either or both.
+
+### Colour scale (gradient)
+
+`colorScale` shades each cell's background by interpolating between up to three
+stops — **min**, **mid**, **max** — based on where the value falls.
+
+```yaml
+columns:
+  - name: revenue
+    label: Revenue
+    format: currency
+    colorScale:
+      min: { type: min,        color: "#E67C73" }
+      mid: { type: percentile, value: 50, color: "#FFFFFF" }
+      max: { type: number,     value: 1000, color: "#57BB8A" }
+```
+
+Each stop is `{ type, value, color }`. A bare string is shorthand for the color
+(`min: "#E67C73"`), and `colorScale: {}` applies the default red → white → green
+scale. Omit `mid` for a two-color scale. Cell text auto-contrasts light/dark.
+
+**Stop types** — how the stop anchors to the data:
+
+| Type | Meaning | `value`? |
+|------|---------|----------|
+| `min` | The column's minimum value | ✗ (not allowed) |
+| `max` | The column's maximum value | ✗ (not allowed) |
+| `number` | A fixed number | ✓ required |
+| `percent` | A percentage across the min–max range | ✓ (0–100) |
+| `percentile` | A percentile of the values | ✓ (0–100) |
+
+Rules enforced at validation:
+
+- The **min** stop may use `min | number | percent | percentile` — **not** `max`.
+- The **max** stop may use `max | number | percent | percentile` — **not** `min`.
+- The **mid** stop may use `number | percent | percentile` only.
+- `value` is provided for `number` / `percent` / `percentile`, and **not** for `min` / `max`.
+
+Defaults: `min` stop → `min` type, `max` stop → `max` type, `mid` stop →
+`percentile` 50 — so `colorScale: { min: "#red", max: "#green" }` anchors to the
+observed range with no `value` needed.
+
+### Single colour (threshold rules)
+
+`singleColor` is a list of rules that apply a fixed style to cells matching a
+condition. Rules are evaluated in order; the **first match wins**.
+
+```yaml
+columns:
+  - name: status
+    label: Status
+    singleColor:
+      - if: text_is_exactly
+        value: overdue
+        background: "#FEE2E2"
+        textColor: "#991B1B"
+        bold: true
+  - name: margin
+    format: number
+    singleColor:
+      - if: less_than
+        value: 0
+        background: "#FEE2E2"
+        strikethrough: true
+      - if: is_between
+        value: [0, 10]   
+        background: "#FEF9C3"
+```
+
+Rule fields — one condition plus one or more styles:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `if` | string | Condition operator (see below). Required. |
+| `value` | any | Comparison value; a `[low, high]` list for `is_between` / `is_not_between`; omitted for `is_empty` / `is_not_empty` |
+| `background` | string | Fill color |
+| `textColor` | string | Text color |
+| `bold` | bool | Bold text |
+| `italic` | bool | Italic text |
+| `underline` | bool | Underline text |
+| `strikethrough` | bool | Strike-through text |
+
+At least one style is required per rule.
+
+**Operators** (`if`): `is_empty`, `is_not_empty`, `text_contains`,
+`text_does_not_contain`, `text_starts_with`, `text_ends_with`, `text_is_exactly`,
+`date_is`, `date_before`, `date_after`, `greater_than`,
+`greater_than_or_equal`, `less_than`, `less_than_or_equal`, `is_equal_to`,
+`is_not_equal_to`, `is_between`, `is_not_between`. Text operators are
+case-insensitive. Date operators (`date_is` / `date_before` / `date_after`)
+accept dates or timestamps: they compare by calendar day when the rule's `value`
+is date-only (e.g. `"2026-07-22"`), or by exact instant when the `value` includes
+a time (e.g. `"2026-07-22T12:00"`).
 
 ## Inline data
 

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -263,18 +263,15 @@ A column sets value display with `number` and coloring with `format`. `number`
 is `currency`, `number`, or a d3-format string. `format` is an **ordered list of
 layers**, and for each cell the **first layer that matches wins**.
 
-A layer is one of two kinds:
-- a **condition** (`if` is set), applied to the cells that satisfy it, or
-- a **base** (no `if`), which always applies: a **gradient** (`backgroundColor`
-  is a list, with optional `range`/`unit`) or a **flat fill** (`backgroundColor`
-  is a string). A base always matches, so put it **last** as the fallback.
+A layer's `if` is optional: with `if`, the layer styles only the cells that match
+the condition; without `if`, the layer styles every cell.
 
 ```yaml
 - name: score
   number: number
   format:
-    - { if: greater_than_or_equal, value: 80, backgroundColor: green }   # condition, checked first
-    - { backgroundColor: [red, white, green] }                           # gradient base, last
+    - { if: greater_than_or_equal, value: 80, backgroundColor: green }   # matches only score >= 80
+    - { backgroundColor: [red, white, green] }                           # no if → every other cell, so last
 ```
 
 **Column keys**
@@ -285,16 +282,26 @@ A layer is one of two kinds:
 | `like` | Mirror another column's coloring, driven by that column's per-row value (keeps own `number`). |
 | `format` | Ordered list of style layers; first match wins. |
 
-**Layer keys**
+**Layer keys** (the `Group` column shows which keys belong together):
 
-| Key | What it does |
-|-----|--------------|
-| `if` | Condition operator (see below). Omit for a base layer (gradient or flat fill) that always applies. |
-| `value` | Comparison value: a scalar, `[low, high]` for between, `{ column: X }` for cross-column, omitted for empty checks. |
-| `backgroundColor` | **string** = flat/single fill. **list** = gradient (at least 2 colors). |
-| `range` + `unit` | Gradient anchors. `range` is a list of numbers; `unit` is `absolute`, `percent`, or `percentile`. Omit `range` for an auto min/max gradient. |
-| `textColor` | Text color. |
-| `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
+| Group | Key | What it does |
+|-------|-----|--------------|
+| Condition | `if` | The operator (see the table below). Omit to apply the layer to every cell. |
+| Condition | `value` | What `if` compares against: a scalar, `[low, high]` for between, `{ column: X }` for cross-column, omitted for empty checks. |
+| Fill | `backgroundColor` | A **string** (flat fill) or a **list** of colors (gradient, at least 2). |
+| Fill | `range` + `unit` | Gradient only. `range` is a list of anchor numbers; `unit` is `absolute`, `percent`, or `percentile`. Omit `range` for an auto min/max gradient. |
+| Text | `textColor` | Text color. |
+| Text | `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
+
+Each layer is a YAML object, so these two forms are identical — use whichever reads better:
+
+```yaml
+- { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }   # compact (flow)
+
+- backgroundColor: [red, white, green]                                            # block
+  range: [-25, 0, 25]
+  unit: absolute
+```
 
 **Colors** (any color field)
 
@@ -340,13 +347,11 @@ rows:
 
           - name: growth
             number: number
-            format:
-              - backgroundColor: [blue, white, amber]                   # gradient colors
-                range: [-25, 0, 25]                                     # pinned anchors, 0 = neutral middle
-                unit: absolute
+            format:                                                     # compact form (0 = neutral middle)
+              - { backgroundColor: [blue, white, amber], range: [-25, 0, 25], unit: absolute }
 
           - name: margin
-            number: ".0%"                                               # d3-format string
+            number: ".0%"                                               # d3-format string; same layer, block form
             format:
               - backgroundColor: [red, amber, green]
                 range: [0, 50, 100]
@@ -355,9 +360,9 @@ rows:
           - name: score
             number: number
             format:                                                     # conditions, first match wins
-              - { if: greater_than_or_equal, value: 80, backgroundColor: green }    # scalar value
+              - { if: greater_than_or_equal, value: 80, backgroundColor: green, textColor: white, bold: true }   # fill + text styles together
               - { if: is_between, value: [50, 79], backgroundColor: amber }         # [low, high] for between
-              - { if: less_than, value: 50, textColor: red, strikethrough: true }   # text style
+              - { if: less_than, value: 50, backgroundColor: "#FEE2E2", textColor: red, strikethrough: true }    # fill + text style
 
           - name: status
             format:                                                     # text conditions
@@ -376,28 +381,33 @@ rows:
             like: score                                                 # mirror score's colors, keep own number
 
           - name: due
-            format:                                                     # date conditions
-              - { if: date_before, value: "2026-07-22", textColor: red }
-              - { if: date_after, value: "2026-07-22", textColor: green }
+            format:                                                     # date conditions (fill + text)
+              - { if: date_before, value: "2026-07-22", backgroundColor: red, textColor: white, bold: true }
+              - { if: date_after, value: "2026-07-22", backgroundColor: green, textColor: white }
 
           - name: health
             number: number
-            format:                                                     # a condition wins over the gradient base below it
+            format:                                                     # order matters: this wins over the layer below
               - { if: is_equal_to, value: 0, backgroundColor: red, bold: true }
-              - { backgroundColor: [red, white, green] }                # gradient base, last (always matches)
+              - { backgroundColor: [red, white, green], range: [0, 50, 100], unit: percent }  
 ```
 
+**Order matters.** Layers are checked top to bottom and the first match wins, so
+list the specific conditions first and any catch-all (a gradient or flat fill with
+no `if`) last. `growth` is written in the compact one-line form and `margin` as an
+indented block; both are the same layer shape.
+
 How the example reads, column by column:
-- `region`: one flat color on every cell, bold text (a single base layer with a string fill plus a text style).
+- `region`: one flat color on every cell, bold text (a single layer, string fill plus a text style).
 - `revenue`: currency, colored by an auto min→max gradient.
 - `growth`: a blue/white/amber gradient with the neutral point pinned to 0 via `range` + `unit: absolute`.
 - `margin`: a percentage, colored by a gradient anchored by `percentile` so the midpoint sits at the median.
-- `score`: numeric conditions covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`), plus a text style (`< 50` struck through in red).
+- `score`: numeric conditions covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`); each layer combines a `backgroundColor` fill with text styles (`< 50` gets a light-red fill plus red struck-through text).
 - `status`: text conditions checked in order, first match wins (contains "urgent", exactly "overdue", or empty).
 - `actual`: cross-column conditions, compared to `target` in the same row (explained next).
 - `bonus`: `like: score`, so it takes score's colors per row but keeps its own currency display.
 - `due`: date conditions, before or after a cutoff day.
-- `health`: a condition (`= 0` turns red) checked first, then a gradient base last as the fallback for every other value.
+- `health`: a condition (`= 0` turns red) checked first, then a `percent`-range gradient with no `if` last, for every other value.
 
 Cross column, step by step. Look at the `actual` rule:
 

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -255,105 +255,162 @@ Table column fields:
 |-------|------|-------------|
 | `name` | string | Result column name (must match the SQL output) |
 | `label` | string | Display header (defaults to `name`) |
-| `format` | string | `number` or `currency` |
-| `colorScale` | object | Gradient conditional formatting — see below |
-| `singleColor` | array | Threshold-based conditional formatting — see below |
+| `format` | string \| object | Value display and conditional coloring, see below |
 
-Conditional formatting comes in two modes: a **colour scale**
-(gradient) or **single colour** (threshold rules). A column may use either or both.
+## Conditional formatting
 
-### Colour scale (gradient)
-
-`colorScale` shades each cell's background by interpolating between up to three
-stops — **min**, **mid**, **max** — based on where the value falls.
+A column's `format` handles the number format **and** coloring together. It is
+either a **string** (shorthand for the number format) or an **object**. The keys
+and options are below; a full worked example follows at the end.
 
 ```yaml
-columns:
-  - name: revenue
-    label: Revenue
-    format: currency
-    colorScale:
-      min: { type: min,        color: "#E67C73" }
-      mid: { type: percentile, value: 50, color: "#FFFFFF" }
-      max: { type: number,     value: 1000, color: "#57BB8A" }
+format: currency          # shorthand: just the number format
+
+format:                   # object: number format + coloring
+  number: "$,.2f"
+  backgroundColor: [red, white, green]
 ```
 
-Each stop is `{ type, value, color }`. A bare string is shorthand for the color
-(`min: "#E67C73"`), and `colorScale: {}` applies the default red → white → green
-scale. Omit `mid` for a two-color scale. Cell text auto-contrasts light/dark.
+**`format` keys**
 
-**Stop types** — how the stop anchors to the data:
+| Key | What it does |
+|-----|--------------|
+| `number` | Value display: `currency`, `number`, or a d3-format string. |
+| `backgroundColor` | **string** = flat fill for the whole column. **array** = gradient (at least 2 colors). |
+| `domain` | Gradient anchors. A raw array `[-25, 0, 25]`, or `{ unit, anchors }` where `unit` is `value` (default) / `percent` / `percentile`. Omit for auto min/max; omit `anchors` to spread evenly (percentile puts the midpoint at the median). |
+| `scheme` | A gradient by name instead of listing colors: a built-in, or a custom `palettes` entry (see below). |
+| `textColor` | Text color. |
+| `bold` / `italic` / `underline` / `strikethrough` | Text styling (booleans). |
+| `rules` | Conditional styling, evaluated in order, first match wins. |
+| `like` | Copy another column's coloring, driven by that column's value. |
 
-| Type | Meaning | `value`? |
-|------|---------|----------|
-| `min` | The column's minimum value | ✗ (not allowed) |
-| `max` | The column's maximum value | ✗ (not allowed) |
-| `number` | A fixed number | ✓ required |
-| `percent` | A percentage across the min–max range | ✓ (0–100) |
-| `percentile` | A percentile of the values | ✓ (0–100) |
+**Colors** (any color field)
 
-Rules enforced at validation:
+| Kind | Values |
+|------|--------|
+| Named | `red` `green` `blue` `indigo` `cyan` `purple` `pink` `amber` |
+| Fixed | `white` `black` |
+| Aliases | `positive` (green), `negative` (red), `warning` (amber) |
+| Hex | any `"#rrggbb"` |
 
-- The **min** stop may use `min | number | percent | percentile` — **not** `max`.
-- The **max** stop may use `max | number | percent | percentile` — **not** `min`.
-- The **mid** stop may use `number | percent | percentile` only.
-- `value` is provided for `number` / `percent` / `percentile`, and **not** for `min` / `max`.
+Named colors match the chart palette and adapt to light/dark; `white` and `black` are fixed literals that stay the same in both themes.
 
-Defaults: `min` stop → `min` type, `max` stop → `max` type, `mid` stop →
-`percentile` 50 — so `colorScale: { min: "#red", max: "#green" }` anchors to the
-observed range with no `value` needed.
+**Built-in `scheme`s:** `red-white-green`, `green-white-red`, `red-amber-green`, `green-amber-red`, `white-green`, `white-red`, `white-blue`.
 
-### Single colour (threshold rules)
-
-`singleColor` is a list of rules that apply a fixed style to cells matching a
-condition. Rules are evaluated in order; the **first match wins**.
+**Custom palettes:** define reusable gradients at the dashboard top level under `palettes` (name to 2+ colors), then reference one by name with `scheme`. A palette name must not collide with a built-in.
 
 ```yaml
+palettes:
+  risk: [red, amber, green]
 columns:
-  - name: status
-    label: Status
-    singleColor:
-      - if: text_is_exactly
-        value: overdue
-        background: "#FEE2E2"
-        textColor: "#991B1B"
-        bold: true
-  - name: margin
-    format: number
-    singleColor:
-      - if: less_than
-        value: 0
-        background: "#FEE2E2"
-        strikethrough: true
-      - if: is_between
-        value: [0, 10]   
-        background: "#FEF9C3"
+  - name: growth
+    format: { scheme: risk }        # the palette, by name
 ```
 
-Rule fields — one condition plus one or more styles:
+**Rule fields** (each rule = one condition + one or more styles)
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `if` | string | Condition operator (see below). Required. |
-| `value` | any | Comparison value; a `[low, high]` list for `is_between` / `is_not_between`; omitted for `is_empty` / `is_not_empty` |
-| `background` | string | Fill color |
-| `textColor` | string | Text color |
-| `bold` | bool | Bold text |
-| `italic` | bool | Italic text |
-| `underline` | bool | Underline text |
-| `strikethrough` | bool | Strike-through text |
+| Field | What it does |
+|-------|--------------|
+| `if` | Operator (required). See the table below. |
+| `value` | Scalar to compare against. Use `[low, high]` for between, `{ column: X }` for cross column, omit for empty checks. |
+| `backgroundColor` / `textColor` | Cell colors. |
+| `bold` / `italic` / `underline` / `strikethrough` | Text styling. At least one style is required. |
 
-At least one style is required per rule.
+**Operators**
 
-**Operators** (`if`): `is_empty`, `is_not_empty`, `text_contains`,
-`text_does_not_contain`, `text_starts_with`, `text_ends_with`, `text_is_exactly`,
-`date_is`, `date_before`, `date_after`, `greater_than`,
-`greater_than_or_equal`, `less_than`, `less_than_or_equal`, `is_equal_to`,
-`is_not_equal_to`, `is_between`, `is_not_between`. Text operators are
-case-insensitive. Date operators (`date_is` / `date_before` / `date_after`)
-accept dates or timestamps: they compare by calendar day when the rule's `value`
-is date-only (e.g. `"2026-07-22"`), or by exact instant when the `value` includes
-a time (e.g. `"2026-07-22T12:00"`).
+| Group | Operators |
+|-------|-----------|
+| Empty | `is_empty`, `is_not_empty` |
+| Text (case insensitive) | `text_contains`, `text_does_not_contain`, `text_starts_with`, `text_ends_with`, `text_is_exactly` |
+| Number | `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `is_equal_to`, `is_not_equal_to` |
+| Range | `is_between`, `is_not_between` |
+| Date | `date_is`, `date_before`, `date_after` (by day for a date, or exact instant if the value has a time) |
+
+**Worked example** (a full dashboard exercising every feature above):
+
+```yaml
+name: Regions
+
+palettes:
+  risk: [red, amber, green]                                       # custom palette, reused by name via `scheme`
+
+rows:
+  - widgets:
+      - name: Regions
+        type: table
+        col: 12
+        sql: SELECT region, revenue, growth, margin, score, status, actual, target, bonus, due FROM regions
+        columns:
+          - name: region
+            format: { backgroundColor: "#F8FAFC", bold: true }          # flat fill + text style
+
+          - name: revenue
+            format:
+              number: currency                                          # value display: currency
+              scheme: red-white-green                                   # built-in gradient
+
+          - name: growth
+            format:
+              number: number
+              domain: [-25, 0, 25]                                      # raw anchors (0 = neutral middle)
+              backgroundColor: [blue, white, amber]                     # custom gradient colors
+
+          - name: margin
+            format:
+              number: ".0%"                                             # d3-format string
+              scheme: risk                                              # custom palette, by name
+              domain: { unit: percentile }                              # anchor by percentile (midpoint = median)
+
+          - name: score
+            format:
+              number: number
+              rules:                                                    # numeric rules, first match wins
+                - { if: greater_than_or_equal, value: 80, backgroundColor: green }    # scalar value
+                - { if: is_between, value: [50, 79], backgroundColor: amber }          # [low, high] for between
+                - { if: less_than, value: 50, textColor: red, strikethrough: true }    # text style
+
+          - name: status
+            format:
+              rules:                                                    # text rules
+                - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
+                - { if: text_is_exactly, value: overdue, backgroundColor: red }
+                - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }           # no value for empty checks
+
+          - name: actual
+            format:
+              number: number
+              rules:
+                - { if: less_than, value: { column: target }, backgroundColor: red }    # cross-column, same row
+                - { if: greater_than, value: { column: target }, backgroundColor: green }
+
+          - name: bonus
+            format: { number: currency, like: score }                  # mirror score's colors, keep own number
+
+          - name: due
+            format:
+              rules:                                                    # date rules
+                - { if: date_before, value: "2026-07-22", textColor: red }
+                - { if: date_after, value: "2026-07-22", textColor: green }
+```
+
+How the example reads, column by column:
+- `region`: one flat color on every cell, bold text (a plain string fill plus a text style).
+- `revenue`: currency, colored by the built-in `red-white-green` gradient.
+- `growth`: a custom blue/white/amber gradient with the neutral point pinned to 0 via a raw `domain`.
+- `margin`: a percentage, colored by the custom `risk` palette, anchored by `percentile` so the midpoint sits at the median.
+- `score`: numeric rules covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`), plus a text style (`< 50` struck through in red).
+- `status`: text rules checked in order, first match wins (contains "urgent", exactly "overdue", or empty).
+- `actual`: cross-column rules, compared to `target` in the same row (explained next).
+- `bonus`: `like: score`, so it takes score's colors per row but keeps its own currency display.
+- `due`: date rules, before or after a cutoff day.
+
+Cross column, step by step. Look at the `actual` rule:
+
+```yaml
+{ if: less_than, value: { column: target }, backgroundColor: red }
+```
+
+The cell being colored is `actual`. `value: { column: target }` means "compare it to the `target` column in the same row", not to a fixed number. So for every row independently: if that row's `actual` is less than that row's `target`, the `actual` cell turns red. Row 1 uses row 1's target, row 2 uses row 2's target, and so on. `target` can even be a column you do not display in the table, because its data is still available for the comparison. (Writing `value: 100` instead would compare against the constant 100.)
 
 ## Inline data
 

--- a/examples/basic-yaml/dashboards/date-number-filters.yml
+++ b/examples/basic-yaml/dashboards/date-number-filters.yml
@@ -96,7 +96,7 @@ rows:
             label: Customer
           - name: amount
             label: Amount
-            format: currency
+            number: currency
           - name: status
             label: Status
           - name: created_at

--- a/examples/basic-yaml/dashboards/sales.yml
+++ b/examples/basic-yaml/dashboards/sales.yml
@@ -163,13 +163,13 @@ rows:
             label: Customer
           - name: orders
             label: Orders
-            format: number
+            number: number
           - name: total_spent
             label: Total Spent
-            format: currency
+            number: currency
           - name: avg_order
             label: Average Order
-            format: currency
+            number: currency
       - name: Revenue by Region & Month
         type: table
         col: 6
@@ -194,10 +194,10 @@ rows:
             label: Month
           - name: sales_count
             label: Sales
-            format: number
+            number: number
           - name: revenue
             label: Revenue
-            format: currency
+            number: currency
 
   # Recent orders
   - widgets:
@@ -217,7 +217,7 @@ rows:
             label: Customer
           - name: amount
             label: Amount
-            format: currency
+            number: currency
           - name: status
             label: Status
           - name: created_at

--- a/examples/semantic-joins/dashboards/orders.yml
+++ b/examples/semantic-joins/dashboards/orders.yml
@@ -75,8 +75,8 @@ rows:
             label: Category
           - name: revenue
             label: Revenue
-            format: currency
+            number: currency
           - name: order_count
             label: Orders
-            format: number
+            number: number
         col: 12

--- a/examples/semantic-yaml/dashboards/semantic-sales.yml
+++ b/examples/semantic-yaml/dashboards/semantic-sales.yml
@@ -151,8 +151,8 @@ rows:
             label: Channel
           - name: revenue
             label: Revenue
-            format: currency
+            number: currency
           - name: sales_count
             label: Sales
-            format: number
+            number: number
         col: 12

--- a/frontend/src/components/DashboardView.tsx
+++ b/frontend/src/components/DashboardView.tsx
@@ -3,7 +3,6 @@ import { useParams } from "react-router-dom";
 import { useDashboard } from "../hooks/useDashboard";
 import { useWidgetQuery } from "../hooks/useWidgetQuery";
 import { useTemplate } from "../themes/TemplateProvider";
-import { PalettesContext } from "../themes/PalettesContext";
 import { resolvePreset } from "../themes/bruin/FilterBar";
 import { YamlPanel } from "./YamlPanel";
 import { ExportMenuButton, type ExportMenuItem } from "./ExportMenuButton";
@@ -286,7 +285,6 @@ export function DashboardView() {
   };
 
   return (
-    <PalettesContext.Provider value={dashboard.palettes ?? {}}>
     <div
       className={`dac-layout h-screen overflow-hidden ${isResizing ? "dac-layout-resizing" : ""}`}
       style={{ gridTemplateColumns: gridColumns }}
@@ -362,6 +360,5 @@ export function DashboardView() {
         onResizeEnd={onResizeEnd}
       />
     </div>
-    </PalettesContext.Provider>
   );
 }

--- a/frontend/src/components/DashboardView.tsx
+++ b/frontend/src/components/DashboardView.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { useDashboard } from "../hooks/useDashboard";
 import { useWidgetQuery } from "../hooks/useWidgetQuery";
 import { useTemplate } from "../themes/TemplateProvider";
+import { PalettesContext } from "../themes/PalettesContext";
 import { resolvePreset } from "../themes/bruin/FilterBar";
 import { YamlPanel } from "./YamlPanel";
 import { ExportMenuButton, type ExportMenuItem } from "./ExportMenuButton";
@@ -285,6 +286,7 @@ export function DashboardView() {
   };
 
   return (
+    <PalettesContext.Provider value={dashboard.palettes ?? {}}>
     <div
       className={`dac-layout h-screen overflow-hidden ${isResizing ? "dac-layout-resizing" : ""}`}
       style={{ gridTemplateColumns: gridColumns }}
@@ -360,5 +362,6 @@ export function DashboardView() {
         onResizeEnd={onResizeEnd}
       />
     </div>
+    </PalettesContext.Provider>
   );
 }

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -61,7 +61,9 @@ export function TableWidget({ widget, data }: Props) {
         seen.add(src.name);
         src = byName.get(src.format.like);
       }
-      return src;
+      // Exited on a cycle (src still points at a `like` column) → no valid
+      // terminal source; the column falls back to its own format.
+      return src?.format?.like ? undefined : src;
     };
     return raw.map((c) => {
       const src = c.format?.like ? likeSource(c) : undefined;

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -1,5 +1,13 @@
-import { useMemo, useState } from "react";
-import type { Widget, WidgetData } from "../../types/dashboard";
+import { useMemo, useState, type CSSProperties } from "react";
+import type { ColorScale, SingleColorRule, Widget, WidgetData } from "../../types/dashboard";
+import {
+  applyRuleStyle,
+  cellColor,
+  matchRule,
+  resolveScale,
+  toNumber,
+  type ResolvedScale,
+} from "./conditionalFormat";
 
 interface Props {
   widget: Widget;
@@ -17,6 +25,8 @@ interface TableColumn {
   name: string;
   label: string;
   format?: string;
+  colorScale?: ColorScale;
+  singleColor?: SingleColorRule[];
   idx: number;
 }
 
@@ -31,12 +41,16 @@ export function TableWidget({ widget, data }: Props) {
           name: col.name,
           label: col.label || col.name,
           format: col.format,
+          colorScale: col.colorScale,
+          singleColor: col.singleColor,
           idx: data.columns.findIndex((c) => c.name === col.name),
         }))
       : data.columns.map((col, idx) => ({
           name: col.name,
           label: col.name,
           format: undefined as string | undefined,
+          colorScale: undefined as ColorScale | undefined,
+          singleColor: undefined as SingleColorRule[] | undefined,
           idx,
         }));
   }, [widget.columns, data?.columns]);
@@ -51,6 +65,23 @@ export function TableWidget({ widget, data }: Props) {
 
     return sortRows(rows, col.idx, sort.direction, isNumericFormat(col.format));
   }, [columns, rows, sort]);
+
+  // Resolve a color scale per column against the full (unsorted) value range so
+  // cell backgrounds stay stable regardless of the active sort.
+  const colorScales = useMemo(() => {
+    const map = new Map<string, ResolvedScale>();
+    for (const col of columns) {
+      if (!col.colorScale || col.idx < 0) continue;
+      const values: number[] = [];
+      for (const row of rows) {
+        const n = toNumber(row[col.idx]);
+        if (n !== null) values.push(n);
+      }
+      const scale = resolveScale(col.colorScale, values);
+      if (scale) map.set(col.name, scale);
+    }
+    return map;
+  }, [columns, rows]);
 
   if (!rows.length) {
     return <div className="text-[var(--dac-text-muted)] text-xs py-4 text-center">No data</div>;
@@ -103,17 +134,33 @@ export function TableWidget({ widget, data }: Props) {
               key={i}
               className="border-b border-[var(--dac-border)] border-opacity-40 last:border-0 hover:bg-[var(--dac-surface)] transition-colors duration-75"
             >
-              {columns.map((col) => (
-                <td
-                  key={col.name}
-                  className={`py-1.5 px-4 whitespace-nowrap ${
-                    isNumericFormat(col.format) ? "text-right tabular-nums text-[12px]" : ""
-                  }`}
-                  style={isNumericFormat(col.format) ? { fontFamily: '"Geist Mono", monospace' } : undefined}
-                >
-                  {formatCell(col.idx >= 0 ? row[col.idx] : null, col.format)}
-                </td>
-              ))}
+              {columns.map((col) => {
+                const numeric = isNumericFormat(col.format);
+                const raw = col.idx >= 0 ? row[col.idx] : null;
+                const scale = colorScales.get(col.name);
+                const fill = scale ? cellColor(scale, toNumber(raw)) : undefined;
+                const style: CSSProperties = {};
+                if (numeric) style.fontFamily = '"Geist Mono", monospace';
+                if (fill) {
+                  style.backgroundColor = fill.background;
+                  style.color = fill.text;
+                }
+                // Single-color rules override the scale where they overlap;
+                // the first matching rule wins.
+                const rule = col.singleColor?.find((r) => matchRule(r, raw));
+                if (rule) applyRuleStyle(style, rule);
+                return (
+                  <td
+                    key={col.name}
+                    className={`py-1.5 px-4 whitespace-nowrap ${
+                      numeric ? "text-right tabular-nums text-[12px]" : ""
+                    }`}
+                    style={Object.keys(style).length ? style : undefined}
+                  >
+                    {formatCell(raw, col.format)}
+                  </td>
+                );
+              })}
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -138,7 +138,7 @@ export function TableWidget({ widget, data }: Props) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-[13px] min-w-[400px]">
+      <table className="w-full text-[13px] min-w-[400px] border-separate [border-spacing:3px_4px]">
         <thead>
           <tr className="bg-[var(--dac-surface)]">
             {columns.map((col) => {
@@ -154,7 +154,7 @@ export function TableWidget({ widget, data }: Props) {
                         : "descending"
                       : "none"
                   }
-                  className={`py-0 px-0 border-b border-[var(--dac-border)] whitespace-nowrap ${
+                  className={`py-0 px-0 whitespace-nowrap ${
                     numeric ? "text-right" : "text-left"
                   }`}
                 >
@@ -177,7 +177,7 @@ export function TableWidget({ widget, data }: Props) {
           {sortedRows.map((row, i) => (
             <tr
               key={i}
-              className="border-b border-[var(--dac-border)] border-opacity-40 last:border-0 hover:bg-[var(--dac-surface)] transition-colors duration-75"
+              className="hover:bg-[var(--dac-surface)] transition-colors duration-75"
             >
               {columns.map((col) => {
                 const numeric = isNumericFormat(col.format);
@@ -195,7 +195,7 @@ export function TableWidget({ widget, data }: Props) {
                 return (
                   <td
                     key={col.name}
-                    className={`py-1.5 px-4 whitespace-nowrap ${
+                    className={`py-1.5 px-4 whitespace-nowrap align-middle rounded-[2px] ${
                       numeric ? "text-right tabular-nums text-[12px]" : ""
                     }`}
                     style={Object.keys(style).length ? style : undefined}

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -1,13 +1,15 @@
 import { useMemo, useState, type CSSProperties } from "react";
-import type { ColorScale, SingleColorRule, Widget, WidgetData } from "../../types/dashboard";
-import {
-  applyRuleStyle,
-  cellColor,
-  matchRule,
-  resolveScale,
-  toNumber,
-  type ResolvedScale,
-} from "./conditionalFormat";
+import { format as d3Format } from "d3-format";
+import type { Format, Widget, WidgetData } from "../../types/dashboard";
+import { useTokens } from "../../themes/TemplateProvider";
+import { cellStyle, hasScale, resolveScale, toNumber, type ResolvedScale } from "./conditionalFormat";
+import { usePalettes } from "../../themes/PalettesContext";
+
+/** A column's `format` may be a bare number-format string; normalize to an object. */
+function toFormat(f?: Format | string): Format | undefined {
+  if (f == null) return undefined;
+  return typeof f === "string" ? { number: f } : f;
+}
 
 interface Props {
   widget: Widget;
@@ -24,38 +26,59 @@ interface SortState {
 interface TableColumn {
   name: string;
   label: string;
-  format?: string;
-  colorScale?: ColorScale;
-  singleColor?: SingleColorRule[];
-  idx: number;
+  format?: Format; // effective format (own, or the mirrored column's if `like`)
+  idx: number; // own data index (drives the displayed value)
+  colorIdx: number; // data index whose value drives coloring (own, or `like` source)
 }
 
 export function TableWidget({ widget, data }: Props) {
   const [sort, setSort] = useState<SortState | null>(null);
+  const tokens = useTokens();
+  const palettes = usePalettes();
 
   const columns: TableColumn[] = useMemo(() => {
     if (!data?.columns) return [];
 
-    return widget.columns?.length
+    const raw = widget.columns?.length
       ? widget.columns.map((col) => ({
           name: col.name,
           label: col.label || col.name,
-          format: col.format,
-          colorScale: col.colorScale,
-          singleColor: col.singleColor,
+          format: toFormat(col.format),
           idx: data.columns.findIndex((c) => c.name === col.name),
         }))
       : data.columns.map((col, idx) => ({
           name: col.name,
           label: col.name,
-          format: undefined as string | undefined,
-          colorScale: undefined as ColorScale | undefined,
-          singleColor: undefined as SingleColorRule[] | undefined,
+          format: undefined as Format | undefined,
           idx,
         }));
+
+    // Resolve `format.like`: adopt the referenced column's *coloring* and drive
+    // it from that column's per-row value (so cells match it exactly), while
+    // keeping this column's own `number` display format.
+    const byName = new Map(raw.map((c) => [c.name, c]));
+    return raw.map((c) => {
+      const src = c.format?.like ? byName.get(c.format.like) : undefined;
+      if (src?.format) {
+        return {
+          ...c,
+          format: { ...src.format, number: c.format?.number ?? src.format.number },
+          colorIdx: src.idx,
+        };
+      }
+      return { ...c, colorIdx: c.idx };
+    });
   }, [widget.columns, data?.columns]);
 
   const rows = data?.rows ?? [];
+
+  // All data columns by name → index, so cross-column rules can reference any
+  // column (even ones not shown).
+  const dataIndex = useMemo(() => {
+    const m = new Map<string, number>();
+    data?.columns.forEach((c, i) => m.set(c.name, i));
+    return m;
+  }, [data?.columns]);
 
   const sortedRows = useMemo(() => {
     if (!sort || rows.length === 0) return rows;
@@ -66,22 +89,38 @@ export function TableWidget({ widget, data }: Props) {
     return sortRows(rows, col.idx, sort.direction, isNumericFormat(col.format));
   }, [columns, rows, sort]);
 
-  // Resolve a color scale per column against the full (unsorted) value range so
+  // Resolve a gradient per column against the full (unsorted) value range so
   // cell backgrounds stay stable regardless of the active sort.
-  const colorScales = useMemo(() => {
+  const scales = useMemo(() => {
     const map = new Map<string, ResolvedScale>();
     for (const col of columns) {
-      if (!col.colorScale || col.idx < 0) continue;
+      if (!col.format || col.colorIdx < 0 || !hasScale(col.format, palettes)) continue;
       const values: number[] = [];
       for (const row of rows) {
-        const n = toNumber(row[col.idx]);
+        const n = toNumber(row[col.colorIdx]);
         if (n !== null) values.push(n);
       }
-      const scale = resolveScale(col.colorScale, values);
+      const scale = resolveScale(col.format, values, tokens, palettes);
       if (scale) map.set(col.name, scale);
     }
     return map;
-  }, [columns, rows]);
+  }, [columns, rows, tokens, palettes]);
+
+  // Compile each column's d3-format spec once (currency/number are handled
+  // separately). Invalid specs are skipped so cells fall back to raw text.
+  const numberFormatters = useMemo(() => {
+    const m = new Map<string, (n: number) => string>();
+    for (const col of columns) {
+      const fmt = col.format?.number;
+      if (!fmt || fmt === "currency" || fmt === "number") continue;
+      try {
+        m.set(col.name, d3Format(fmt));
+      } catch {
+        // Invalid d3-format spec: leave unset; formatCell renders raw text.
+      }
+    }
+    return m;
+  }, [columns]);
 
   if (!rows.length) {
     return <div className="text-[var(--dac-text-muted)] text-xs py-4 text-center">No data</div>;
@@ -136,19 +175,17 @@ export function TableWidget({ widget, data }: Props) {
             >
               {columns.map((col) => {
                 const numeric = isNumericFormat(col.format);
-                const raw = col.idx >= 0 ? row[col.idx] : null;
-                const scale = colorScales.get(col.name);
-                const fill = scale ? cellColor(scale, toNumber(raw)) : undefined;
-                const style: CSSProperties = {};
-                if (numeric) style.fontFamily = '"Geist Mono", monospace';
-                if (fill) {
-                  style.backgroundColor = fill.background;
-                  style.color = fill.text;
+                const raw = col.idx >= 0 ? row[col.idx] : null; // displayed value (own column)
+                const style: CSSProperties = numeric ? { fontFamily: '"Geist Mono", monospace' } : {};
+                if (col.format) {
+                  const lookup = (name: string) => {
+                    const idx = dataIndex.get(name);
+                    return idx === undefined ? undefined : row[idx];
+                  };
+                  // Coloring reads the color-source column (own, or `like` source).
+                  const colorRaw = col.colorIdx >= 0 ? row[col.colorIdx] : null;
+                  Object.assign(style, cellStyle(col.format, scales.get(col.name) ?? null, colorRaw, tokens, lookup));
                 }
-                // Single-color rules override the scale where they overlap;
-                // the first matching rule wins.
-                const rule = col.singleColor?.find((r) => matchRule(r, raw));
-                if (rule) applyRuleStyle(style, rule);
                 return (
                   <td
                     key={col.name}
@@ -157,7 +194,7 @@ export function TableWidget({ widget, data }: Props) {
                     }`}
                     style={Object.keys(style).length ? style : undefined}
                   >
-                    {formatCell(raw, col.format)}
+                    {formatCell(raw, col.format?.number, numberFormatters.get(col.name))}
                   </td>
                 );
               })}
@@ -187,8 +224,10 @@ function SortIndicator({ direction }: { direction: SortDirection | null }) {
   );
 }
 
-function isNumericFormat(format?: string): boolean {
-  return format === "currency" || format === "number";
+function isNumericFormat(format?: Format): boolean {
+  // Any explicit number format (currency, number, or a d3-format string) marks
+  // the column as numeric for alignment and sorting.
+  return format?.number != null;
 }
 
 function nextSortState(current: SortState | null, column: string): SortState | null {
@@ -234,7 +273,7 @@ function compareValues(a: unknown, b: unknown, numeric: boolean): number {
   return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: "base" });
 }
 
-function formatCell(value: unknown, format?: string): string {
+function formatCell(value: unknown, format?: string, d3fmt?: (n: number) => string): string {
   if (value === null || value === undefined) return "—";
   if (format === "currency") {
     const num = Number(value);
@@ -243,6 +282,11 @@ function formatCell(value: unknown, format?: string): string {
   if (format === "number") {
     const num = Number(value);
     return isNaN(num) ? String(value) : num.toLocaleString();
+  }
+  if (d3fmt) {
+    // d3-format spec (e.g. "$,.2f", ".0%"); applies only to finite numbers.
+    const num = Number(value);
+    if (Number.isFinite(num)) return d3fmt(num);
   }
   const s = String(value);
   const isoMatch = s.match(/^(\d{4})-(\d{2})-(\d{2})T/);

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -3,7 +3,6 @@ import { format as d3Format } from "d3-format";
 import type { Format, Widget, WidgetData } from "../../types/dashboard";
 import { useTokens } from "../../themes/TemplateProvider";
 import { cellStyle, hasScale, resolveScale, toNumber, type ResolvedScale } from "./conditionalFormat";
-import { usePalettes } from "../../themes/PalettesContext";
 
 /** A column's `format` may be a bare number-format string; normalize to an object. */
 function toFormat(f?: Format | string): Format | undefined {
@@ -34,7 +33,6 @@ interface TableColumn {
 export function TableWidget({ widget, data }: Props) {
   const [sort, setSort] = useState<SortState | null>(null);
   const tokens = useTokens();
-  const palettes = usePalettes();
 
   const columns: TableColumn[] = useMemo(() => {
     if (!data?.columns) return [];
@@ -102,17 +100,17 @@ export function TableWidget({ widget, data }: Props) {
   const scales = useMemo(() => {
     const map = new Map<string, ResolvedScale>();
     for (const col of columns) {
-      if (!col.format || col.colorIdx < 0 || !hasScale(col.format, palettes)) continue;
+      if (!col.format || col.colorIdx < 0 || !hasScale(col.format)) continue;
       const values: number[] = [];
       for (const row of rows) {
         const n = toNumber(row[col.colorIdx]);
         if (n !== null) values.push(n);
       }
-      const scale = resolveScale(col.format, values, tokens, palettes);
+      const scale = resolveScale(col.format, values, tokens);
       if (scale) map.set(col.name, scale);
     }
     return map;
-  }, [columns, rows, tokens, palettes]);
+  }, [columns, rows, tokens]);
 
   // Compile each column's d3-format spec once (currency/number are handled
   // separately). Invalid specs are skipped so cells fall back to raw text.

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -53,12 +53,20 @@ export function TableWidget({ widget, data }: Props) {
           idx,
         }));
 
-    // Resolve `format.like`: adopt the referenced column's *coloring* and drive
-    // it from that column's per-row value (so cells match it exactly), while
-    // keeping this column's own `number` display format.
+    // `format.like`: adopt the source's coloring driven by its per-row value,
+    // keeping own `number`. Followed transitively (cycle-guarded) to the terminal source.
     const byName = new Map(raw.map((c) => [c.name, c]));
+    const likeSource = (col: (typeof raw)[number]) => {
+      let src = col.format?.like ? byName.get(col.format.like) : undefined;
+      const seen = new Set([col.name]);
+      while (src && src.format?.like && !seen.has(src.name)) {
+        seen.add(src.name);
+        src = byName.get(src.format.like);
+      }
+      return src;
+    };
     return raw.map((c) => {
-      const src = c.format?.like ? byName.get(c.format.like) : undefined;
+      const src = c.format?.like ? likeSource(c) : undefined;
       if (src?.format) {
         return {
           ...c,

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -137,7 +137,7 @@ export function TableWidget({ widget, data }: Props) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-[13px] min-w-[400px] border-separate [border-spacing:2px_3px]">
+      <table className="w-full text-[13px] min-w-[400px] border-separate [border-spacing:1px_2px]">
         <thead>
           <tr className="bg-[var(--dac-surface)]">
             {columns.map((col) => {

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -1,14 +1,8 @@
 import { useMemo, useState, type CSSProperties } from "react";
 import { format as d3Format } from "d3-format";
-import type { Format, Widget, WidgetData } from "../../types/dashboard";
+import type { FormatLayer, Widget, WidgetData } from "../../types/dashboard";
 import { useTokens } from "../../themes/TemplateProvider";
-import { cellStyle, hasScale, resolveScale, toNumber, type ResolvedScale } from "./conditionalFormat";
-
-/** A column's `format` may be a bare number-format string; normalize to an object. */
-function toFormat(f?: Format | string): Format | undefined {
-  if (f == null) return undefined;
-  return typeof f === "string" ? { number: f } : f;
-}
+import { cellStyle, isGradient, resolveScale, toNumber, type ResolvedScale } from "./conditionalFormat";
 
 interface Props {
   widget: Widget;
@@ -25,7 +19,8 @@ interface SortState {
 interface TableColumn {
   name: string;
   label: string;
-  format?: Format; // effective format (own, or the mirrored column's if `like`)
+  number?: string; // value display (currency | number | d3-format)
+  format?: FormatLayer[]; // effective layers (own, or the mirrored column's if `like`)
   idx: number; // own data index (drives the displayed value)
   colorIdx: number; // data index whose value drives coloring (own, or `like` source)
 }
@@ -41,38 +36,37 @@ export function TableWidget({ widget, data }: Props) {
       ? widget.columns.map((col) => ({
           name: col.name,
           label: col.label || col.name,
-          format: toFormat(col.format),
+          number: col.number,
+          like: col.like,
+          format: col.format,
           idx: data.columns.findIndex((c) => c.name === col.name),
         }))
       : data.columns.map((col, idx) => ({
           name: col.name,
           label: col.name,
-          format: undefined as Format | undefined,
+          number: undefined as string | undefined,
+          like: undefined as string | undefined,
+          format: undefined as FormatLayer[] | undefined,
           idx,
         }));
 
-    // `format.like`: adopt the source's coloring driven by its per-row value,
+    // `like`: adopt the source column's coloring driven by its per-row value,
     // keeping own `number`. Followed transitively (cycle-guarded) to the terminal source.
     const byName = new Map(raw.map((c) => [c.name, c]));
     const likeSource = (col: (typeof raw)[number]) => {
-      let src = col.format?.like ? byName.get(col.format.like) : undefined;
+      let src = col.like ? byName.get(col.like) : undefined;
       const seen = new Set([col.name]);
-      while (src && src.format?.like && !seen.has(src.name)) {
+      while (src && src.like && !seen.has(src.name)) {
         seen.add(src.name);
-        src = byName.get(src.format.like);
+        src = byName.get(src.like);
       }
-      // Exited on a cycle (src still points at a `like` column) → no valid
-      // terminal source; the column falls back to its own format.
-      return src?.format?.like ? undefined : src;
+      // Exited on a cycle (src still points at a `like` column) → no valid source.
+      return src?.like ? undefined : src;
     };
     return raw.map((c) => {
-      const src = c.format?.like ? likeSource(c) : undefined;
-      if (src?.format) {
-        return {
-          ...c,
-          format: { ...src.format, number: c.format?.number ?? src.format.number },
-          colorIdx: src.idx,
-        };
+      const src = c.like ? likeSource(c) : undefined;
+      if (src) {
+        return { ...c, format: src.format, colorIdx: src.idx };
       }
       return { ...c, colorIdx: c.idx };
     });
@@ -94,22 +88,25 @@ export function TableWidget({ widget, data }: Props) {
     const col = columns.find((c) => c.name === sort.column);
     if (!col || col.idx < 0) return rows;
 
-    return sortRows(rows, col.idx, sort.direction, isNumericFormat(col.format));
+    return sortRows(rows, col.idx, sort.direction, col.number != null);
   }, [columns, rows, sort]);
 
-  // Resolve a gradient per column against the full (unsorted) value range so
-  // cell backgrounds stay stable regardless of the active sort.
+  // Resolve gradient scales per column against the full (unsorted) value range,
+  // one entry per layer (null for non-gradient layers) so cell colors stay stable
+  // regardless of the active sort.
   const scales = useMemo(() => {
-    const map = new Map<string, ResolvedScale>();
+    const map = new Map<string, (ResolvedScale | null)[]>();
     for (const col of columns) {
-      if (!col.format || col.colorIdx < 0 || !hasScale(col.format)) continue;
+      if (!col.format || col.colorIdx < 0) continue;
       const values: number[] = [];
       for (const row of rows) {
         const n = toNumber(row[col.colorIdx]);
         if (n !== null) values.push(n);
       }
-      const scale = resolveScale(col.format, values, tokens);
-      if (scale) map.set(col.name, scale);
+      map.set(
+        col.name,
+        col.format.map((layer) => (isGradient(layer) ? resolveScale(layer, values, tokens) : null)),
+      );
     }
     return map;
   }, [columns, rows, tokens]);
@@ -119,7 +116,7 @@ export function TableWidget({ widget, data }: Props) {
   const numberFormatters = useMemo(() => {
     const m = new Map<string, (n: number) => string>();
     for (const col of columns) {
-      const fmt = col.format?.number;
+      const fmt = col.number;
       if (!fmt || fmt === "currency" || fmt === "number") continue;
       try {
         m.set(col.name, d3Format(fmt));
@@ -140,11 +137,11 @@ export function TableWidget({ widget, data }: Props) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-[13px] min-w-[400px] border-separate [border-spacing:3px_4px]">
+      <table className="w-full text-[13px] min-w-[400px] border-separate [border-spacing:2px_3px]">
         <thead>
           <tr className="bg-[var(--dac-surface)]">
             {columns.map((col) => {
-              const numeric = isNumericFormat(col.format);
+              const numeric = col.number != null;
               const active = sort?.column === col.name;
               return (
                 <th
@@ -182,7 +179,7 @@ export function TableWidget({ widget, data }: Props) {
               className="hover:bg-[var(--dac-surface)] transition-colors duration-75"
             >
               {columns.map((col) => {
-                const numeric = isNumericFormat(col.format);
+                const numeric = col.number != null;
                 const raw = col.idx >= 0 ? row[col.idx] : null; // displayed value (own column)
                 const style: CSSProperties = numeric ? { fontFamily: '"Geist Mono", monospace' } : {};
                 if (col.format) {
@@ -192,17 +189,17 @@ export function TableWidget({ widget, data }: Props) {
                   };
                   // Coloring reads the color-source column (own, or `like` source).
                   const colorRaw = col.colorIdx >= 0 ? row[col.colorIdx] : null;
-                  Object.assign(style, cellStyle(col.format, scales.get(col.name) ?? null, colorRaw, tokens, lookup));
+                  Object.assign(style, cellStyle(col.format, scales.get(col.name) ?? [], colorRaw, tokens, lookup));
                 }
                 return (
                   <td
                     key={col.name}
-                    className={`py-1.5 px-4 whitespace-nowrap align-middle rounded-[2px] ${
+                    className={`py-1.5 px-4 whitespace-nowrap align-middle rounded-[3px] ${
                       numeric ? "text-right tabular-nums text-[12px]" : ""
                     }`}
                     style={Object.keys(style).length ? style : undefined}
                   >
-                    {formatCell(raw, col.format?.number, numberFormatters.get(col.name))}
+                    {formatCell(raw, col.number, numberFormatters.get(col.name))}
                   </td>
                 );
               })}
@@ -230,12 +227,6 @@ function SortIndicator({ direction }: { direction: SortDirection | null }) {
       </span>
     </span>
   );
-}
-
-function isNumericFormat(format?: Format): boolean {
-  // Any explicit number format (currency, number, or a d3-format string) marks
-  // the column as numeric for alignment and sorting.
-  return format?.number != null;
 }
 
 function nextSortState(current: SortState | null, column: string): SortState | null {

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -137,7 +137,7 @@ export function TableWidget({ widget, data }: Props) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-[13px] min-w-[400px] border-separate [border-spacing:1px_2px]">
+      <table className="w-full text-[13px] min-w-[400px] border-separate [border-spacing:1px_1px]">
         <thead>
           <tr className="bg-[var(--dac-surface)]">
             {columns.map((col) => {
@@ -194,7 +194,7 @@ export function TableWidget({ widget, data }: Props) {
                 return (
                   <td
                     key={col.name}
-                    className={`py-1.5 px-4 whitespace-nowrap align-middle rounded-[3px] ${
+                    className={`py-1.5 px-4 whitespace-nowrap align-middle rounded-none ${
                       numeric ? "text-right tabular-nums text-[12px]" : ""
                     }`}
                     style={Object.keys(style).length ? style : undefined}

--- a/frontend/src/components/widgets/conditionalFormat.ts
+++ b/frontend/src/components/widgets/conditionalFormat.ts
@@ -1,17 +1,11 @@
 import type { CSSProperties } from "react";
-import type { ColorScale, ColorStop, SingleColorRule } from "../../types/dashboard";
+import type { ColumnRef, Format, FormatRule, RuleValue } from "../../types/dashboard";
 
-// Pure logic for table conditional formatting — colour scales (gradient) and
-// single-colour rules (thresholds).
+// Pure logic for table conditional formatting: value scales (gradient) and
+// rules (thresholds/conditions). Colors are resolved against the theme token map so
+// named colors follow light/dark mode.
 
-// Default three-color scale: muted red (low) → white (mid) → muted green (high).
-// Going through white keeps mid-range cells calm; only the extremes get color.
-const DEFAULT_MIN_COLOR: RGB = [230, 124, 115]; // #E67C73
-const DEFAULT_MID_COLOR: RGB = [255, 255, 255]; // #FFFFFF
-const DEFAULT_MAX_COLOR: RGB = [87, 187, 138]; // #57BB8A
-
-export type RGB = [number, number, number];
-type StopRole = "min" | "mid" | "max";
+type RGB = [number, number, number];
 
 interface ScaleStop {
   value: number;
@@ -19,7 +13,47 @@ interface ScaleStop {
 }
 
 export interface ResolvedScale {
-  stops: ScaleStop[]; // sorted ascending by value; length 2 or 3
+  stops: ScaleStop[]; // sorted ascending by value
+}
+
+// Friendly color names → theme token key (the chart palette). Resolving through
+// tokens gives automatic light/dark values, and keeps table + chart colors identical.
+const NAMED_TOKEN: Record<string, string> = {
+  red: "chart-7",
+  green: "chart-6",
+  blue: "chart-8",
+  indigo: "chart-1",
+  cyan: "chart-2",
+  purple: "chart-3",
+  pink: "chart-4",
+  amber: "chart-5",
+  positive: "chart-6",
+  negative: "chart-7",
+  warning: "chart-5",
+};
+
+// Built-in gradient schemes. "background" is the theme surface, so the neutral
+// middle blends with the page in both light and dark mode.
+const SCHEMES: Record<string, string[]> = {
+  "red-white-green": ["red", "background", "green"],
+  "green-white-red": ["green", "background", "red"],
+  "red-amber-green": ["red", "amber", "green"],
+  "green-amber-red": ["green", "amber", "red"],
+  "white-green": ["background", "green"],
+  "white-red": ["background", "red"],
+  "white-blue": ["background", "blue"],
+};
+
+/** Resolve a color value (hex, named color, token, or raw CSS) to a CSS color string. */
+export function resolveColor(value: string | undefined, tokens: Record<string, string>): string | undefined {
+  if (!value) return undefined;
+  if (value.startsWith("#")) return value;
+  if (value === "white") return "#FFFFFF";
+  if (value === "black") return "#000000";
+  const named = NAMED_TOKEN[value];
+  if (named && tokens[named]) return tokens[named];
+  if (tokens[value]) return tokens[value]; // e.g. background, success, chart-3
+  return value; // raw CSS name / var(...)
 }
 
 export function toNumber(value: unknown): number | null {
@@ -28,69 +62,41 @@ export function toNumber(value: unknown): number | null {
   return isNaN(n) ? null : n;
 }
 
-function normalizeStop(stop?: ColorStop | string): ColorStop | undefined {
-  if (stop == null) return undefined;
-  return typeof stop === "string" ? { color: stop } : stop;
+// Custom palettes are dashboard-defined gradients, referenced by name via
+// `scheme`, and take the same shape as the built-ins.
+type Palettes = Record<string, string[]>;
+
+function gradientColorNames(format: Format, palettes?: Palettes): string[] | null {
+  if (Array.isArray(format.backgroundColor)) return format.backgroundColor;
+  if (format.scheme) return SCHEMES[format.scheme] ?? palettes?.[format.scheme] ?? null;
+  return null;
 }
 
-/** Resolve a stop's anchor value against the sorted column values, per its type. */
-function resolveAnchor(stop: ColorStop | undefined, role: StopRole, sorted: number[]): number {
+/** True when this format paints a gradient (needs the column's value range). */
+export function hasScale(format: Format, palettes?: Palettes): boolean {
+  return gradientColorNames(format, palettes) !== null;
+}
+
+/** Build the gradient stops for a column from its format and observed values. */
+export function resolveScale(
+  format: Format,
+  values: number[],
+  tokens: Record<string, string>,
+  palettes?: Palettes,
+): ResolvedScale | null {
+  const names = gradientColorNames(format, palettes);
+  if (!names || names.length < 2 || values.length === 0) return null;
+
+  const rgbs: RGB[] = names.map((n) => parseHex(resolveColor(n, tokens)) ?? [136, 136, 136]);
+  const sorted = [...values].sort((a, b) => a - b);
   const lo = sorted[0];
   const hi = sorted[sorted.length - 1];
-  const type = stop?.type ?? (role === "min" ? "min" : role === "max" ? "max" : "percentile");
-  const pctDefault = role === "min" ? 0 : role === "max" ? 100 : 50;
-  switch (type) {
-    case "min":
-      return lo;
-    case "max":
-      return hi;
-    case "number":
-      return stop?.value ?? (role === "max" ? hi : lo);
-    case "percent":
-      return lo + ((stop?.value ?? pctDefault) / 100) * (hi - lo);
-    case "percentile":
-      return percentileValue(sorted, stop?.value ?? pctDefault);
-    default:
-      return role === "max" ? hi : lo;
-  }
-}
 
-/** Linear-interpolated percentile of an ascending-sorted array (p in 0–100). */
-export function percentileValue(sorted: number[], p: number): number {
-  if (sorted.length === 1) return sorted[0];
-  const rank = (Math.max(0, Math.min(100, p)) / 100) * (sorted.length - 1);
-  const lo = Math.floor(rank);
-  const hi = Math.ceil(rank);
-  if (lo === hi) return sorted[lo];
-  return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
-}
+  const k = names.length;
+  const anchors = resolveAnchors(format.domain, k, sorted, lo, hi);
+  const stops = rgbs.map((rgb, i) => ({ value: anchors[i], rgb })).sort((a, b) => a.value - b.value);
 
-/** Build the concrete color stops for a column from its config and observed values. */
-export function resolveScale(cs: ColorScale, values: number[]): ResolvedScale | null {
-  if (values.length === 0) return null;
-
-  const sorted = [...values].sort((a, b) => a - b);
-  const minStop = normalizeStop(cs.min);
-  const midStop = normalizeStop(cs.mid);
-  const maxStop = normalizeStop(cs.max);
-
-  const hasExplicitColor = Boolean(minStop?.color || midStop?.color || maxStop?.color);
-  // The mid stop is active when it is given, or when nothing is configured at
-  // all (the pure default is a three-color scale).
-  const useMid = cs.mid != null || !hasExplicitColor;
-
-  const minColor = parseHex(minStop?.color) ?? DEFAULT_MIN_COLOR;
-  const maxColor = parseHex(maxStop?.color) ?? DEFAULT_MAX_COLOR;
-
-  const stops: ScaleStop[] = [{ value: resolveAnchor(minStop, "min", sorted), rgb: minColor }];
-  if (useMid) {
-    stops.push({ value: resolveAnchor(midStop, "mid", sorted), rgb: parseHex(midStop?.color) ?? DEFAULT_MID_COLOR });
-  }
-  stops.push({ value: resolveAnchor(maxStop, "max", sorted), rgb: maxColor });
-  stops.sort((a, b) => a.value - b.value);
-
-  // Degenerate range (all anchors equal): paint every cell with the top color
-  // rather than dividing by zero.
+  // Degenerate range (all anchors equal): paint every cell the top color.
   if (!(stops[stops.length - 1].value > stops[0].value)) {
     const rgb = stops[stops.length - 1].rgb;
     return { stops: [{ value: 0, rgb }, { value: 0, rgb }] };
@@ -98,8 +104,51 @@ export function resolveScale(cs: ColorScale, values: number[]): ResolvedScale | 
   return { stops };
 }
 
+/**
+ * Turn a `domain` into `k` anchor values.
+ * - omitted → evenly spaced across the value range (auto min/max)
+ * - array → raw values
+ * - `{ unit, anchors }` → anchors (or, if omitted, evenly spaced in that unit)
+ *   read as raw values / percent of range / percentile of the data.
+ */
+function resolveAnchors(
+  domain: number[] | { unit?: string; anchors?: number[] } | undefined,
+  k: number,
+  sorted: number[],
+  lo: number,
+  hi: number,
+): number[] {
+  const evenValue = () => Array.from({ length: k }, (_, i) => (k === 1 ? lo : lo + (i / (k - 1)) * (hi - lo)));
+
+  if (!domain) return evenValue();
+  if (Array.isArray(domain)) {
+    return domain.length === k ? domain : evenValue();
+  }
+
+  const unit = domain.unit ?? "value";
+  if (unit === "value") {
+    return domain.anchors && domain.anchors.length === k ? domain.anchors : evenValue();
+  }
+  // percent / percentile: use given positions, or spread evenly 0..100.
+  const positions =
+    domain.anchors && domain.anchors.length === k
+      ? domain.anchors
+      : Array.from({ length: k }, (_, i) => (k === 1 ? 0 : (i / (k - 1)) * 100));
+  return positions.map((p) => (unit === "percent" ? lo + (p / 100) * (hi - lo) : percentileValue(sorted, p)));
+}
+
+/** Linear-interpolated percentile of an ascending-sorted array (p in 0–100). */
+function percentileValue(sorted: number[], p: number): number {
+  if (sorted.length <= 1) return sorted[0] ?? 0;
+  const rank = (Math.max(0, Math.min(100, p)) / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+}
+
 /** Interpolate the background/text colors for a single cell value. */
-export function cellColor(scale: ResolvedScale, value: number | null): { background: string; text: string } | undefined {
+function cellColor(scale: ResolvedScale, value: number | null): { background: string; text: string } | undefined {
   if (value === null) return undefined;
 
   const { stops } = scale;
@@ -122,6 +171,58 @@ export function cellColor(scale: ResolvedScale, value: number | null): { backgro
     text: rgbLuminance(rgb) > 0.4 ? "#0A0D14" : "#FFFFFF",
   };
 }
+
+/**
+ * Compute the inline style for one cell: whole-column base → gradient → first
+ * matching rule (each layer overrides the properties it sets). `lookup` returns
+ * another column's value in the same row for cross-column rules.
+ */
+export function cellStyle(
+  format: Format,
+  scale: ResolvedScale | null,
+  raw: unknown,
+  tokens: Record<string, string>,
+  lookup: (column: string) => unknown,
+): CSSProperties {
+  const style: CSSProperties = {};
+
+  // 1. whole-column base (flat fill + text styles)
+  if (typeof format.backgroundColor === "string") style.backgroundColor = resolveColor(format.backgroundColor, tokens);
+  if (format.textColor) style.color = resolveColor(format.textColor, tokens);
+  applyTextStyles(style, format);
+
+  // 2. gradient (overrides background; sets contrasting text unless one is fixed)
+  if (scale) {
+    const fill = cellColor(scale, toNumber(raw));
+    if (fill) {
+      style.backgroundColor = fill.background;
+      if (!format.textColor) style.color = fill.text;
+    }
+  }
+
+  // 3. first matching rule
+  const rule = format.rules?.find((r) => matchRule(r, raw, lookup));
+  if (rule) applyRuleStyle(style, rule, tokens);
+
+  return style;
+}
+
+function applyTextStyles(style: CSSProperties, s: Format | FormatRule): void {
+  if (s.bold) style.fontWeight = 600;
+  if (s.italic) style.fontStyle = "italic";
+  const decoration: string[] = [];
+  if (s.underline) decoration.push("underline");
+  if (s.strikethrough) decoration.push("line-through");
+  if (decoration.length) style.textDecoration = decoration.join(" ");
+}
+
+function applyRuleStyle(style: CSSProperties, rule: FormatRule, tokens: Record<string, string>): void {
+  if (rule.backgroundColor) style.backgroundColor = resolveColor(rule.backgroundColor, tokens);
+  if (rule.textColor) style.color = resolveColor(rule.textColor, tokens);
+  applyTextStyles(style, rule);
+}
+
+// --- color helpers ---
 
 function lerpRGB(a: RGB, b: RGB, t: number): RGB {
   return [
@@ -146,38 +247,23 @@ function rgbLuminance([r, g, b]: RGB): number {
   return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
 }
 
-/** Turn a matched single-color rule into inline styles, merged onto `style`. */
-export function applyRuleStyle(style: CSSProperties, rule: SingleColorRule): void {
-  if (rule.background) style.backgroundColor = rule.background;
-  if (rule.textColor) style.color = rule.textColor;
-  if (rule.bold) style.fontWeight = 600;
-  if (rule.italic) style.fontStyle = "italic";
-  const decoration: string[] = [];
-  if (rule.underline) decoration.push("underline");
-  if (rule.strikethrough) decoration.push("line-through");
-  if (decoration.length) style.textDecoration = decoration.join(" ");
-}
+// --- rule matching ---
 
 const isEmpty = (v: unknown): boolean => v === null || v === undefined || v === "";
-
-// Lowercased text for case-insensitive comparison; arrays/nullish become "".
 const asText = (v: unknown): string => (v == null || Array.isArray(v) ? "" : String(v)).toLowerCase();
 
-// Numeric comparison that only matches when both sides parse as numbers.
 function numericCompare(cell: unknown, value: unknown, ok: (a: number, b: number) => boolean): boolean {
   const a = toNumber(cell);
   const b = toNumber(value);
   return a !== null && b !== null && ok(a, b);
 }
 
-// Numeric when both sides are numbers, otherwise a string comparison.
 function valuesEqual(cell: unknown, value: unknown): boolean {
   const a = toNumber(cell);
   const b = toNumber(value);
   return a !== null && b !== null ? a === b : String(cell) === String(value);
 }
 
-// true/false when the [low, high] range is valid, null when it is malformed.
 function betweenResult(cell: unknown, value: unknown): boolean | null {
   const pair = Array.isArray(value) ? value : [];
   const n = toNumber(cell);
@@ -187,9 +273,7 @@ function betweenResult(cell: unknown, value: unknown): boolean | null {
   return n >= Math.min(lo, hi) && n <= Math.max(lo, hi);
 }
 
-// Each operator is a predicate over (cell value, rule value). Empty cells are
-// handled in matchRule before this table is consulted.
-const CONDITIONS: Record<SingleColorRule["if"], (cell: unknown, value: unknown) => boolean> = {
+const CONDITIONS: Record<FormatRule["if"], (cell: unknown, value: unknown) => boolean> = {
   is_empty: (c) => isEmpty(c),
   is_not_empty: (c) => !isEmpty(c),
   text_contains: (c, v) => asText(c).includes(asText(v)),
@@ -210,21 +294,33 @@ const CONDITIONS: Record<SingleColorRule["if"], (cell: unknown, value: unknown) 
   is_not_between: (c, v) => betweenResult(c, v) === false,
 };
 
-/** Evaluate whether a cell value satisfies a single-color rule's condition. */
-export function matchRule(rule: SingleColorRule, raw: unknown): boolean {
+/** Resolve `{ column: X }` references (scalar or inside a list) to same-row values. */
+function resolveRuleValue(value: RuleValue | undefined, lookup: (column: string) => unknown): unknown {
+  if (Array.isArray(value)) return value.map((v) => resolveOne(v, lookup));
+  return resolveOne(value, lookup);
+}
+
+function resolveOne(v: unknown, lookup: (column: string) => unknown): unknown {
+  if (v !== null && typeof v === "object" && !Array.isArray(v) && "column" in (v as object)) {
+    return lookup((v as ColumnRef).column);
+  }
+  return v;
+}
+
+/** Evaluate whether a cell value satisfies a rule's condition. */
+function matchRule(rule: FormatRule, raw: unknown, lookup: (column: string) => unknown): boolean {
   if (rule.if === "is_empty") return isEmpty(raw);
   if (rule.if === "is_not_empty") return !isEmpty(raw);
-  // Every other operator treats an empty cell as a non-match.
-  if (isEmpty(raw)) return false;
-  return CONDITIONS[rule.if]?.(raw, rule.value) ?? false;
+  if (isEmpty(raw)) return false; // every other operator: empty is a non-match
+  const value = resolveRuleValue(rule.value, lookup);
+  return CONDITIONS[rule.if]?.(raw, value) ?? false;
 }
 
 function matchDate(op: "date_is" | "date_before" | "date_after", raw: unknown, value: unknown): boolean {
   const a = Date.parse(String(raw));
   const b = Date.parse(String(value));
   if (isNaN(a) || isNaN(b)) return false;
-  // Compare exact instants when the target value carries a time component;
-  // otherwise compare by calendar day.
+  // Exact instant when the value carries a time, otherwise by calendar day.
   const hasTime = /[T\s]\d{1,2}:/.test(String(value));
   const x = hasTime ? a : Math.floor(a / 86400000);
   const y = hasTime ? b : Math.floor(b / 86400000);

--- a/frontend/src/components/widgets/conditionalFormat.ts
+++ b/frontend/src/components/widgets/conditionalFormat.ts
@@ -225,8 +225,9 @@ function applyRuleStyle(style: CSSProperties, rule: FormatRule, tokens: Record<s
 
 /**
  * Paint a background fill. Semantic palette colors (red/green/amber/…) are
- * softened toward the theme surface and get contrast-aware text unless a text
- * color is set later; explicit hex/white/raw fills are left exactly as given.
+ * softened toward the theme surface so the theme's own text color stays legible;
+ * explicit hex/white/raw fills are left exactly as given. Text color is never
+ * forced here — it follows the theme, or an explicit `textColor`.
  */
 function setFill(style: CSSProperties, name: string, tokens: Record<string, string>): void {
   const resolved = resolveColor(name, tokens);
@@ -238,7 +239,6 @@ function setFill(style: CSSProperties, name: string, tokens: Record<string, stri
   }
   const s = soften(rgb, surfaceRGB(tokens));
   style.backgroundColor = `rgb(${s[0]}, ${s[1]}, ${s[2]})`;
-  style.color = rgbLuminance(s) > 0.4 ? "#0A0D14" : "#FFFFFF";
 }
 
 /** Mix a color toward another by `ratio` (0 = unchanged, 1 = fully the target). */

--- a/frontend/src/components/widgets/conditionalFormat.ts
+++ b/frontend/src/components/widgets/conditionalFormat.ts
@@ -1,9 +1,11 @@
 import type { CSSProperties } from "react";
-import type { ColumnRef, Format, FormatRule, RuleValue } from "../../types/dashboard";
+import type { ColumnRef, FormatLayer, RuleValue } from "../../types/dashboard";
 
-// Pure logic for table conditional formatting: value scales (gradient) and
-// rules (thresholds/conditions). Colors are resolved against the theme token map so
-// named colors follow light/dark mode.
+// Pure logic for table conditional formatting. A column's `format` is an ordered
+// list of layers; the first layer that matches a cell wins. A layer with `if` is
+// a condition; a layer without `if` always matches (a gradient or flat base —
+// place it last). Colors resolve against the theme token map so named colors
+// follow light/dark mode.
 
 type RGB = [number, number, number];
 
@@ -33,18 +35,6 @@ const NAMED_TOKEN: Record<string, string> = {
   warning: "chart-5",
 };
 
-// Built-in gradient schemes. "background" is the theme surface, so the neutral
-// middle blends with the page in both light and dark mode.
-const SCHEMES: Record<string, string[]> = {
-  "red-white-green": ["red", "background", "green"],
-  "green-white-red": ["green", "background", "red"],
-  "red-amber-green": ["red", "amber", "green"],
-  "green-amber-red": ["green", "amber", "red"],
-  "white-green": ["background", "green"],
-  "white-red": ["background", "red"],
-  "white-blue": ["background", "blue"],
-};
-
 /** Resolve a color value (hex, named color, token, or raw CSS) to a CSS color string. */
 export function resolveColor(value: string | undefined, tokens: Record<string, string>): string | undefined {
   if (!value) return undefined;
@@ -63,30 +53,23 @@ export function toNumber(value: unknown): number | null {
   return isNaN(n) ? null : n;
 }
 
-function gradientColorNames(format: Format): string[] | null {
-  if (Array.isArray(format.backgroundColor)) return format.backgroundColor;
-  if (format.scheme) return SCHEMES[format.scheme] ?? null;
-  return null;
+/** True when this layer paints a gradient (an array backgroundColor). */
+export function isGradient(layer: FormatLayer): boolean {
+  return Array.isArray(layer.backgroundColor);
 }
 
-/** True when this format paints a gradient (needs the column's value range). */
-export function hasScale(format: Format): boolean {
-  return gradientColorNames(format) !== null;
-}
-
-/** Build the gradient stops for a column from its format and observed values. */
+/** Build a gradient's stops for one layer, resolved against the column's values. */
 export function resolveScale(
-  format: Format,
+  layer: FormatLayer,
   values: number[],
   tokens: Record<string, string>,
 ): ResolvedScale | null {
-  const names = gradientColorNames(format);
+  const names = Array.isArray(layer.backgroundColor) ? layer.backgroundColor : null;
   if (!names || names.length < 2 || values.length === 0) return null;
 
   const surface = surfaceRGB(tokens);
   const rgbs: RGB[] = names.map((n) => {
     const base = parseHex(resolveColor(n, tokens)) ?? [136, 136, 136];
-    // Soften only the semantic palette colors; leave surface/white/hex stops as-is.
     return n in NAMED_TOKEN ? soften(base, surface) : base;
   });
   const sorted = [...values].sort((a, b) => a - b);
@@ -94,7 +77,7 @@ export function resolveScale(
   const hi = sorted[sorted.length - 1];
 
   const k = names.length;
-  const anchors = resolveAnchors(format.domain, k, sorted, lo, hi);
+  const anchors = resolveAnchors(layer.range, layer.unit, k, sorted, lo, hi);
   const stops = rgbs.map((rgb, i) => ({ value: anchors[i], rgb })).sort((a, b) => a.value - b.value);
 
   // Degenerate range (all anchors equal): paint every cell the top color.
@@ -106,36 +89,25 @@ export function resolveScale(
 }
 
 /**
- * Turn a `domain` into `k` anchor values.
- * - omitted → evenly spaced across the value range (auto min/max)
- * - array → raw values
- * - `{ unit, anchors }` → anchors (or, if omitted, evenly spaced in that unit)
- *   read as raw values / percent of range / percentile of the data.
+ * Turn a `range` + `unit` into `k` anchor values.
+ * - omitted (or wrong length) → evenly spaced across the value range (auto min/max)
+ * - unit `absolute` → raw values
+ * - unit `percent` → percent of the min..max range
+ * - unit `percentile` → percentile of the data
  */
 function resolveAnchors(
-  domain: number[] | { unit?: string; anchors?: number[] } | undefined,
+  range: number[] | undefined,
+  unit: string | undefined,
   k: number,
   sorted: number[],
   lo: number,
   hi: number,
 ): number[] {
-  const evenValue = () => Array.from({ length: k }, (_, i) => (k === 1 ? lo : lo + (i / (k - 1)) * (hi - lo)));
-
-  if (!domain) return evenValue();
-  if (Array.isArray(domain)) {
-    return domain.length === k ? domain : evenValue();
-  }
-
-  const unit = domain.unit ?? "value";
-  if (unit === "value") {
-    return domain.anchors && domain.anchors.length === k ? domain.anchors : evenValue();
-  }
-  // percent / percentile: use given positions, or spread evenly 0..100.
-  const positions =
-    domain.anchors && domain.anchors.length === k
-      ? domain.anchors
-      : Array.from({ length: k }, (_, i) => (k === 1 ? 0 : (i / (k - 1)) * 100));
-  return positions.map((p) => (unit === "percent" ? lo + (p / 100) * (hi - lo) : percentileValue(sorted, p)));
+  const even = () => Array.from({ length: k }, (_, i) => (k === 1 ? lo : lo + (i / (k - 1)) * (hi - lo)));
+  if (!range || range.length !== k) return even();
+  const u = unit || "absolute";
+  if (u === "absolute") return range;
+  return range.map((p) => (u === "percent" ? lo + (p / 100) * (hi - lo) : percentileValue(sorted, p)));
 }
 
 /** Linear-interpolated percentile of an ascending-sorted array (p in 0–100). */
@@ -174,53 +146,59 @@ function cellColor(scale: ResolvedScale, value: number | null): { background: st
 }
 
 /**
- * Compute the inline style for one cell: whole-column base → gradient → first
- * matching rule (each layer overrides the properties it sets). `lookup` returns
- * another column's value in the same row for cross-column rules.
+ * Compute the inline style for one cell: the first matching layer wins. `scales`
+ * is aligned to `layers` (one resolved gradient scale per layer, or null).
+ * `lookup` returns another column's value in the same row for cross-column rules.
  */
 export function cellStyle(
-  format: Format,
-  scale: ResolvedScale | null,
+  layers: FormatLayer[] | undefined,
+  scales: (ResolvedScale | null)[],
   raw: unknown,
   tokens: Record<string, string>,
   lookup: (column: string) => unknown,
 ): CSSProperties {
   const style: CSSProperties = {};
+  if (!layers) return style;
 
-  // 1. whole-column base (flat fill + text styles)
-  if (typeof format.backgroundColor === "string") setFill(style, format.backgroundColor, tokens);
-  if (format.textColor) style.color = resolveColor(format.textColor, tokens);
-  applyTextStyles(style, format);
+  for (let i = 0; i < layers.length; i++) {
+    const layer = layers[i];
+    if (!matchLayer(layer, raw, lookup)) continue;
 
-  // 2. gradient (overrides background; sets contrasting text unless one is fixed)
-  if (scale) {
-    const fill = cellColor(scale, toNumber(raw));
-    if (fill) {
-      style.backgroundColor = fill.background;
-      if (!format.textColor) style.color = fill.text;
+    // Matched — apply this layer and stop (first match wins).
+    if (Array.isArray(layer.backgroundColor)) {
+      const scale = scales[i];
+      const fill = scale ? cellColor(scale, toNumber(raw)) : undefined;
+      if (fill) {
+        style.backgroundColor = fill.background;
+        if (!layer.textColor) style.color = fill.text;
+      }
+    } else if (typeof layer.backgroundColor === "string") {
+      setFill(style, layer.backgroundColor, tokens);
     }
+    if (layer.textColor) style.color = resolveColor(layer.textColor, tokens);
+    applyTextStyles(style, layer);
+    return style;
   }
-
-  // 3. first matching rule
-  const rule = format.rules?.find((r) => matchRule(r, raw, lookup));
-  if (rule) applyRuleStyle(style, rule, tokens);
-
   return style;
 }
 
-function applyTextStyles(style: CSSProperties, s: Format | FormatRule): void {
+/** A layer matches a cell when it has no `if` (base) or its condition holds. */
+function matchLayer(layer: FormatLayer, raw: unknown, lookup: (column: string) => unknown): boolean {
+  if (!layer.if) return true;
+  if (layer.if === "is_empty") return isEmpty(raw);
+  if (layer.if === "is_not_empty") return !isEmpty(raw);
+  if (isEmpty(raw)) return false; // every other operator: empty is a non-match
+  const value = resolveRuleValue(layer.value, lookup);
+  return CONDITIONS[layer.if]?.(raw, value) ?? false;
+}
+
+function applyTextStyles(style: CSSProperties, s: FormatLayer): void {
   if (s.bold) style.fontWeight = 600;
   if (s.italic) style.fontStyle = "italic";
   const decoration: string[] = [];
   if (s.underline) decoration.push("underline");
   if (s.strikethrough) decoration.push("line-through");
   if (decoration.length) style.textDecoration = decoration.join(" ");
-}
-
-function applyRuleStyle(style: CSSProperties, rule: FormatRule, tokens: Record<string, string>): void {
-  if (rule.backgroundColor) setFill(style, rule.backgroundColor, tokens);
-  if (rule.textColor) style.color = resolveColor(rule.textColor, tokens);
-  applyTextStyles(style, rule);
 }
 
 /**
@@ -280,7 +258,7 @@ function rgbLuminance([r, g, b]: RGB): number {
   return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
 }
 
-// --- rule matching ---
+// --- condition matching ---
 
 const isEmpty = (v: unknown): boolean => v === null || v === undefined || v === "";
 const asText = (v: unknown): string => (v == null || Array.isArray(v) ? "" : String(v)).toLowerCase();
@@ -306,7 +284,7 @@ function betweenResult(cell: unknown, value: unknown): boolean | null {
   return n >= Math.min(lo, hi) && n <= Math.max(lo, hi);
 }
 
-const CONDITIONS: Record<FormatRule["if"], (cell: unknown, value: unknown) => boolean> = {
+const CONDITIONS: Record<string, (cell: unknown, value: unknown) => boolean> = {
   is_empty: (c) => isEmpty(c),
   is_not_empty: (c) => !isEmpty(c),
   text_contains: (c, v) => asText(c).includes(asText(v)),
@@ -338,15 +316,6 @@ function resolveOne(v: unknown, lookup: (column: string) => unknown): unknown {
     return lookup((v as ColumnRef).column);
   }
   return v;
-}
-
-/** Evaluate whether a cell value satisfies a rule's condition. */
-function matchRule(rule: FormatRule, raw: unknown, lookup: (column: string) => unknown): boolean {
-  if (rule.if === "is_empty") return isEmpty(raw);
-  if (rule.if === "is_not_empty") return !isEmpty(raw);
-  if (isEmpty(raw)) return false; // every other operator: empty is a non-match
-  const value = resolveRuleValue(rule.value, lookup);
-  return CONDITIONS[rule.if]?.(raw, value) ?? false;
 }
 
 function matchDate(op: "date_is" | "date_before" | "date_after", raw: unknown, value: unknown): boolean {

--- a/frontend/src/components/widgets/conditionalFormat.ts
+++ b/frontend/src/components/widgets/conditionalFormat.ts
@@ -62,19 +62,15 @@ export function toNumber(value: unknown): number | null {
   return isNaN(n) ? null : n;
 }
 
-// Custom palettes are dashboard-defined gradients, referenced by name via
-// `scheme`, and take the same shape as the built-ins.
-type Palettes = Record<string, string[]>;
-
-function gradientColorNames(format: Format, palettes?: Palettes): string[] | null {
+function gradientColorNames(format: Format): string[] | null {
   if (Array.isArray(format.backgroundColor)) return format.backgroundColor;
-  if (format.scheme) return SCHEMES[format.scheme] ?? palettes?.[format.scheme] ?? null;
+  if (format.scheme) return SCHEMES[format.scheme] ?? null;
   return null;
 }
 
 /** True when this format paints a gradient (needs the column's value range). */
-export function hasScale(format: Format, palettes?: Palettes): boolean {
-  return gradientColorNames(format, palettes) !== null;
+export function hasScale(format: Format): boolean {
+  return gradientColorNames(format) !== null;
 }
 
 /** Build the gradient stops for a column from its format and observed values. */
@@ -82,9 +78,8 @@ export function resolveScale(
   format: Format,
   values: number[],
   tokens: Record<string, string>,
-  palettes?: Palettes,
 ): ResolvedScale | null {
-  const names = gradientColorNames(format, palettes);
+  const names = gradientColorNames(format);
   if (!names || names.length < 2 || values.length === 0) return null;
 
   const rgbs: RGB[] = names.map((n) => parseHex(resolveColor(n, tokens)) ?? [136, 136, 136]);

--- a/frontend/src/components/widgets/conditionalFormat.ts
+++ b/frontend/src/components/widgets/conditionalFormat.ts
@@ -1,0 +1,234 @@
+import type { CSSProperties } from "react";
+import type { ColorScale, ColorStop, SingleColorRule } from "../../types/dashboard";
+
+// Pure logic for table conditional formatting — colour scales (gradient) and
+// single-colour rules (thresholds).
+
+// Default three-color scale: muted red (low) → white (mid) → muted green (high).
+// Going through white keeps mid-range cells calm; only the extremes get color.
+const DEFAULT_MIN_COLOR: RGB = [230, 124, 115]; // #E67C73
+const DEFAULT_MID_COLOR: RGB = [255, 255, 255]; // #FFFFFF
+const DEFAULT_MAX_COLOR: RGB = [87, 187, 138]; // #57BB8A
+
+export type RGB = [number, number, number];
+type StopRole = "min" | "mid" | "max";
+
+interface ScaleStop {
+  value: number;
+  rgb: RGB;
+}
+
+export interface ResolvedScale {
+  stops: ScaleStop[]; // sorted ascending by value; length 2 or 3
+}
+
+export function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const n = Number(value);
+  return isNaN(n) ? null : n;
+}
+
+function normalizeStop(stop?: ColorStop | string): ColorStop | undefined {
+  if (stop == null) return undefined;
+  return typeof stop === "string" ? { color: stop } : stop;
+}
+
+/** Resolve a stop's anchor value against the sorted column values, per its type. */
+function resolveAnchor(stop: ColorStop | undefined, role: StopRole, sorted: number[]): number {
+  const lo = sorted[0];
+  const hi = sorted[sorted.length - 1];
+  const type = stop?.type ?? (role === "min" ? "min" : role === "max" ? "max" : "percentile");
+  const pctDefault = role === "min" ? 0 : role === "max" ? 100 : 50;
+  switch (type) {
+    case "min":
+      return lo;
+    case "max":
+      return hi;
+    case "number":
+      return stop?.value ?? (role === "max" ? hi : lo);
+    case "percent":
+      return lo + ((stop?.value ?? pctDefault) / 100) * (hi - lo);
+    case "percentile":
+      return percentileValue(sorted, stop?.value ?? pctDefault);
+    default:
+      return role === "max" ? hi : lo;
+  }
+}
+
+/** Linear-interpolated percentile of an ascending-sorted array (p in 0–100). */
+export function percentileValue(sorted: number[], p: number): number {
+  if (sorted.length === 1) return sorted[0];
+  const rank = (Math.max(0, Math.min(100, p)) / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+}
+
+/** Build the concrete color stops for a column from its config and observed values. */
+export function resolveScale(cs: ColorScale, values: number[]): ResolvedScale | null {
+  if (values.length === 0) return null;
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const minStop = normalizeStop(cs.min);
+  const midStop = normalizeStop(cs.mid);
+  const maxStop = normalizeStop(cs.max);
+
+  const hasExplicitColor = Boolean(minStop?.color || midStop?.color || maxStop?.color);
+  // The mid stop is active when it is given, or when nothing is configured at
+  // all (the pure default is a three-color scale).
+  const useMid = cs.mid != null || !hasExplicitColor;
+
+  const minColor = parseHex(minStop?.color) ?? DEFAULT_MIN_COLOR;
+  const maxColor = parseHex(maxStop?.color) ?? DEFAULT_MAX_COLOR;
+
+  const stops: ScaleStop[] = [{ value: resolveAnchor(minStop, "min", sorted), rgb: minColor }];
+  if (useMid) {
+    stops.push({ value: resolveAnchor(midStop, "mid", sorted), rgb: parseHex(midStop?.color) ?? DEFAULT_MID_COLOR });
+  }
+  stops.push({ value: resolveAnchor(maxStop, "max", sorted), rgb: maxColor });
+  stops.sort((a, b) => a.value - b.value);
+
+  // Degenerate range (all anchors equal): paint every cell with the top color
+  // rather than dividing by zero.
+  if (!(stops[stops.length - 1].value > stops[0].value)) {
+    const rgb = stops[stops.length - 1].rgb;
+    return { stops: [{ value: 0, rgb }, { value: 0, rgb }] };
+  }
+  return { stops };
+}
+
+/** Interpolate the background/text colors for a single cell value. */
+export function cellColor(scale: ResolvedScale, value: number | null): { background: string; text: string } | undefined {
+  if (value === null) return undefined;
+
+  const { stops } = scale;
+  const clamped = Math.max(stops[0].value, Math.min(stops[stops.length - 1].value, value));
+
+  let rgb = stops[stops.length - 1].rgb;
+  for (let i = 0; i < stops.length - 1; i++) {
+    const a = stops[i];
+    const b = stops[i + 1];
+    if (clamped <= b.value) {
+      const span = b.value - a.value;
+      const t = span === 0 ? 0 : (clamped - a.value) / span;
+      rgb = lerpRGB(a.rgb, b.rgb, t);
+      break;
+    }
+  }
+
+  return {
+    background: `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`,
+    text: rgbLuminance(rgb) > 0.4 ? "#0A0D14" : "#FFFFFF",
+  };
+}
+
+function lerpRGB(a: RGB, b: RGB, t: number): RGB {
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * t),
+    Math.round(a[1] + (b[1] - a[1]) * t),
+    Math.round(a[2] + (b[2] - a[2]) * t),
+  ];
+}
+
+function parseHex(hex?: string): RGB | null {
+  if (!hex) return null;
+  const match = hex.trim().match(/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i);
+  if (!match) return null;
+  return [parseInt(match[1], 16), parseInt(match[2], 16), parseInt(match[3], 16)];
+}
+
+function rgbLuminance([r, g, b]: RGB): number {
+  const channels = [r, g, b].map((c) => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+/** Turn a matched single-color rule into inline styles, merged onto `style`. */
+export function applyRuleStyle(style: CSSProperties, rule: SingleColorRule): void {
+  if (rule.background) style.backgroundColor = rule.background;
+  if (rule.textColor) style.color = rule.textColor;
+  if (rule.bold) style.fontWeight = 600;
+  if (rule.italic) style.fontStyle = "italic";
+  const decoration: string[] = [];
+  if (rule.underline) decoration.push("underline");
+  if (rule.strikethrough) decoration.push("line-through");
+  if (decoration.length) style.textDecoration = decoration.join(" ");
+}
+
+const isEmpty = (v: unknown): boolean => v === null || v === undefined || v === "";
+
+// Lowercased text for case-insensitive comparison; arrays/nullish become "".
+const asText = (v: unknown): string => (v == null || Array.isArray(v) ? "" : String(v)).toLowerCase();
+
+// Numeric comparison that only matches when both sides parse as numbers.
+function numericCompare(cell: unknown, value: unknown, ok: (a: number, b: number) => boolean): boolean {
+  const a = toNumber(cell);
+  const b = toNumber(value);
+  return a !== null && b !== null && ok(a, b);
+}
+
+// Numeric when both sides are numbers, otherwise a string comparison.
+function valuesEqual(cell: unknown, value: unknown): boolean {
+  const a = toNumber(cell);
+  const b = toNumber(value);
+  return a !== null && b !== null ? a === b : String(cell) === String(value);
+}
+
+// true/false when the [low, high] range is valid, null when it is malformed.
+function betweenResult(cell: unknown, value: unknown): boolean | null {
+  const pair = Array.isArray(value) ? value : [];
+  const n = toNumber(cell);
+  const lo = toNumber(pair[0]);
+  const hi = toNumber(pair[1]);
+  if (n === null || lo === null || hi === null) return null;
+  return n >= Math.min(lo, hi) && n <= Math.max(lo, hi);
+}
+
+// Each operator is a predicate over (cell value, rule value). Empty cells are
+// handled in matchRule before this table is consulted.
+const CONDITIONS: Record<SingleColorRule["if"], (cell: unknown, value: unknown) => boolean> = {
+  is_empty: (c) => isEmpty(c),
+  is_not_empty: (c) => !isEmpty(c),
+  text_contains: (c, v) => asText(c).includes(asText(v)),
+  text_does_not_contain: (c, v) => !asText(c).includes(asText(v)),
+  text_starts_with: (c, v) => asText(c).startsWith(asText(v)),
+  text_ends_with: (c, v) => asText(c).endsWith(asText(v)),
+  text_is_exactly: (c, v) => asText(c) === asText(v),
+  date_is: (c, v) => matchDate("date_is", c, v),
+  date_before: (c, v) => matchDate("date_before", c, v),
+  date_after: (c, v) => matchDate("date_after", c, v),
+  greater_than: (c, v) => numericCompare(c, v, (a, b) => a > b),
+  greater_than_or_equal: (c, v) => numericCompare(c, v, (a, b) => a >= b),
+  less_than: (c, v) => numericCompare(c, v, (a, b) => a < b),
+  less_than_or_equal: (c, v) => numericCompare(c, v, (a, b) => a <= b),
+  is_equal_to: (c, v) => valuesEqual(c, v),
+  is_not_equal_to: (c, v) => !valuesEqual(c, v),
+  is_between: (c, v) => betweenResult(c, v) === true,
+  is_not_between: (c, v) => betweenResult(c, v) === false,
+};
+
+/** Evaluate whether a cell value satisfies a single-color rule's condition. */
+export function matchRule(rule: SingleColorRule, raw: unknown): boolean {
+  if (rule.if === "is_empty") return isEmpty(raw);
+  if (rule.if === "is_not_empty") return !isEmpty(raw);
+  // Every other operator treats an empty cell as a non-match.
+  if (isEmpty(raw)) return false;
+  return CONDITIONS[rule.if]?.(raw, rule.value) ?? false;
+}
+
+function matchDate(op: "date_is" | "date_before" | "date_after", raw: unknown, value: unknown): boolean {
+  const a = Date.parse(String(raw));
+  const b = Date.parse(String(value));
+  if (isNaN(a) || isNaN(b)) return false;
+  // Compare exact instants when the target value carries a time component;
+  // otherwise compare by calendar day.
+  const hasTime = /[T\s]\d{1,2}:/.test(String(value));
+  const x = hasTime ? a : Math.floor(a / 86400000);
+  const y = hasTime ? b : Math.floor(b / 86400000);
+  if (op === "date_is") return x === y;
+  if (op === "date_before") return x < y;
+  return x > y;
+}

--- a/frontend/src/components/widgets/conditionalFormat.ts
+++ b/frontend/src/components/widgets/conditionalFormat.ts
@@ -17,7 +17,8 @@ export interface ResolvedScale {
 }
 
 // Friendly color names → theme token key (the chart palette). Resolving through
-// tokens gives automatic light/dark values, and keeps table + chart colors identical.
+// tokens gives automatic light/dark values; as table fills these are softened
+// toward the surface (see `setFill`) so cells read gentler than solid chart marks.
 const NAMED_TOKEN: Record<string, string> = {
   red: "chart-7",
   green: "chart-6",
@@ -82,7 +83,12 @@ export function resolveScale(
   const names = gradientColorNames(format);
   if (!names || names.length < 2 || values.length === 0) return null;
 
-  const rgbs: RGB[] = names.map((n) => parseHex(resolveColor(n, tokens)) ?? [136, 136, 136]);
+  const surface = surfaceRGB(tokens);
+  const rgbs: RGB[] = names.map((n) => {
+    const base = parseHex(resolveColor(n, tokens)) ?? [136, 136, 136];
+    // Soften only the semantic palette colors; leave surface/white/hex stops as-is.
+    return n in NAMED_TOKEN ? soften(base, surface) : base;
+  });
   const sorted = [...values].sort((a, b) => a - b);
   const lo = sorted[0];
   const hi = sorted[sorted.length - 1];
@@ -182,7 +188,7 @@ export function cellStyle(
   const style: CSSProperties = {};
 
   // 1. whole-column base (flat fill + text styles)
-  if (typeof format.backgroundColor === "string") style.backgroundColor = resolveColor(format.backgroundColor, tokens);
+  if (typeof format.backgroundColor === "string") setFill(style, format.backgroundColor, tokens);
   if (format.textColor) style.color = resolveColor(format.textColor, tokens);
   applyTextStyles(style, format);
 
@@ -212,9 +218,41 @@ function applyTextStyles(style: CSSProperties, s: Format | FormatRule): void {
 }
 
 function applyRuleStyle(style: CSSProperties, rule: FormatRule, tokens: Record<string, string>): void {
-  if (rule.backgroundColor) style.backgroundColor = resolveColor(rule.backgroundColor, tokens);
+  if (rule.backgroundColor) setFill(style, rule.backgroundColor, tokens);
   if (rule.textColor) style.color = resolveColor(rule.textColor, tokens);
   applyTextStyles(style, rule);
+}
+
+/**
+ * Paint a background fill. Semantic palette colors (red/green/amber/…) are
+ * softened toward the theme surface and get contrast-aware text unless a text
+ * color is set later; explicit hex/white/raw fills are left exactly as given.
+ */
+function setFill(style: CSSProperties, name: string, tokens: Record<string, string>): void {
+  const resolved = resolveColor(name, tokens);
+  if (!resolved) return;
+  const rgb = name in NAMED_TOKEN ? parseHex(resolved) : null;
+  if (!rgb) {
+    style.backgroundColor = resolved;
+    return;
+  }
+  const s = soften(rgb, surfaceRGB(tokens));
+  style.backgroundColor = `rgb(${s[0]}, ${s[1]}, ${s[2]})`;
+  style.color = rgbLuminance(s) > 0.4 ? "#0A0D14" : "#FFFFFF";
+}
+
+/** Mix a color toward another by `ratio` (0 = unchanged, 1 = fully the target). */
+function soften(rgb: RGB, toward: RGB, ratio = 0.32): RGB {
+  return [
+    Math.round(rgb[0] + (toward[0] - rgb[0]) * ratio),
+    Math.round(rgb[1] + (toward[1] - rgb[1]) * ratio),
+    Math.round(rgb[2] + (toward[2] - rgb[2]) * ratio),
+  ];
+}
+
+/** The theme surface color as RGB, so softening is light/dark aware. Falls back to white. */
+function surfaceRGB(tokens: Record<string, string>): RGB {
+  return parseHex(resolveColor("background", tokens)) ?? [255, 255, 255];
 }
 
 // --- color helpers ---

--- a/frontend/src/themes/PalettesContext.ts
+++ b/frontend/src/themes/PalettesContext.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from "react";
+
+/** Dashboard-level custom palettes (name -> gradient colors), referenced by a
+ * column's format.scheme. Empty by default so widgets work without a provider. */
+export const PalettesContext = createContext<Record<string, string[]>>({});
+
+export function usePalettes(): Record<string, string[]> {
+  return useContext(PalettesContext);
+}

--- a/frontend/src/themes/PalettesContext.ts
+++ b/frontend/src/themes/PalettesContext.ts
@@ -1,9 +1,0 @@
-import { createContext, useContext } from "react";
-
-/** Dashboard-level custom palettes (name -> gradient colors), referenced by a
- * column's format.scheme. Empty by default so widgets work without a provider. */
-export const PalettesContext = createContext<Record<string, string[]>>({});
-
-export function usePalettes(): Record<string, string[]> {
-  return useContext(PalettesContext);
-}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -15,8 +15,6 @@ export interface Dashboard {
   models?: Record<string, string>;
   filters?: Filter[];
   queries?: Record<string, Query>;
-  /** Reusable named gradients, referenced by a column's format.scheme. */
-  palettes?: Record<string, string[]>;
   rows: Row[];
   file_type?: "yaml" | "tsx";
 }
@@ -158,7 +156,7 @@ export interface FormatRule {
  * A column's value display and conditional coloring.
  * `backgroundColor`: string = flat fill · array = gradient.
  * `domain`: gradient anchor values (omit → auto min/max).
- * `scheme`: a gradient by name (built-in or a dashboard `palettes` entry). `rules`: conditional styling (first match wins).
+ * `scheme`: a built-in gradient by name. `rules`: conditional styling (first match wins).
  */
 export interface Format {
   /** Mirror another column's format and per-row value, so cells get identical colors. */

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -15,6 +15,8 @@ export interface Dashboard {
   models?: Record<string, string>;
   filters?: Filter[];
   queries?: Record<string, Query>;
+  /** Reusable named gradients, referenced by a column's format.scheme. */
+  palettes?: Record<string, string[]>;
   rows: Row[];
   file_type?: "yaml" | "tsx";
 }
@@ -110,26 +112,11 @@ export interface Widget {
 export interface TableColumn {
   name: string;
   label?: string;
-  format?: string;
-  colorScale?: ColorScale;
-  singleColor?: SingleColorRule[];
+  /** Value display + conditional coloring. A bare string is shorthand for `{ number }`. */
+  format?: Format | string;
 }
 
-export type ColorStopType = "min" | "max" | "number" | "percent" | "percentile";
-
-export interface ColorStop {
-  type?: ColorStopType; // min | max | number | percent | percentile
-  value?: number; // for number | percent | percentile
-  color?: string;
-}
-
-export interface ColorScale {
-  min?: ColorStop | string;
-  mid?: ColorStop | string;
-  max?: ColorStop | string;
-}
-
-export type SingleColorOperator =
+export type FormatOperator =
   | "is_empty"
   | "is_not_empty"
   | "text_contains"
@@ -149,16 +136,53 @@ export type SingleColorOperator =
   | "is_between"
   | "is_not_between";
 
+/** Reference to another column in the same row, used as a rule comparison value. */
+export interface ColumnRef {
+  column: string;
+}
 
-export interface SingleColorRule {
-  if: SingleColorOperator;
-  value?: number | string | Array<number | string>; // scalar, or [low, high] for between
+export type RuleValue = number | string | ColumnRef | Array<number | string | ColumnRef>;
+
+export interface FormatRule {
+  if: FormatOperator;
+  value?: RuleValue;
   bold?: boolean;
   italic?: boolean;
   underline?: boolean;
   strikethrough?: boolean;
   textColor?: string;
-  background?: string;
+  backgroundColor?: string;
+}
+
+/**
+ * A column's value display and conditional coloring.
+ * `backgroundColor`: string = flat fill · array = gradient.
+ * `domain`: gradient anchor values (omit → auto min/max).
+ * `scheme`: a gradient by name (built-in or a dashboard `palettes` entry). `rules`: conditional styling (first match wins).
+ */
+export interface Format {
+  /** Mirror another column's format and per-row value, so cells get identical colors. */
+  like?: string;
+  number?: string;
+  backgroundColor?: string | string[];
+  textColor?: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  /**
+   * Gradient anchors. Either a bare array of raw values, or `{ unit, anchors }`
+   * where `unit` is `value` (default), `percent`, or `percentile`. Omitting
+   * `anchors` spreads the colors evenly across the unit (percentile → median midpoint).
+   */
+  domain?: number[] | Domain;
+  scheme?: string;
+  rules?: FormatRule[];
+}
+
+export interface Domain {
+  unit?: "value" | "percent" | "percentile";
+  anchors?: number[];
 }
 
 /** Structured encoding for a chart axis. `y.field` may list several series columns. */

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -110,8 +110,12 @@ export interface Widget {
 export interface TableColumn {
   name: string;
   label?: string;
-  /** Value display + conditional coloring. A bare string is shorthand for `{ number }`. */
-  format?: Format | string;
+  /** Value display: `currency`, `number`, or a d3-format spec. */
+  number?: string;
+  /** Mirror another column's coloring, driven by that column's per-row value. */
+  like?: string;
+  /** Ordered style layers; the first layer that matches a cell wins. */
+  format?: FormatLayer[];
 }
 
 export type FormatOperator =
@@ -141,46 +145,29 @@ export interface ColumnRef {
 
 export type RuleValue = number | string | ColumnRef | Array<number | string | ColumnRef>;
 
-export interface FormatRule {
-  if: FormatOperator;
-  value?: RuleValue;
-  bold?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-  strikethrough?: boolean;
-  textColor?: string;
-  backgroundColor?: string;
-}
-
 /**
- * A column's value display and conditional coloring.
- * `backgroundColor`: string = flat fill · array = gradient.
- * `domain`: gradient anchor values (omit → auto min/max).
- * `scheme`: a built-in gradient by name. `rules`: conditional styling (first match wins).
+ * One entry in a column's `format` list. The first layer that matches a cell wins.
+ *
+ * - A layer with `if` is a **condition** (applies to matching cells).
+ * - A layer without `if` always matches — a **gradient** (`backgroundColor` array,
+ *   optional `range`/`unit`) or a **flat fill** (`backgroundColor` string). Place
+ *   it last as the fallback base.
+ *
+ * `backgroundColor`: string = flat/single fill · array = gradient.
+ * `range` + `unit` (`absolute` | `percent` | `percentile`) pin a gradient's
+ * anchors; omit `range` for an auto min/max gradient.
  */
-export interface Format {
-  /** Mirror another column's format and per-row value, so cells get identical colors. */
-  like?: string;
-  number?: string;
+export interface FormatLayer {
+  if?: FormatOperator;
+  value?: RuleValue;
   backgroundColor?: string | string[];
+  range?: number[];
+  unit?: "absolute" | "percent" | "percentile";
   textColor?: string;
   bold?: boolean;
   italic?: boolean;
   underline?: boolean;
   strikethrough?: boolean;
-  /**
-   * Gradient anchors. Either a bare array of raw values, or `{ unit, anchors }`
-   * where `unit` is `value` (default), `percent`, or `percentile`. Omitting
-   * `anchors` spreads the colors evenly across the unit (percentile → median midpoint).
-   */
-  domain?: number[] | Domain;
-  scheme?: string;
-  rules?: FormatRule[];
-}
-
-export interface Domain {
-  unit?: "value" | "percent" | "percentile";
-  anchors?: number[];
 }
 
 /** Structured encoding for a chart axis. `y.field` may list several series columns. */

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -111,6 +111,54 @@ export interface TableColumn {
   name: string;
   label?: string;
   format?: string;
+  colorScale?: ColorScale;
+  singleColor?: SingleColorRule[];
+}
+
+export type ColorStopType = "min" | "max" | "number" | "percent" | "percentile";
+
+export interface ColorStop {
+  type?: ColorStopType; // min | max | number | percent | percentile
+  value?: number; // for number | percent | percentile
+  color?: string;
+}
+
+export interface ColorScale {
+  min?: ColorStop | string;
+  mid?: ColorStop | string;
+  max?: ColorStop | string;
+}
+
+export type SingleColorOperator =
+  | "is_empty"
+  | "is_not_empty"
+  | "text_contains"
+  | "text_does_not_contain"
+  | "text_starts_with"
+  | "text_ends_with"
+  | "text_is_exactly"
+  | "date_is"
+  | "date_before"
+  | "date_after"
+  | "greater_than"
+  | "greater_than_or_equal"
+  | "less_than"
+  | "less_than_or_equal"
+  | "is_equal_to"
+  | "is_not_equal_to"
+  | "is_between"
+  | "is_not_between";
+
+
+export interface SingleColorRule {
+  if: SingleColorOperator;
+  value?: number | string | Array<number | string>; // scalar, or [low, high] for between
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  textColor?: string;
+  background?: string;
 }
 
 /** Structured encoding for a chart axis. `y.field` may list several series columns. */

--- a/pkg/dashboard/color_scale_test.go
+++ b/pkg/dashboard/color_scale_test.go
@@ -8,106 +8,92 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestFormat_YAML_StringShorthand(t *testing.T) {
+func TestFormat_YAML_Layers(t *testing.T) {
 	yamlBody := `
 columns:
   - name: revenue
-    format: currency
-`
-	var w Widget
-	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	f := w.Columns[0].Format
-	if f == nil || f.Number != "currency" {
-		t.Fatalf("expected string shorthand → Number=currency, got %+v", f)
-	}
-}
-
-func TestFormat_YAML_Object(t *testing.T) {
-	yamlBody := `
-columns:
-  - name: revenue
+    number: "$,.2f"
     format:
-      number: "$,.2f"
-      domain: [-25, 0, 25]
-      backgroundColor: [red, white, green]
+      - backgroundColor: [red, white, green]
+        range: [-25, 0, 25]
+        unit: absolute
   - name: region
-    format: { backgroundColor: "#F8FAFC", bold: true }
+    format:
+      - { backgroundColor: "#F8FAFC", bold: true }
 `
 	var w Widget
 	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	f := w.Columns[0].Format
-	if f == nil || f.Number != "$,.2f" {
-		t.Fatalf("unexpected format: %+v", f)
+	if w.Columns[0].Number != "$,.2f" {
+		t.Fatalf("expected column-level number, got %q", w.Columns[0].Number)
 	}
-	if f.Domain == nil || len(f.Domain.Anchors) != 3 || f.Domain.Anchors[0] != -25 || f.Domain.Anchors[2] != 25 {
-		t.Errorf("unexpected domain: %+v", f.Domain)
+	layers := w.Columns[0].Format
+	if len(layers) != 1 {
+		t.Fatalf("expected 1 layer, got %d", len(layers))
 	}
-	colors, ok := f.BackgroundColor.([]interface{})
+	colors, ok := layers[0].BackgroundColor.([]interface{})
 	if !ok || len(colors) != 3 {
-		t.Errorf("expected gradient array, got %#v", f.BackgroundColor)
+		t.Errorf("expected gradient array, got %#v", layers[0].BackgroundColor)
+	}
+	if layers[0].Unit != "absolute" || len(layers[0].Range) != 3 || layers[0].Range[0] != -25 || layers[0].Range[2] != 25 {
+		t.Errorf("unexpected range/unit: %+v", layers[0])
 	}
 	flat := w.Columns[1].Format
-	if flat == nil || flat.BackgroundColor != "#F8FAFC" || !flat.Bold {
-		t.Errorf("unexpected flat format: %+v", flat)
+	if len(flat) != 1 || flat[0].BackgroundColor != "#F8FAFC" || !flat[0].Bold {
+		t.Errorf("unexpected flat layer: %+v", flat)
 	}
 }
 
-func TestFormat_YAML_Rules(t *testing.T) {
+func TestFormat_YAML_Conditions(t *testing.T) {
 	yamlBody := `
 columns:
   - name: status
     format:
-      rules:
-        - { if: text_is_exactly, value: overdue, backgroundColor: red, bold: true }
-        - { if: is_between, value: [10, 20], backgroundColor: amber }
-        - { if: less_than, value: { column: target }, backgroundColor: red }
+      - { if: text_is_exactly, value: overdue, backgroundColor: red, bold: true }
+      - { if: is_between, value: [10, 20], backgroundColor: amber }
+      - { if: less_than, value: { column: target }, backgroundColor: red }
+      - { backgroundColor: [red, white, green] }
 `
 	var w Widget
 	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	rules := w.Columns[0].Format.Rules
-	if len(rules) != 3 {
-		t.Fatalf("expected 3 rules, got %d", len(rules))
+	layers := w.Columns[0].Format
+	if len(layers) != 4 {
+		t.Fatalf("expected 4 layers, got %d", len(layers))
 	}
-	if rules[0].If != CondTextIsExactly || rules[0].Value != "overdue" || rules[0].BackgroundColor != "red" || !rules[0].Bold {
-		t.Errorf("unexpected rule 0: %+v", rules[0])
+	if layers[0].If != CondTextIsExactly || layers[0].Value != "overdue" || layers[0].BackgroundColor != "red" || !layers[0].Bold {
+		t.Errorf("unexpected layer 0: %+v", layers[0])
 	}
-	if pair, ok := rules[1].Value.([]interface{}); !ok || len(pair) != 2 {
-		t.Errorf("expected two-element between value, got %+v", rules[1].Value)
+	if pair, ok := layers[1].Value.([]interface{}); !ok || len(pair) != 2 {
+		t.Errorf("expected two-element between value, got %+v", layers[1].Value)
 	}
-	ref, ok := rules[2].Value.(map[string]interface{})
+	ref, ok := layers[2].Value.(map[string]interface{})
 	if !ok || ref["column"] != "target" {
-		t.Errorf("expected cross-column ref, got %+v", rules[2].Value)
+		t.Errorf("expected cross-column ref, got %+v", layers[2].Value)
+	}
+	// the last (if-less) layer is the gradient base
+	if layers[3].If != "" {
+		t.Errorf("expected base layer without if, got %+v", layers[3])
 	}
 }
 
 func TestFormat_JSON_RoundTrip(t *testing.T) {
-	body := []byte(`{"columns":[{"name":"r","format":{"number":"currency","backgroundColor":["red","green"]}}]}`)
+	body := []byte(`{"columns":[{"name":"r","number":"currency","format":[{"backgroundColor":["red","green"]}]}]}`)
 	var w Widget
 	if err := json.Unmarshal(body, &w); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	f := w.Columns[0].Format
-	if f == nil || f.Number != "currency" {
-		t.Fatalf("unexpected format: %+v", f)
+	if w.Columns[0].Number != "currency" {
+		t.Fatalf("unexpected number: %q", w.Columns[0].Number)
 	}
-	if colors, ok := f.BackgroundColor.([]interface{}); !ok || len(colors) != 2 {
-		t.Errorf("expected 2-color gradient, got %#v", f.BackgroundColor)
+	layers := w.Columns[0].Format
+	if len(layers) != 1 {
+		t.Fatalf("expected 1 layer, got %d", len(layers))
 	}
-}
-
-func TestFormat_JSON_StringShorthand(t *testing.T) {
-	var w Widget
-	if err := json.Unmarshal([]byte(`{"columns":[{"name":"r","format":"number"}]}`), &w); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if w.Columns[0].Format.Number != "number" {
-		t.Errorf("expected Number=number, got %+v", w.Columns[0].Format)
+	if colors, ok := layers[0].BackgroundColor.([]interface{}); !ok || len(colors) != 2 {
+		t.Errorf("expected 2-color gradient, got %#v", layers[0].BackgroundColor)
 	}
 }
 
@@ -120,12 +106,10 @@ export default (
         sql="SELECT region, revenue, status FROM sales"
         columns={[
           { name: "region", label: "Region" },
-          { name: "revenue", format: { number: "currency", backgroundColor: ["red", "white", "green"] } },
-          { name: "status", format: {
-              rules: [
-                { if: "text_contains", value: "fail", backgroundColor: "red", bold: true },
-              ],
-            } },
+          { name: "revenue", number: "currency", format: [{ backgroundColor: ["red", "white", "green"] }] },
+          { name: "status", format: [
+              { if: "text_contains", value: "fail", backgroundColor: "red", bold: true },
+            ] },
         ]} />
       <Chart name="Sales" chart="bar" col={12}
         sql="SELECT m, a, b FROM t" x="m" y={["a", "b"]} />
@@ -140,16 +124,15 @@ export default (
 	if len(cols) != 3 {
 		t.Fatalf("expected 3 columns, got %d", len(cols))
 	}
-	f := cols[1].Format
-	if f == nil || f.Number != "currency" {
-		t.Fatalf("unexpected revenue format: %+v", f)
+	if cols[1].Number != "currency" {
+		t.Fatalf("unexpected revenue number: %q", cols[1].Number)
 	}
-	if colors, ok := f.BackgroundColor.([]interface{}); !ok || len(colors) != 3 {
-		t.Errorf("expected 3-color gradient, got %#v", f.BackgroundColor)
+	if colors, ok := cols[1].Format[0].BackgroundColor.([]interface{}); !ok || len(colors) != 3 {
+		t.Errorf("expected 3-color gradient, got %#v", cols[1].Format[0].BackgroundColor)
 	}
 	sc := cols[2].Format
-	if sc == nil || len(sc.Rules) != 1 || sc.Rules[0].If != CondTextContains || !sc.Rules[0].Bold {
-		t.Errorf("unexpected status rules: %+v", sc)
+	if len(sc) != 1 || sc[0].If != CondTextContains || !sc[0].Bold {
+		t.Errorf("unexpected status layers: %+v", sc)
 	}
 }
 
@@ -163,13 +146,13 @@ func runValidate(d *Dashboard) []string {
 	return err.(*ValidationError).Errors
 }
 
-func validateColumnFormat(t *testing.T, f *Format) []string {
+func validateColumnFormat(t *testing.T, layers []FormatLayer) []string {
 	t.Helper()
 	return runValidate(&Dashboard{
 		Name: "d",
 		Rows: []Row{{Widgets: []Widget{{
 			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
-			Columns: []TableColumn{{Name: "c", Format: f}},
+			Columns: []TableColumn{{Name: "c", Format: layers}},
 		}}}},
 	})
 }
@@ -183,132 +166,82 @@ func hasErrContaining(errs []string, substr string) bool {
 	return false
 }
 
-func TestValidate_UnknownScheme(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{Scheme: "rainbow"})
-	if !hasErrContaining(errs, "unknown scheme") {
-		t.Errorf("expected unknown-scheme error, got %v", errs)
+func TestValidate_RangeNeedsGradient(t *testing.T) {
+	errs := validateColumnFormat(t, []FormatLayer{{BackgroundColor: "#fff", Range: []float64{0, 100}}})
+	if !hasErrContaining(errs, "range: requires a gradient") {
+		t.Errorf("expected range-needs-gradient error, got %v", errs)
 	}
 }
 
-func TestValidate_DomainNeedsGradient(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{Domain: &Domain{Anchors: []float64{0, 100}}, BackgroundColor: "#fff"})
-	if !hasErrContaining(errs, "domain: requires a gradient") {
-		t.Errorf("expected domain-needs-gradient error, got %v", errs)
-	}
-}
-
-func TestValidate_DomainWithSchemeAccepted(t *testing.T) {
-	// A built-in scheme is a gradient, so a matching domain is valid.
-	errs := validateColumnFormat(t, &Format{Scheme: "red-white-green", Domain: &Domain{Anchors: []float64{-25, 0, 25}}})
-	if len(errs) != 0 {
-		t.Errorf("expected domain+scheme to pass, got %v", errs)
-	}
-}
-
-func TestValidate_DomainSchemeLengthMismatch(t *testing.T) {
-	// white-green has 2 colors, so a 3-value domain must not match.
-	errs := validateColumnFormat(t, &Format{Scheme: "white-green", Domain: &Domain{Anchors: []float64{0, 50, 100}}})
-	if !hasErrContaining(errs, "must match") {
-		t.Errorf("expected length-mismatch error, got %v", errs)
-	}
-}
-
-func TestValidate_DomainLengthMismatch(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{
-		Domain:          &Domain{Anchors: []float64{0, 50, 100}},
+func TestValidate_RangeLengthMismatch(t *testing.T) {
+	errs := validateColumnFormat(t, []FormatLayer{{
 		BackgroundColor: []interface{}{"red", "green"},
-	})
+		Range:           []float64{0, 50, 100},
+		Unit:            "absolute",
+	}})
 	if !hasErrContaining(errs, "must match") {
-		t.Errorf("expected domain-length error, got %v", errs)
+		t.Errorf("expected range-length error, got %v", errs)
 	}
 }
 
-func TestValidate_RuleUnknownOperator(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{Rules: []FormatRule{{If: "bogus", BackgroundColor: "red"}}})
+func TestValidate_ConditionUnknownOperator(t *testing.T) {
+	errs := validateColumnFormat(t, []FormatLayer{{If: "bogus", BackgroundColor: "red"}})
 	if !hasErrContaining(errs, "unknown operator \"bogus\"") {
 		t.Errorf("expected unknown-operator error, got %v", errs)
 	}
 }
 
-func TestValidate_RuleBetweenNeedsPair(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{Rules: []FormatRule{{If: CondIsBetween, Value: 5, BackgroundColor: "red"}}})
+func TestValidate_ConditionBetweenNeedsPair(t *testing.T) {
+	errs := validateColumnFormat(t, []FormatLayer{{If: CondIsBetween, Value: 5, BackgroundColor: "red"}})
 	if !hasErrContaining(errs, "requires a two-element value list") {
 		t.Errorf("expected between-pair error, got %v", errs)
 	}
 }
 
-func TestValidate_RuleRequiresStyle(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{Rules: []FormatRule{{If: CondGreaterThan, Value: 5}}})
+func TestValidate_LayerRequiresStyle(t *testing.T) {
+	errs := validateColumnFormat(t, []FormatLayer{{If: CondGreaterThan, Value: 5}})
 	if !hasErrContaining(errs, "at least one style") {
 		t.Errorf("expected style-required error, got %v", errs)
 	}
 }
 
 func TestValidate_GradientNeedsTwoColors(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{BackgroundColor: []interface{}{"red"}})
+	errs := validateColumnFormat(t, []FormatLayer{{BackgroundColor: []interface{}{"red"}}})
 	if !hasErrContaining(errs, "a gradient needs at least 2 colors") {
 		t.Errorf("expected min-2-colors error, got %v", errs)
 	}
 }
 
-func TestValidate_DomainUnknownUnit(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{
-		Domain:          &Domain{Unit: "bogus"},
+func TestValidate_UnknownUnit(t *testing.T) {
+	errs := validateColumnFormat(t, []FormatLayer{{
 		BackgroundColor: []interface{}{"red", "green"},
-	})
-	if !hasErrContaining(errs, "domain.unit: unknown unit \"bogus\"") {
-		t.Errorf("expected domain.unit error, got %v", errs)
+		Range:           []float64{0, 100},
+		Unit:            "bogus",
+	}})
+	if !hasErrContaining(errs, "unit: unknown unit \"bogus\"") {
+		t.Errorf("expected unit error, got %v", errs)
 	}
 }
 
-func TestValidate_PercentileDomainRange(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{
-		Domain:          &Domain{Unit: "percentile", Anchors: []float64{0, 50, 150}},
+func TestValidate_PercentileRange(t *testing.T) {
+	errs := validateColumnFormat(t, []FormatLayer{{
 		BackgroundColor: []interface{}{"red", "white", "green"},
-	})
+		Range:           []float64{0, 50, 150},
+		Unit:            "percentile",
+	}})
 	if !hasErrContaining(errs, "percentile anchors must be between 0 and 100") {
 		t.Errorf("expected percentile-range error, got %v", errs)
 	}
 }
 
-func TestValidate_DomainPercentileValid(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{
-		Domain:          &Domain{Unit: "percentile", Anchors: []float64{0, 50, 100}},
+func TestValidate_PercentileValid(t *testing.T) {
+	errs := validateColumnFormat(t, []FormatLayer{{
 		BackgroundColor: []interface{}{"red", "white", "green"},
-	})
+		Range:           []float64{0, 50, 100},
+		Unit:            "percentile",
+	}})
 	if len(errs) != 0 {
 		t.Errorf("expected no errors, got %v", errs)
-	}
-}
-
-func TestFormat_YAML_DomainObject(t *testing.T) {
-	yamlBody := `
-columns:
-  - name: a
-    format:
-      domain: [-25, 0, 25]
-      backgroundColor: [red, white, green]
-  - name: b
-    format:
-      domain: { unit: percentile, anchors: [0, 50, 100] }
-      backgroundColor: [red, white, green]
-  - name: c
-    format:
-      domain: { unit: percentile }
-      backgroundColor: [red, white, green]
-`
-	var w Widget
-	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if d := w.Columns[0].Format.Domain; d == nil || d.Unit != "" || len(d.Anchors) != 3 {
-		t.Errorf("array form: expected raw values, got %+v", d)
-	}
-	if d := w.Columns[1].Format.Domain; d == nil || d.Unit != "percentile" || len(d.Anchors) != 3 {
-		t.Errorf("object form: expected percentile + 3 values, got %+v", d)
-	}
-	if d := w.Columns[2].Format.Domain; d == nil || d.Unit != "percentile" || len(d.Anchors) != 0 {
-		t.Errorf("unit-only form: expected percentile, no values, got %+v", d)
 	}
 }
 
@@ -316,16 +249,19 @@ func TestFormat_YAML_Like(t *testing.T) {
 	yamlBody := `
 columns:
   - name: revenue
-    format: { number: currency, backgroundColor: [red, white, green] }
+    number: currency
+    format:
+      - { backgroundColor: [red, white, green] }
   - name: profit
-    format: { like: revenue }
+    number: currency
+    like: revenue
 `
 	var w Widget
 	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if w.Columns[1].Format == nil || w.Columns[1].Format.Like != "revenue" {
-		t.Fatalf("expected like=revenue, got %+v", w.Columns[1].Format)
+	if w.Columns[1].Like != "revenue" {
+		t.Fatalf("expected like=revenue, got %q", w.Columns[1].Like)
 	}
 }
 
@@ -334,7 +270,7 @@ func TestValidate_LikeUnknownColumn(t *testing.T) {
 		Name: "d",
 		Rows: []Row{{Widgets: []Widget{{
 			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
-			Columns: []TableColumn{{Name: "profit", Format: &Format{Like: "revenue"}}},
+			Columns: []TableColumn{{Name: "profit", Like: "revenue"}},
 		}}}},
 	}
 	errs := runValidate(d)
@@ -348,7 +284,7 @@ func TestValidate_LikeSelfReference(t *testing.T) {
 		Name: "d",
 		Rows: []Row{{Widgets: []Widget{{
 			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
-			Columns: []TableColumn{{Name: "a", Format: &Format{Like: "a"}}},
+			Columns: []TableColumn{{Name: "a", Like: "a"}},
 		}}}},
 	}
 	errs := runValidate(d)
@@ -358,15 +294,11 @@ func TestValidate_LikeSelfReference(t *testing.T) {
 }
 
 func TestValidate_FormatValidPasses(t *testing.T) {
-	errs := validateColumnFormat(t, &Format{
-		Number:          "currency",
-		Domain:          &Domain{Anchors: []float64{-25, 0, 25}},
-		BackgroundColor: []interface{}{"red", "white", "green"},
-		Rules: []FormatRule{
-			{If: CondGreaterThan, Value: 100, BackgroundColor: "green", Bold: true},
-			{If: CondIsBetween, Value: []interface{}{10, 20}, TextColor: "amber"},
-			{If: CondIsEmpty, Italic: true},
-		},
+	errs := validateColumnFormat(t, []FormatLayer{
+		{If: CondGreaterThan, Value: 100, BackgroundColor: "green", Bold: true},
+		{If: CondIsBetween, Value: []interface{}{10, 20}, TextColor: "amber"},
+		{If: CondIsEmpty, Italic: true},
+		{BackgroundColor: []interface{}{"red", "white", "green"}, Range: []float64{-25, 0, 25}, Unit: "absolute"},
 	})
 	if len(errs) != 0 {
 		t.Errorf("expected no errors, got %v", errs)

--- a/pkg/dashboard/color_scale_test.go
+++ b/pkg/dashboard/color_scale_test.go
@@ -213,15 +213,6 @@ func TestValidate_DomainSchemeLengthMismatch(t *testing.T) {
 	}
 }
 
-func TestValidate_DomainWithPaletteAccepted(t *testing.T) {
-	// A custom palette is a gradient too; a matching domain is valid.
-	d := paletteDashboard(map[string][]string{"risk": {"red", "amber", "green"}}, "risk")
-	d.Rows[0].Widgets[0].Columns[0].Format.Domain = &Domain{Anchors: []float64{-25, 0, 25}}
-	if errs := runValidate(d); len(errs) != 0 {
-		t.Errorf("expected domain+palette to pass, got %v", errs)
-	}
-}
-
 func TestValidate_DomainLengthMismatch(t *testing.T) {
 	errs := validateColumnFormat(t, &Format{
 		Domain:          &Domain{Anchors: []float64{0, 50, 100}},
@@ -379,95 +370,5 @@ func TestValidate_FormatValidPasses(t *testing.T) {
 	})
 	if len(errs) != 0 {
 		t.Errorf("expected no errors, got %v", errs)
-	}
-}
-
-// --- custom palettes ---
-
-// paletteDashboard builds a dashboard with the given palettes and one table
-// column whose format references a scheme by name.
-func paletteDashboard(palettes map[string][]string, scheme string) *Dashboard {
-	return &Dashboard{
-		Name:     "d",
-		Palettes: palettes,
-		Rows: []Row{{Widgets: []Widget{{
-			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
-			Columns: []TableColumn{{Name: "c", Format: &Format{Scheme: scheme}}},
-		}}}},
-	}
-}
-
-func TestFormat_YAML_Palettes(t *testing.T) {
-	yamlBody := `
-name: Palettes
-palettes:
-  risk: [red, amber, green]
-  heat: ["#FEF0D9", "#E34A33"]
-rows:
-  - widgets:
-      - name: t
-        type: table
-        sql: SELECT 1
-        columns:
-          - name: c
-            format: { scheme: risk }
-`
-	var d Dashboard
-	if err := yaml.Unmarshal([]byte(yamlBody), &d); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if got := d.Palettes["risk"]; len(got) != 3 || got[0] != "red" || got[2] != "green" {
-		t.Errorf("unexpected risk palette: %v", d.Palettes["risk"])
-	}
-	if len(d.Palettes["heat"]) != 2 {
-		t.Errorf("unexpected heat palette: %v", d.Palettes["heat"])
-	}
-}
-
-func TestFormat_TSX_Palettes(t *testing.T) {
-	source := `
-export default (
-  <Dashboard name="Heat" palettes={{ risk: ["red", "amber", "green"] }}>
-    <Row>
-      <Table name="Sales" col={12} sql="SELECT region, revenue FROM sales"
-        columns={[
-          { name: "revenue", format: { scheme: "risk" } },
-        ]} />
-    </Row>
-  </Dashboard>
-)
-`
-	d, err := evalTSX(source, "test.tsx", &tsxConfig{})
-	assertNoErr(t, err)
-	if got := d.Palettes["risk"]; len(got) != 3 || got[1] != "amber" {
-		t.Errorf("unexpected risk palette from TSX: %v", d.Palettes["risk"])
-	}
-}
-
-func TestValidate_PaletteSchemeAccepted(t *testing.T) {
-	errs := runValidate(paletteDashboard(map[string][]string{"risk": {"red", "amber", "green"}}, "risk"))
-	if len(errs) != 0 {
-		t.Errorf("expected palette scheme to pass, got %v", errs)
-	}
-}
-
-func TestValidate_PaletteUnknownScheme(t *testing.T) {
-	errs := runValidate(paletteDashboard(map[string][]string{"risk": {"red", "amber", "green"}}, "nope"))
-	if !hasErrContaining(errs, "unknown scheme") {
-		t.Errorf("expected unknown-scheme error, got %v", errs)
-	}
-}
-
-func TestValidate_PaletteTooFewColors(t *testing.T) {
-	errs := runValidate(paletteDashboard(map[string][]string{"solo": {"red"}}, "solo"))
-	if !hasErrContaining(errs, "at least 2 colors") {
-		t.Errorf("expected too-few-colors error, got %v", errs)
-	}
-}
-
-func TestValidate_PaletteCollidesWithBuiltin(t *testing.T) {
-	errs := runValidate(paletteDashboard(map[string][]string{"white-green": {"red", "green"}}, "white-green"))
-	if !hasErrContaining(errs, "collides with a built-in") {
-		t.Errorf("expected collision error, got %v", errs)
 	}
 }

--- a/pkg/dashboard/color_scale_test.go
+++ b/pkg/dashboard/color_scale_test.go
@@ -8,127 +8,127 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestColorScale_YAML_NestedStops(t *testing.T) {
+func TestFormat_YAML_StringShorthand(t *testing.T) {
 	yamlBody := `
 columns:
   - name: revenue
     format: currency
-    colorScale:
-      min: { type: min, color: "#F8696B" }
-      mid: { type: percentile, value: 50, color: "#FFEB84" }
-      max: { type: number, value: 1000, color: "#63BE7B" }
 `
 	var w Widget
 	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	cs := w.Columns[0].ColorScale
-	if cs == nil || cs.Min == nil || cs.Mid == nil || cs.Max == nil {
-		t.Fatalf("expected all three stops, got %+v", cs)
-	}
-	if cs.Min.Type != StopTypeMin || cs.Min.Color != "#F8696B" || cs.Min.Value != nil {
-		t.Errorf("unexpected min stop: %+v", cs.Min)
-	}
-	if cs.Mid.Type != StopTypePercentile || cs.Mid.Value == nil || *cs.Mid.Value != 50 {
-		t.Errorf("unexpected mid stop: %+v", cs.Mid)
-	}
-	if cs.Max.Type != StopTypeNumber || cs.Max.Value == nil || *cs.Max.Value != 1000 {
-		t.Errorf("unexpected max stop: %+v", cs.Max)
+	f := w.Columns[0].Format
+	if f == nil || f.Number != "currency" {
+		t.Fatalf("expected string shorthand → Number=currency, got %+v", f)
 	}
 }
 
-func TestColorScale_YAML_BareStringShorthand(t *testing.T) {
+func TestFormat_YAML_Object(t *testing.T) {
 	yamlBody := `
 columns:
   - name: revenue
-    colorScale:
-      min: "#000000"
-      max: "#FFFFFF"
+    format:
+      number: "$,.2f"
+      domain: [-25, 0, 25]
+      backgroundColor: [red, white, green]
+  - name: region
+    format: { backgroundColor: "#F8FAFC", bold: true }
 `
 	var w Widget
 	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	cs := w.Columns[0].ColorScale
-	if cs.Min == nil || cs.Min.Color != "#000000" || cs.Min.Type != "" {
-		t.Errorf("expected bare-string min color, got %+v", cs.Min)
+	f := w.Columns[0].Format
+	if f == nil || f.Number != "$,.2f" {
+		t.Fatalf("unexpected format: %+v", f)
 	}
-	if cs.Mid != nil {
-		t.Errorf("expected no mid stop, got %+v", cs.Mid)
+	if f.Domain == nil || len(f.Domain.Anchors) != 3 || f.Domain.Anchors[0] != -25 || f.Domain.Anchors[2] != 25 {
+		t.Errorf("unexpected domain: %+v", f.Domain)
 	}
-	if cs.Max == nil || cs.Max.Color != "#FFFFFF" {
-		t.Errorf("expected bare-string max color, got %+v", cs.Max)
+	colors, ok := f.BackgroundColor.([]interface{})
+	if !ok || len(colors) != 3 {
+		t.Errorf("expected gradient array, got %#v", f.BackgroundColor)
+	}
+	flat := w.Columns[1].Format
+	if flat == nil || flat.BackgroundColor != "#F8FAFC" || !flat.Bold {
+		t.Errorf("unexpected flat format: %+v", flat)
 	}
 }
 
-func TestColorScale_JSON_BareStringAndObject(t *testing.T) {
-	body := []byte(`{"columns":[{"name":"r","colorScale":{"min":"#000000","max":{"type":"percentile","value":90,"color":"#FFFFFF"}}}]}`)
+func TestFormat_YAML_Rules(t *testing.T) {
+	yamlBody := `
+columns:
+  - name: status
+    format:
+      rules:
+        - { if: text_is_exactly, value: overdue, backgroundColor: red, bold: true }
+        - { if: is_between, value: [10, 20], backgroundColor: amber }
+        - { if: less_than, value: { column: target }, backgroundColor: red }
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rules := w.Columns[0].Format.Rules
+	if len(rules) != 3 {
+		t.Fatalf("expected 3 rules, got %d", len(rules))
+	}
+	if rules[0].If != CondTextIsExactly || rules[0].Value != "overdue" || rules[0].BackgroundColor != "red" || !rules[0].Bold {
+		t.Errorf("unexpected rule 0: %+v", rules[0])
+	}
+	if pair, ok := rules[1].Value.([]interface{}); !ok || len(pair) != 2 {
+		t.Errorf("expected two-element between value, got %+v", rules[1].Value)
+	}
+	ref, ok := rules[2].Value.(map[string]interface{})
+	if !ok || ref["column"] != "target" {
+		t.Errorf("expected cross-column ref, got %+v", rules[2].Value)
+	}
+}
+
+func TestFormat_JSON_RoundTrip(t *testing.T) {
+	body := []byte(`{"columns":[{"name":"r","format":{"number":"currency","backgroundColor":["red","green"]}}]}`)
 	var w Widget
 	if err := json.Unmarshal(body, &w); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	cs := w.Columns[0].ColorScale
-	if cs.Min == nil || cs.Min.Color != "#000000" {
-		t.Errorf("expected bare-string min, got %+v", cs.Min)
+	f := w.Columns[0].Format
+	if f == nil || f.Number != "currency" {
+		t.Fatalf("unexpected format: %+v", f)
 	}
-	if cs.Max == nil || cs.Max.Type != StopTypePercentile || cs.Max.Value == nil || *cs.Max.Value != 90 {
-		t.Errorf("expected percentile max, got %+v", cs.Max)
+	if colors, ok := f.BackgroundColor.([]interface{}); !ok || len(colors) != 2 {
+		t.Errorf("expected 2-color gradient, got %#v", f.BackgroundColor)
 	}
 }
 
-func TestSingleColor_YAML(t *testing.T) {
-	yamlBody := `
-columns:
-  - name: status
-    singleColor:
-      - if: text_is_exactly
-        value: overdue
-        background: "#FEE2E2"
-        textColor: "#991B1B"
-        bold: true
-      - if: is_between
-        value: [10, 20]
-        background: "#D1FAE5"
-`
+func TestFormat_JSON_StringShorthand(t *testing.T) {
 	var w Widget
-	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+	if err := json.Unmarshal([]byte(`{"columns":[{"name":"r","format":"number"}]}`), &w); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	rules := w.Columns[0].SingleColor
-	if len(rules) != 2 {
-		t.Fatalf("expected 2 rules, got %d", len(rules))
-	}
-	if rules[0].If != CondTextIsExactly || rules[0].Value != "overdue" || !rules[0].Bold {
-		t.Errorf("unexpected rule 0: %+v", rules[0])
-	}
-	if rules[0].Background != "#FEE2E2" || rules[0].TextColor != "#991B1B" {
-		t.Errorf("unexpected rule 0 styles: %+v", rules[0])
-	}
-	pair, ok := rules[1].Value.([]interface{})
-	if !ok || len(pair) != 2 {
-		t.Errorf("expected two-element value for between, got %+v", rules[1].Value)
+	if w.Columns[0].Format.Number != "number" {
+		t.Errorf("expected Number=number, got %+v", w.Columns[0].Format)
 	}
 }
 
-func TestColorScale_TSX(t *testing.T) {
+func TestFormat_TSX(t *testing.T) {
 	source := `
 export default (
   <Dashboard name="Heat" connection="db">
     <Row>
       <Table name="Sales" col={12}
-        sql="SELECT region, revenue FROM sales"
+        sql="SELECT region, revenue, status FROM sales"
         columns={[
           { name: "region", label: "Region" },
-          { name: "revenue", format: "currency",
-            colorScale: {
-              min: { type: "min", color: "#F8696B" },
-              max: { type: "percent", value: 90, color: "#63BE7B" },
+          { name: "revenue", format: { number: "currency", backgroundColor: ["red", "white", "green"] } },
+          { name: "status", format: {
+              rules: [
+                { if: "text_contains", value: "fail", backgroundColor: "red", bold: true },
+              ],
             } },
-          { name: "status",
-            singleColor: [
-              { if: "text_contains", value: "fail", background: "#FEE2E2", bold: true },
-            ] },
         ]} />
+      <Chart name="Sales" chart="bar" col={12}
+        sql="SELECT m, a, b FROM t" x="m" y={["a", "b"]} />
     </Row>
   </Dashboard>
 )
@@ -140,33 +140,22 @@ export default (
 	if len(cols) != 3 {
 		t.Fatalf("expected 3 columns, got %d", len(cols))
 	}
-	cs := cols[1].ColorScale
-	if cs == nil || cs.Min == nil || cs.Min.Type != StopTypeMin || cs.Min.Color != "#F8696B" {
-		t.Fatalf("unexpected colorScale min: %+v", cs)
+	f := cols[1].Format
+	if f == nil || f.Number != "currency" {
+		t.Fatalf("unexpected revenue format: %+v", f)
 	}
-	if cs.Max == nil || cs.Max.Type != StopTypePercent || cs.Max.Value == nil || *cs.Max.Value != 90 {
-		t.Errorf("unexpected colorScale max: %+v", cs.Max)
+	if colors, ok := f.BackgroundColor.([]interface{}); !ok || len(colors) != 3 {
+		t.Errorf("expected 3-color gradient, got %#v", f.BackgroundColor)
 	}
-	if cs.Mid != nil {
-		t.Errorf("expected no mid stop, got %+v", cs.Mid)
-	}
-	sc := cols[2].SingleColor
-	if len(sc) != 1 || sc[0].If != CondTextContains || sc[0].Value != "fail" || !sc[0].Bold {
-		t.Errorf("unexpected singleColor: %+v", sc)
+	sc := cols[2].Format
+	if sc == nil || len(sc.Rules) != 1 || sc.Rules[0].If != CondTextContains || !sc.Rules[0].Bold {
+		t.Errorf("unexpected status rules: %+v", sc)
 	}
 }
 
 // --- validation ---
 
-func validateColumnColorScale(t *testing.T, cs *ColorScale, singleColor []SingleColorRule) []string {
-	t.Helper()
-	d := &Dashboard{
-		Name: "d",
-		Rows: []Row{{Widgets: []Widget{{
-			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
-			Columns: []TableColumn{{Name: "c", ColorScale: cs, SingleColor: singleColor}},
-		}}}},
-	}
+func runValidate(d *Dashboard) []string {
 	err := Validate(d)
 	if err == nil {
 		return nil
@@ -174,7 +163,16 @@ func validateColumnColorScale(t *testing.T, cs *ColorScale, singleColor []Single
 	return err.(*ValidationError).Errors
 }
 
-func fptr(f float64) *float64 { return &f }
+func validateColumnFormat(t *testing.T, f *Format) []string {
+	t.Helper()
+	return runValidate(&Dashboard{
+		Name: "d",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
+			Columns: []TableColumn{{Name: "c", Format: f}},
+		}}}},
+	})
+}
 
 func hasErrContaining(errs []string, substr string) bool {
 	for _, e := range errs {
@@ -185,87 +183,291 @@ func hasErrContaining(errs []string, substr string) bool {
 	return false
 }
 
-func TestValidate_MinStopCannotBeMaxType(t *testing.T) {
-	errs := validateColumnColorScale(t, &ColorScale{Min: &ColorStop{Type: StopTypeMax}}, nil)
-	if !hasErrContaining(errs, "colorScale.min: type \"max\" not allowed") {
-		t.Errorf("expected min-type error, got %v", errs)
+func TestValidate_UnknownScheme(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{Scheme: "rainbow"})
+	if !hasErrContaining(errs, "unknown scheme") {
+		t.Errorf("expected unknown-scheme error, got %v", errs)
 	}
 }
 
-func TestValidate_MaxStopCannotBeMinType(t *testing.T) {
-	errs := validateColumnColorScale(t, &ColorScale{Max: &ColorStop{Type: StopTypeMin}}, nil)
-	if !hasErrContaining(errs, "colorScale.max: type \"min\" not allowed") {
-		t.Errorf("expected max-type error, got %v", errs)
+func TestValidate_DomainNeedsGradient(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{Domain: &Domain{Anchors: []float64{0, 100}}, BackgroundColor: "#fff"})
+	if !hasErrContaining(errs, "domain: requires a gradient") {
+		t.Errorf("expected domain-needs-gradient error, got %v", errs)
 	}
 }
 
-func TestValidate_MidStopTypeRestricted(t *testing.T) {
-	errs := validateColumnColorScale(t, &ColorScale{Mid: &ColorStop{Type: StopTypeMin}}, nil)
-	if !hasErrContaining(errs, "colorScale.mid: type \"min\" not allowed") {
-		t.Errorf("expected mid-type error, got %v", errs)
-	}
-}
-
-func TestValidate_ValueNotAllowedForMinMaxType(t *testing.T) {
-	errs := validateColumnColorScale(t, &ColorScale{Min: &ColorStop{Type: StopTypeMin, Value: fptr(5)}}, nil)
-	if !hasErrContaining(errs, "value is not allowed for type \"min\"") {
-		t.Errorf("expected value-not-allowed error, got %v", errs)
-	}
-}
-
-func TestValidate_ValueRequiredForNumberType(t *testing.T) {
-	errs := validateColumnColorScale(t, &ColorScale{Max: &ColorStop{Type: StopTypeNumber}}, nil)
-	if !hasErrContaining(errs, "value is required for type \"number\"") {
-		t.Errorf("expected value-required error, got %v", errs)
-	}
-}
-
-func TestValidate_PercentileRange(t *testing.T) {
-	errs := validateColumnColorScale(t, &ColorScale{Mid: &ColorStop{Type: StopTypePercentile, Value: fptr(150)}}, nil)
-	if !hasErrContaining(errs, "percentile value must be between 0 and 100") {
-		t.Errorf("expected percentile-range error, got %v", errs)
-	}
-}
-
-func TestValidate_ColorScaleValidPasses(t *testing.T) {
-	errs := validateColumnColorScale(t, &ColorScale{
-		Min: &ColorStop{Type: StopTypeMin, Color: "#F8696B"},
-		Mid: &ColorStop{Type: StopTypePercentile, Value: fptr(50), Color: "#FFEB84"},
-		Max: &ColorStop{Type: StopTypeNumber, Value: fptr(100), Color: "#63BE7B"},
-	}, nil)
+func TestValidate_DomainWithSchemeAccepted(t *testing.T) {
+	// A built-in scheme is a gradient, so a matching domain is valid.
+	errs := validateColumnFormat(t, &Format{Scheme: "red-white-green", Domain: &Domain{Anchors: []float64{-25, 0, 25}}})
 	if len(errs) != 0 {
-		t.Errorf("expected no errors, got %v", errs)
+		t.Errorf("expected domain+scheme to pass, got %v", errs)
 	}
 }
 
-func TestValidate_SingleColorUnknownOperator(t *testing.T) {
-	errs := validateColumnColorScale(t, nil, []SingleColorRule{{If: "bogus", Background: "#fff"}})
+func TestValidate_DomainSchemeLengthMismatch(t *testing.T) {
+	// white-green has 2 colors, so a 3-value domain must not match.
+	errs := validateColumnFormat(t, &Format{Scheme: "white-green", Domain: &Domain{Anchors: []float64{0, 50, 100}}})
+	if !hasErrContaining(errs, "must match") {
+		t.Errorf("expected length-mismatch error, got %v", errs)
+	}
+}
+
+func TestValidate_DomainWithPaletteAccepted(t *testing.T) {
+	// A custom palette is a gradient too; a matching domain is valid.
+	d := paletteDashboard(map[string][]string{"risk": {"red", "amber", "green"}}, "risk")
+	d.Rows[0].Widgets[0].Columns[0].Format.Domain = &Domain{Anchors: []float64{-25, 0, 25}}
+	if errs := runValidate(d); len(errs) != 0 {
+		t.Errorf("expected domain+palette to pass, got %v", errs)
+	}
+}
+
+func TestValidate_DomainLengthMismatch(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{
+		Domain:          &Domain{Anchors: []float64{0, 50, 100}},
+		BackgroundColor: []interface{}{"red", "green"},
+	})
+	if !hasErrContaining(errs, "must match") {
+		t.Errorf("expected domain-length error, got %v", errs)
+	}
+}
+
+func TestValidate_RuleUnknownOperator(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{Rules: []FormatRule{{If: "bogus", BackgroundColor: "red"}}})
 	if !hasErrContaining(errs, "unknown operator \"bogus\"") {
 		t.Errorf("expected unknown-operator error, got %v", errs)
 	}
 }
 
-func TestValidate_SingleColorBetweenNeedsPair(t *testing.T) {
-	errs := validateColumnColorScale(t, nil, []SingleColorRule{{If: CondIsBetween, Value: 5, Background: "#fff"}})
+func TestValidate_RuleBetweenNeedsPair(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{Rules: []FormatRule{{If: CondIsBetween, Value: 5, BackgroundColor: "red"}}})
 	if !hasErrContaining(errs, "requires a two-element value list") {
 		t.Errorf("expected between-pair error, got %v", errs)
 	}
 }
 
-func TestValidate_SingleColorRequiresStyle(t *testing.T) {
-	errs := validateColumnColorScale(t, nil, []SingleColorRule{{If: CondGreaterThan, Value: 5}})
+func TestValidate_RuleRequiresStyle(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{Rules: []FormatRule{{If: CondGreaterThan, Value: 5}}})
 	if !hasErrContaining(errs, "at least one style") {
 		t.Errorf("expected style-required error, got %v", errs)
 	}
 }
 
-func TestValidate_SingleColorValidPasses(t *testing.T) {
-	errs := validateColumnColorScale(t, nil, []SingleColorRule{
-		{If: CondGreaterThan, Value: 100, Background: "#D1FAE5", Bold: true},
-		{If: CondIsBetween, Value: []interface{}{10, 20}, TextColor: "#065F46"},
-		{If: CondIsEmpty, Italic: true},
+func TestValidate_GradientNeedsTwoColors(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{BackgroundColor: []interface{}{"red"}})
+	if !hasErrContaining(errs, "a gradient needs at least 2 colors") {
+		t.Errorf("expected min-2-colors error, got %v", errs)
+	}
+}
+
+func TestValidate_DomainUnknownUnit(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{
+		Domain:          &Domain{Unit: "bogus"},
+		BackgroundColor: []interface{}{"red", "green"},
+	})
+	if !hasErrContaining(errs, "domain.unit: unknown unit \"bogus\"") {
+		t.Errorf("expected domain.unit error, got %v", errs)
+	}
+}
+
+func TestValidate_PercentileDomainRange(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{
+		Domain:          &Domain{Unit: "percentile", Anchors: []float64{0, 50, 150}},
+		BackgroundColor: []interface{}{"red", "white", "green"},
+	})
+	if !hasErrContaining(errs, "percentile anchors must be between 0 and 100") {
+		t.Errorf("expected percentile-range error, got %v", errs)
+	}
+}
+
+func TestValidate_DomainPercentileValid(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{
+		Domain:          &Domain{Unit: "percentile", Anchors: []float64{0, 50, 100}},
+		BackgroundColor: []interface{}{"red", "white", "green"},
 	})
 	if len(errs) != 0 {
 		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestFormat_YAML_DomainObject(t *testing.T) {
+	yamlBody := `
+columns:
+  - name: a
+    format:
+      domain: [-25, 0, 25]
+      backgroundColor: [red, white, green]
+  - name: b
+    format:
+      domain: { unit: percentile, anchors: [0, 50, 100] }
+      backgroundColor: [red, white, green]
+  - name: c
+    format:
+      domain: { unit: percentile }
+      backgroundColor: [red, white, green]
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if d := w.Columns[0].Format.Domain; d == nil || d.Unit != "" || len(d.Anchors) != 3 {
+		t.Errorf("array form: expected raw values, got %+v", d)
+	}
+	if d := w.Columns[1].Format.Domain; d == nil || d.Unit != "percentile" || len(d.Anchors) != 3 {
+		t.Errorf("object form: expected percentile + 3 values, got %+v", d)
+	}
+	if d := w.Columns[2].Format.Domain; d == nil || d.Unit != "percentile" || len(d.Anchors) != 0 {
+		t.Errorf("unit-only form: expected percentile, no values, got %+v", d)
+	}
+}
+
+func TestFormat_YAML_Like(t *testing.T) {
+	yamlBody := `
+columns:
+  - name: revenue
+    format: { number: currency, backgroundColor: [red, white, green] }
+  - name: profit
+    format: { like: revenue }
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if w.Columns[1].Format == nil || w.Columns[1].Format.Like != "revenue" {
+		t.Fatalf("expected like=revenue, got %+v", w.Columns[1].Format)
+	}
+}
+
+func TestValidate_LikeUnknownColumn(t *testing.T) {
+	d := &Dashboard{
+		Name: "d",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
+			Columns: []TableColumn{{Name: "profit", Format: &Format{Like: "revenue"}}},
+		}}}},
+	}
+	errs := runValidate(d)
+	if !hasErrContaining(errs, "like: references unknown column \"revenue\"") {
+		t.Errorf("expected like-unknown error, got %v", errs)
+	}
+}
+
+func TestValidate_LikeSelfReference(t *testing.T) {
+	d := &Dashboard{
+		Name: "d",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
+			Columns: []TableColumn{{Name: "a", Format: &Format{Like: "a"}}},
+		}}}},
+	}
+	errs := runValidate(d)
+	if !hasErrContaining(errs, "cannot reference itself") {
+		t.Errorf("expected self-reference error, got %v", errs)
+	}
+}
+
+func TestValidate_FormatValidPasses(t *testing.T) {
+	errs := validateColumnFormat(t, &Format{
+		Number:          "currency",
+		Domain:          &Domain{Anchors: []float64{-25, 0, 25}},
+		BackgroundColor: []interface{}{"red", "white", "green"},
+		Rules: []FormatRule{
+			{If: CondGreaterThan, Value: 100, BackgroundColor: "green", Bold: true},
+			{If: CondIsBetween, Value: []interface{}{10, 20}, TextColor: "amber"},
+			{If: CondIsEmpty, Italic: true},
+		},
+	})
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+// --- custom palettes ---
+
+// paletteDashboard builds a dashboard with the given palettes and one table
+// column whose format references a scheme by name.
+func paletteDashboard(palettes map[string][]string, scheme string) *Dashboard {
+	return &Dashboard{
+		Name:     "d",
+		Palettes: palettes,
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
+			Columns: []TableColumn{{Name: "c", Format: &Format{Scheme: scheme}}},
+		}}}},
+	}
+}
+
+func TestFormat_YAML_Palettes(t *testing.T) {
+	yamlBody := `
+name: Palettes
+palettes:
+  risk: [red, amber, green]
+  heat: ["#FEF0D9", "#E34A33"]
+rows:
+  - widgets:
+      - name: t
+        type: table
+        sql: SELECT 1
+        columns:
+          - name: c
+            format: { scheme: risk }
+`
+	var d Dashboard
+	if err := yaml.Unmarshal([]byte(yamlBody), &d); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := d.Palettes["risk"]; len(got) != 3 || got[0] != "red" || got[2] != "green" {
+		t.Errorf("unexpected risk palette: %v", d.Palettes["risk"])
+	}
+	if len(d.Palettes["heat"]) != 2 {
+		t.Errorf("unexpected heat palette: %v", d.Palettes["heat"])
+	}
+}
+
+func TestFormat_TSX_Palettes(t *testing.T) {
+	source := `
+export default (
+  <Dashboard name="Heat" palettes={{ risk: ["red", "amber", "green"] }}>
+    <Row>
+      <Table name="Sales" col={12} sql="SELECT region, revenue FROM sales"
+        columns={[
+          { name: "revenue", format: { scheme: "risk" } },
+        ]} />
+    </Row>
+  </Dashboard>
+)
+`
+	d, err := evalTSX(source, "test.tsx", &tsxConfig{})
+	assertNoErr(t, err)
+	if got := d.Palettes["risk"]; len(got) != 3 || got[1] != "amber" {
+		t.Errorf("unexpected risk palette from TSX: %v", d.Palettes["risk"])
+	}
+}
+
+func TestValidate_PaletteSchemeAccepted(t *testing.T) {
+	errs := runValidate(paletteDashboard(map[string][]string{"risk": {"red", "amber", "green"}}, "risk"))
+	if len(errs) != 0 {
+		t.Errorf("expected palette scheme to pass, got %v", errs)
+	}
+}
+
+func TestValidate_PaletteUnknownScheme(t *testing.T) {
+	errs := runValidate(paletteDashboard(map[string][]string{"risk": {"red", "amber", "green"}}, "nope"))
+	if !hasErrContaining(errs, "unknown scheme") {
+		t.Errorf("expected unknown-scheme error, got %v", errs)
+	}
+}
+
+func TestValidate_PaletteTooFewColors(t *testing.T) {
+	errs := runValidate(paletteDashboard(map[string][]string{"solo": {"red"}}, "solo"))
+	if !hasErrContaining(errs, "at least 2 colors") {
+		t.Errorf("expected too-few-colors error, got %v", errs)
+	}
+}
+
+func TestValidate_PaletteCollidesWithBuiltin(t *testing.T) {
+	errs := runValidate(paletteDashboard(map[string][]string{"white-green": {"red", "green"}}, "white-green"))
+	if !hasErrContaining(errs, "collides with a built-in") {
+		t.Errorf("expected collision error, got %v", errs)
 	}
 }

--- a/pkg/dashboard/color_scale_test.go
+++ b/pkg/dashboard/color_scale_test.go
@@ -1,0 +1,271 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestColorScale_YAML_NestedStops(t *testing.T) {
+	yamlBody := `
+columns:
+  - name: revenue
+    format: currency
+    colorScale:
+      min: { type: min, color: "#F8696B" }
+      mid: { type: percentile, value: 50, color: "#FFEB84" }
+      max: { type: number, value: 1000, color: "#63BE7B" }
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cs := w.Columns[0].ColorScale
+	if cs == nil || cs.Min == nil || cs.Mid == nil || cs.Max == nil {
+		t.Fatalf("expected all three stops, got %+v", cs)
+	}
+	if cs.Min.Type != StopTypeMin || cs.Min.Color != "#F8696B" || cs.Min.Value != nil {
+		t.Errorf("unexpected min stop: %+v", cs.Min)
+	}
+	if cs.Mid.Type != StopTypePercentile || cs.Mid.Value == nil || *cs.Mid.Value != 50 {
+		t.Errorf("unexpected mid stop: %+v", cs.Mid)
+	}
+	if cs.Max.Type != StopTypeNumber || cs.Max.Value == nil || *cs.Max.Value != 1000 {
+		t.Errorf("unexpected max stop: %+v", cs.Max)
+	}
+}
+
+func TestColorScale_YAML_BareStringShorthand(t *testing.T) {
+	yamlBody := `
+columns:
+  - name: revenue
+    colorScale:
+      min: "#000000"
+      max: "#FFFFFF"
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cs := w.Columns[0].ColorScale
+	if cs.Min == nil || cs.Min.Color != "#000000" || cs.Min.Type != "" {
+		t.Errorf("expected bare-string min color, got %+v", cs.Min)
+	}
+	if cs.Mid != nil {
+		t.Errorf("expected no mid stop, got %+v", cs.Mid)
+	}
+	if cs.Max == nil || cs.Max.Color != "#FFFFFF" {
+		t.Errorf("expected bare-string max color, got %+v", cs.Max)
+	}
+}
+
+func TestColorScale_JSON_BareStringAndObject(t *testing.T) {
+	body := []byte(`{"columns":[{"name":"r","colorScale":{"min":"#000000","max":{"type":"percentile","value":90,"color":"#FFFFFF"}}}]}`)
+	var w Widget
+	if err := json.Unmarshal(body, &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cs := w.Columns[0].ColorScale
+	if cs.Min == nil || cs.Min.Color != "#000000" {
+		t.Errorf("expected bare-string min, got %+v", cs.Min)
+	}
+	if cs.Max == nil || cs.Max.Type != StopTypePercentile || cs.Max.Value == nil || *cs.Max.Value != 90 {
+		t.Errorf("expected percentile max, got %+v", cs.Max)
+	}
+}
+
+func TestSingleColor_YAML(t *testing.T) {
+	yamlBody := `
+columns:
+  - name: status
+    singleColor:
+      - if: text_is_exactly
+        value: overdue
+        background: "#FEE2E2"
+        textColor: "#991B1B"
+        bold: true
+      - if: is_between
+        value: [10, 20]
+        background: "#D1FAE5"
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rules := w.Columns[0].SingleColor
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(rules))
+	}
+	if rules[0].If != CondTextIsExactly || rules[0].Value != "overdue" || !rules[0].Bold {
+		t.Errorf("unexpected rule 0: %+v", rules[0])
+	}
+	if rules[0].Background != "#FEE2E2" || rules[0].TextColor != "#991B1B" {
+		t.Errorf("unexpected rule 0 styles: %+v", rules[0])
+	}
+	pair, ok := rules[1].Value.([]interface{})
+	if !ok || len(pair) != 2 {
+		t.Errorf("expected two-element value for between, got %+v", rules[1].Value)
+	}
+}
+
+func TestColorScale_TSX(t *testing.T) {
+	source := `
+export default (
+  <Dashboard name="Heat" connection="db">
+    <Row>
+      <Table name="Sales" col={12}
+        sql="SELECT region, revenue FROM sales"
+        columns={[
+          { name: "region", label: "Region" },
+          { name: "revenue", format: "currency",
+            colorScale: {
+              min: { type: "min", color: "#F8696B" },
+              max: { type: "percent", value: 90, color: "#63BE7B" },
+            } },
+          { name: "status",
+            singleColor: [
+              { if: "text_contains", value: "fail", background: "#FEE2E2", bold: true },
+            ] },
+        ]} />
+    </Row>
+  </Dashboard>
+)
+`
+	d, err := evalTSX(source, "test.tsx", &tsxConfig{})
+	assertNoErr(t, err)
+
+	cols := d.Rows[0].Widgets[0].Columns
+	if len(cols) != 3 {
+		t.Fatalf("expected 3 columns, got %d", len(cols))
+	}
+	cs := cols[1].ColorScale
+	if cs == nil || cs.Min == nil || cs.Min.Type != StopTypeMin || cs.Min.Color != "#F8696B" {
+		t.Fatalf("unexpected colorScale min: %+v", cs)
+	}
+	if cs.Max == nil || cs.Max.Type != StopTypePercent || cs.Max.Value == nil || *cs.Max.Value != 90 {
+		t.Errorf("unexpected colorScale max: %+v", cs.Max)
+	}
+	if cs.Mid != nil {
+		t.Errorf("expected no mid stop, got %+v", cs.Mid)
+	}
+	sc := cols[2].SingleColor
+	if len(sc) != 1 || sc[0].If != CondTextContains || sc[0].Value != "fail" || !sc[0].Bold {
+		t.Errorf("unexpected singleColor: %+v", sc)
+	}
+}
+
+// --- validation ---
+
+func validateColumnColorScale(t *testing.T, cs *ColorScale, singleColor []SingleColorRule) []string {
+	t.Helper()
+	d := &Dashboard{
+		Name: "d",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
+			Columns: []TableColumn{{Name: "c", ColorScale: cs, SingleColor: singleColor}},
+		}}}},
+	}
+	err := Validate(d)
+	if err == nil {
+		return nil
+	}
+	return err.(*ValidationError).Errors
+}
+
+func fptr(f float64) *float64 { return &f }
+
+func hasErrContaining(errs []string, substr string) bool {
+	for _, e := range errs {
+		if strings.Contains(e, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidate_MinStopCannotBeMaxType(t *testing.T) {
+	errs := validateColumnColorScale(t, &ColorScale{Min: &ColorStop{Type: StopTypeMax}}, nil)
+	if !hasErrContaining(errs, "colorScale.min: type \"max\" not allowed") {
+		t.Errorf("expected min-type error, got %v", errs)
+	}
+}
+
+func TestValidate_MaxStopCannotBeMinType(t *testing.T) {
+	errs := validateColumnColorScale(t, &ColorScale{Max: &ColorStop{Type: StopTypeMin}}, nil)
+	if !hasErrContaining(errs, "colorScale.max: type \"min\" not allowed") {
+		t.Errorf("expected max-type error, got %v", errs)
+	}
+}
+
+func TestValidate_MidStopTypeRestricted(t *testing.T) {
+	errs := validateColumnColorScale(t, &ColorScale{Mid: &ColorStop{Type: StopTypeMin}}, nil)
+	if !hasErrContaining(errs, "colorScale.mid: type \"min\" not allowed") {
+		t.Errorf("expected mid-type error, got %v", errs)
+	}
+}
+
+func TestValidate_ValueNotAllowedForMinMaxType(t *testing.T) {
+	errs := validateColumnColorScale(t, &ColorScale{Min: &ColorStop{Type: StopTypeMin, Value: fptr(5)}}, nil)
+	if !hasErrContaining(errs, "value is not allowed for type \"min\"") {
+		t.Errorf("expected value-not-allowed error, got %v", errs)
+	}
+}
+
+func TestValidate_ValueRequiredForNumberType(t *testing.T) {
+	errs := validateColumnColorScale(t, &ColorScale{Max: &ColorStop{Type: StopTypeNumber}}, nil)
+	if !hasErrContaining(errs, "value is required for type \"number\"") {
+		t.Errorf("expected value-required error, got %v", errs)
+	}
+}
+
+func TestValidate_PercentileRange(t *testing.T) {
+	errs := validateColumnColorScale(t, &ColorScale{Mid: &ColorStop{Type: StopTypePercentile, Value: fptr(150)}}, nil)
+	if !hasErrContaining(errs, "percentile value must be between 0 and 100") {
+		t.Errorf("expected percentile-range error, got %v", errs)
+	}
+}
+
+func TestValidate_ColorScaleValidPasses(t *testing.T) {
+	errs := validateColumnColorScale(t, &ColorScale{
+		Min: &ColorStop{Type: StopTypeMin, Color: "#F8696B"},
+		Mid: &ColorStop{Type: StopTypePercentile, Value: fptr(50), Color: "#FFEB84"},
+		Max: &ColorStop{Type: StopTypeNumber, Value: fptr(100), Color: "#63BE7B"},
+	}, nil)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidate_SingleColorUnknownOperator(t *testing.T) {
+	errs := validateColumnColorScale(t, nil, []SingleColorRule{{If: "bogus", Background: "#fff"}})
+	if !hasErrContaining(errs, "unknown operator \"bogus\"") {
+		t.Errorf("expected unknown-operator error, got %v", errs)
+	}
+}
+
+func TestValidate_SingleColorBetweenNeedsPair(t *testing.T) {
+	errs := validateColumnColorScale(t, nil, []SingleColorRule{{If: CondIsBetween, Value: 5, Background: "#fff"}})
+	if !hasErrContaining(errs, "requires a two-element value list") {
+		t.Errorf("expected between-pair error, got %v", errs)
+	}
+}
+
+func TestValidate_SingleColorRequiresStyle(t *testing.T) {
+	errs := validateColumnColorScale(t, nil, []SingleColorRule{{If: CondGreaterThan, Value: 5}})
+	if !hasErrContaining(errs, "at least one style") {
+		t.Errorf("expected style-required error, got %v", errs)
+	}
+}
+
+func TestValidate_SingleColorValidPasses(t *testing.T) {
+	errs := validateColumnColorScale(t, nil, []SingleColorRule{
+		{If: CondGreaterThan, Value: 100, Background: "#D1FAE5", Bold: true},
+		{If: CondIsBetween, Value: []interface{}{10, 20}, TextColor: "#065F46"},
+		{If: CondIsEmpty, Italic: true},
+	})
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -392,6 +392,7 @@ func vnodeToDashboard(root *vnode) (*Dashboard, error) {
 		Connection:  asString(root.Props["connection"]),
 		Model:       asString(root.Props["model"]),
 		Models:      asStringMap(root.Props["models"]),
+		Palettes:    asStringSliceMap(root.Props["palettes"]),
 	}
 
 	for _, child := range root.Children {
@@ -602,21 +603,6 @@ func asInt(v interface{}) int {
 	}
 }
 
-func asFloatPtr(v interface{}) *float64 {
-	switch val := v.(type) {
-	case float64:
-		return &val
-	case int:
-		f := float64(val)
-		return &f
-	case int64:
-		f := float64(val)
-		return &f
-	default:
-		return nil
-	}
-}
-
 func asBool(v interface{}) bool {
 	if v == nil {
 		return false
@@ -751,6 +737,23 @@ func asStringMap(v interface{}) map[string]string {
 	return out
 }
 
+// asStringSliceMap converts a JS object of string arrays (e.g. `palettes`) into
+// map[string][]string.
+func asStringSliceMap(v interface{}) map[string][]string {
+	if v == nil {
+		return nil
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	out := make(map[string][]string, len(m))
+	for key, value := range m {
+		out[key] = asStringSlice(value)
+	}
+	return out
+}
+
 func asSemanticDimensionRefs(v interface{}) []SemanticDimensionRef {
 	if v == nil {
 		return nil
@@ -842,70 +845,97 @@ func asTableColumns(v interface{}) []TableColumn {
 	for _, item := range arr {
 		if m, ok := item.(map[string]interface{}); ok {
 			cols = append(cols, TableColumn{
-				Name:        asString(m["name"]),
-				Label:       asString(m["label"]),
-				Format:      asString(m["format"]),
-				ColorScale:  asColorScale(m["colorScale"]),
-				SingleColor: asSingleColor(m["singleColor"]),
+				Name:   asString(m["name"]),
+				Label:  asString(m["label"]),
+				Format: asFormat(m["format"]),
 			})
 		}
 	}
 	return cols
 }
 
-func asColorScale(v interface{}) *ColorScale {
-	m, ok := v.(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	return &ColorScale{
-		Min: asColorStop(m["min"]),
-		Mid: asColorStop(m["mid"]),
-		Max: asColorStop(m["max"]),
-	}
-}
-
-// asColorStop accepts a bare color string or a { type, value, color } object.
-func asColorStop(v interface{}) *ColorStop {
+// asFormat accepts a bare string (value format shorthand) or a full object.
+func asFormat(v interface{}) *Format {
 	switch val := v.(type) {
 	case nil:
 		return nil
 	case string:
-		return &ColorStop{Color: val}
+		return &Format{Number: val}
 	case map[string]interface{}:
-		return &ColorStop{
-			Type:  asString(val["type"]),
-			Value: asFloatPtr(val["value"]),
-			Color: asString(val["color"]),
+		return &Format{
+			Like:            asString(val["like"]),
+			Number:          asString(val["number"]),
+			BackgroundColor: val["backgroundColor"],
+			TextColor:       asString(val["textColor"]),
+			Bold:            asBool(val["bold"]),
+			Italic:          asBool(val["italic"]),
+			Underline:       asBool(val["underline"]),
+			Strikethrough:   asBool(val["strikethrough"]),
+			Domain:          asDomain(val["domain"]),
+			Scheme:          asString(val["scheme"]),
+			Rules:           asFormatRules(val["rules"]),
 		}
 	default:
 		return nil
 	}
 }
 
-func asSingleColor(v interface{}) []SingleColorRule {
+func asFormatRules(v interface{}) []FormatRule {
 	arr, ok := v.([]interface{})
 	if !ok {
 		return nil
 	}
-	var rules []SingleColorRule
+	var rules []FormatRule
 	for _, item := range arr {
 		m, ok := item.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		rules = append(rules, SingleColorRule{
-			If:            asString(m["if"]),
-			Value:         m["value"],
-			Bold:          asBool(m["bold"]),
-			Italic:        asBool(m["italic"]),
-			Underline:     asBool(m["underline"]),
-			Strikethrough: asBool(m["strikethrough"]),
-			TextColor:     asString(m["textColor"]),
-			Background:    asString(m["background"]),
+		rules = append(rules, FormatRule{
+			If:              asString(m["if"]),
+			Value:           m["value"],
+			BackgroundColor: asString(m["backgroundColor"]),
+			TextColor:       asString(m["textColor"]),
+			Bold:            asBool(m["bold"]),
+			Italic:          asBool(m["italic"]),
+			Underline:       asBool(m["underline"]),
+			Strikethrough:   asBool(m["strikethrough"]),
 		})
 	}
 	return rules
+}
+
+// asDomain accepts a bare array of raw values or a { unit, anchors } object.
+func asDomain(v interface{}) *Domain {
+	switch val := v.(type) {
+	case nil:
+		return nil
+	case []interface{}:
+		return &Domain{Anchors: asFloatSlice(val)}
+	case map[string]interface{}:
+		return &Domain{Unit: asString(val["unit"]), Anchors: asFloatSlice(val["anchors"])}
+	default:
+		return nil
+	}
+}
+
+func asFloatSlice(v interface{}) []float64 {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]float64, 0, len(arr))
+	for _, item := range arr {
+		switch n := item.(type) {
+		case float64:
+			out = append(out, n)
+		case int:
+			out = append(out, float64(n))
+		case int64:
+			out = append(out, float64(n))
+		}
+	}
+	return out
 }
 
 // IsTSXFile checks if a filename matches the .dashboard.tsx convention.

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -602,6 +602,21 @@ func asInt(v interface{}) int {
 	}
 }
 
+func asFloatPtr(v interface{}) *float64 {
+	switch val := v.(type) {
+	case float64:
+		return &val
+	case int:
+		f := float64(val)
+		return &f
+	case int64:
+		f := float64(val)
+		return &f
+	default:
+		return nil
+	}
+}
+
 func asBool(v interface{}) bool {
 	if v == nil {
 		return false
@@ -827,13 +842,70 @@ func asTableColumns(v interface{}) []TableColumn {
 	for _, item := range arr {
 		if m, ok := item.(map[string]interface{}); ok {
 			cols = append(cols, TableColumn{
-				Name:   asString(m["name"]),
-				Label:  asString(m["label"]),
-				Format: asString(m["format"]),
+				Name:        asString(m["name"]),
+				Label:       asString(m["label"]),
+				Format:      asString(m["format"]),
+				ColorScale:  asColorScale(m["colorScale"]),
+				SingleColor: asSingleColor(m["singleColor"]),
 			})
 		}
 	}
 	return cols
+}
+
+func asColorScale(v interface{}) *ColorScale {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return &ColorScale{
+		Min: asColorStop(m["min"]),
+		Mid: asColorStop(m["mid"]),
+		Max: asColorStop(m["max"]),
+	}
+}
+
+// asColorStop accepts a bare color string or a { type, value, color } object.
+func asColorStop(v interface{}) *ColorStop {
+	switch val := v.(type) {
+	case nil:
+		return nil
+	case string:
+		return &ColorStop{Color: val}
+	case map[string]interface{}:
+		return &ColorStop{
+			Type:  asString(val["type"]),
+			Value: asFloatPtr(val["value"]),
+			Color: asString(val["color"]),
+		}
+	default:
+		return nil
+	}
+}
+
+func asSingleColor(v interface{}) []SingleColorRule {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	var rules []SingleColorRule
+	for _, item := range arr {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rules = append(rules, SingleColorRule{
+			If:            asString(m["if"]),
+			Value:         m["value"],
+			Bold:          asBool(m["bold"]),
+			Italic:        asBool(m["italic"]),
+			Underline:     asBool(m["underline"]),
+			Strikethrough: asBool(m["strikethrough"]),
+			TextColor:     asString(m["textColor"]),
+			Background:    asString(m["background"]),
+		})
+	}
+	return rules
 }
 
 // IsTSXFile checks if a filename matches the .dashboard.tsx convention.

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -392,7 +392,6 @@ func vnodeToDashboard(root *vnode) (*Dashboard, error) {
 		Connection:  asString(root.Props["connection"]),
 		Model:       asString(root.Props["model"]),
 		Models:      asStringMap(root.Props["models"]),
-		Palettes:    asStringSliceMap(root.Props["palettes"]),
 	}
 
 	for _, child := range root.Children {
@@ -733,23 +732,6 @@ func asStringMap(v interface{}) map[string]string {
 	out := make(map[string]string, len(m))
 	for key, value := range m {
 		out[key] = asString(value)
-	}
-	return out
-}
-
-// asStringSliceMap converts a JS object of string arrays (e.g. `palettes`) into
-// map[string][]string.
-func asStringSliceMap(v interface{}) map[string][]string {
-	if v == nil {
-		return nil
-	}
-	m, ok := v.(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	out := make(map[string][]string, len(m))
-	for key, value := range m {
-		out[key] = asStringSlice(value)
 	}
 	return out
 }

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -829,54 +829,33 @@ func asTableColumns(v interface{}) []TableColumn {
 			cols = append(cols, TableColumn{
 				Name:   asString(m["name"]),
 				Label:  asString(m["label"]),
-				Format: asFormat(m["format"]),
+				Number: asString(m["number"]),
+				Like:   asString(m["like"]),
+				Format: asFormatLayers(m["format"]),
 			})
 		}
 	}
 	return cols
 }
 
-// asFormat accepts a bare string (value format shorthand) or a full object.
-func asFormat(v interface{}) *Format {
-	switch val := v.(type) {
-	case nil:
-		return nil
-	case string:
-		return &Format{Number: val}
-	case map[string]interface{}:
-		return &Format{
-			Like:            asString(val["like"]),
-			Number:          asString(val["number"]),
-			BackgroundColor: val["backgroundColor"],
-			TextColor:       asString(val["textColor"]),
-			Bold:            asBool(val["bold"]),
-			Italic:          asBool(val["italic"]),
-			Underline:       asBool(val["underline"]),
-			Strikethrough:   asBool(val["strikethrough"]),
-			Domain:          asDomain(val["domain"]),
-			Scheme:          asString(val["scheme"]),
-			Rules:           asFormatRules(val["rules"]),
-		}
-	default:
-		return nil
-	}
-}
-
-func asFormatRules(v interface{}) []FormatRule {
+// asFormatLayers reads a column's ordered `format` list of style layers.
+func asFormatLayers(v interface{}) []FormatLayer {
 	arr, ok := v.([]interface{})
 	if !ok {
 		return nil
 	}
-	var rules []FormatRule
+	var layers []FormatLayer
 	for _, item := range arr {
 		m, ok := item.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		rules = append(rules, FormatRule{
+		layers = append(layers, FormatLayer{
 			If:              asString(m["if"]),
 			Value:           m["value"],
-			BackgroundColor: asString(m["backgroundColor"]),
+			BackgroundColor: m["backgroundColor"],
+			Range:           asFloatSlice(m["range"]),
+			Unit:            asString(m["unit"]),
 			TextColor:       asString(m["textColor"]),
 			Bold:            asBool(m["bold"]),
 			Italic:          asBool(m["italic"]),
@@ -884,21 +863,7 @@ func asFormatRules(v interface{}) []FormatRule {
 			Strikethrough:   asBool(m["strikethrough"]),
 		})
 	}
-	return rules
-}
-
-// asDomain accepts a bare array of raw values or a { unit, anchors } object.
-func asDomain(v interface{}) *Domain {
-	switch val := v.(type) {
-	case nil:
-		return nil
-	case []interface{}:
-		return &Domain{Anchors: asFloatSlice(val)}
-	case map[string]interface{}:
-		return &Domain{Unit: asString(val["unit"]), Anchors: asFloatSlice(val["anchors"])}
-	default:
-		return nil
-	}
+	return layers
 }
 
 func asFloatSlice(v interface{}) []float64 {

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -465,13 +465,13 @@ func TestLoadDir_MixedYAMLAndTSX(t *testing.T) {
 	dashboards, err := LoadDir("../../testdata/dashboards")
 	assertNoErr(t, err)
 
-	// Should find 5 YAML + 2 TSX = 7 dashboards.
-	if len(dashboards) != 7 {
+	// Should find 6 YAML + 2 TSX = 8 dashboards.
+	if len(dashboards) != 8 {
 		names := make([]string, len(dashboards))
 		for i, d := range dashboards {
 			names[i] = d.Name
 		}
-		t.Fatalf("expected 7 dashboards, got %d: %v", len(dashboards), names)
+		t.Fatalf("expected 8 dashboards, got %d: %v", len(dashboards), names)
 	}
 
 	// Verify TSX dashboard was loaded.

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -375,8 +375,8 @@ export default (
 	if w.Columns[0].Name != "id" || w.Columns[0].Label != "Order ID" {
 		t.Errorf("unexpected column 0: %+v", w.Columns[0])
 	}
-	if w.Columns[1].Format != "currency" {
-		t.Errorf("expected format %q, got %q", "currency", w.Columns[1].Format)
+	if w.Columns[1].Format == nil || w.Columns[1].Format.Number != "currency" {
+		t.Errorf("expected format number %q, got %+v", "currency", w.Columns[1].Format)
 	}
 }
 

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -359,7 +359,7 @@ export default (
         sql="SELECT * FROM orders"
         columns={[
           { name: "id", label: "Order ID" },
-          { name: "amount", label: "Amount", format: "currency" },
+          { name: "amount", label: "Amount", number: "currency" },
         ]} />
     </Row>
   </Dashboard>
@@ -375,8 +375,8 @@ export default (
 	if w.Columns[0].Name != "id" || w.Columns[0].Label != "Order ID" {
 		t.Errorf("unexpected column 0: %+v", w.Columns[0])
 	}
-	if w.Columns[1].Format == nil || w.Columns[1].Format.Number != "currency" {
-		t.Errorf("expected format number %q, got %+v", "currency", w.Columns[1].Format)
+	if w.Columns[1].Number != "currency" {
+		t.Errorf("expected number %q, got %+v", "currency", w.Columns[1].Number)
 	}
 }
 

--- a/pkg/dashboard/loader_test.go
+++ b/pkg/dashboard/loader_test.go
@@ -15,9 +15,9 @@ func TestLoadDir_LoadsAllDashboards(t *testing.T) {
 	dashboards, err := LoadDir("../../testdata/dashboards")
 	assertNoErr(t, err)
 
-	// 5 YAML + 2 TSX = 7
-	if len(dashboards) != 7 {
-		t.Fatalf("expected 7 dashboards, got %d", len(dashboards))
+	// 6 YAML + 2 TSX = 8
+	if len(dashboards) != 8 {
+		t.Fatalf("expected 8 dashboards, got %d", len(dashboards))
 	}
 }
 

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -24,15 +24,16 @@ const (
 
 // Dashboard represents a complete dashboard definition loaded from YAML.
 type Dashboard struct {
-	Schema      string            `yaml:"schema,omitempty" json:"schema,omitempty"`
-	Name        string            `yaml:"name" json:"name"`
-	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Connection  string            `yaml:"connection,omitempty" json:"connection,omitempty"`
-	Model       string            `yaml:"model,omitempty" json:"model,omitempty"`
-	Models      map[string]string `yaml:"models,omitempty" json:"models,omitempty"`
-	Filters     []Filter          `yaml:"filters,omitempty" json:"filters,omitempty"`
-	Queries     map[string]Query  `yaml:"queries,omitempty" json:"queries,omitempty"`
-	Rows        []Row             `yaml:"rows" json:"rows"`
+	Schema      string              `yaml:"schema,omitempty" json:"schema,omitempty"`
+	Name        string              `yaml:"name" json:"name"`
+	Description string              `yaml:"description,omitempty" json:"description,omitempty"`
+	Connection  string              `yaml:"connection,omitempty" json:"connection,omitempty"`
+	Model       string              `yaml:"model,omitempty" json:"model,omitempty"`
+	Models      map[string]string   `yaml:"models,omitempty" json:"models,omitempty"`
+	Filters     []Filter            `yaml:"filters,omitempty" json:"filters,omitempty"`
+	Queries     map[string]Query    `yaml:"queries,omitempty" json:"queries,omitempty"`
+	Palettes    map[string][]string `yaml:"palettes,omitempty" json:"palettes,omitempty"`
+	Rows        []Row               `yaml:"rows" json:"rows"`
 
 	// FilePath is the source file path, not serialized to JSON for API consumers.
 	FilePath string `yaml:"-" json:"-"`
@@ -147,62 +148,90 @@ type Widget struct {
 }
 
 type TableColumn struct {
-	Name   string `yaml:"name" json:"name"`
-	Label  string `yaml:"label,omitempty" json:"label,omitempty"`
-	Format string `yaml:"format,omitempty" json:"format,omitempty"`
-	ColorScale *ColorScale `yaml:"colorScale,omitempty" json:"colorScale,omitempty"`
-	SingleColor []SingleColorRule `yaml:"singleColor,omitempty" json:"singleColor,omitempty"`
+	Name   string  `yaml:"name" json:"name"`
+	Label  string  `yaml:"label,omitempty" json:"label,omitempty"`
+	Format *Format `yaml:"format,omitempty" json:"format,omitempty"`
 }
 
-type ColorScale struct {
-	Min *ColorStop `yaml:"min,omitempty" json:"min,omitempty"`
-	Mid *ColorStop `yaml:"mid,omitempty" json:"mid,omitempty"`
-	Max *ColorStop `yaml:"max,omitempty" json:"max,omitempty"`
+// Format controls a column's value display and conditional coloring.
+type Format struct {
+	Like            string       `yaml:"like,omitempty" json:"like,omitempty"` // mirror another column's format + per-row value
+	Number          string       `yaml:"number,omitempty" json:"number,omitempty"`
+	BackgroundColor any          `yaml:"backgroundColor,omitempty" json:"backgroundColor,omitempty"` // string | []string
+	TextColor       string       `yaml:"textColor,omitempty" json:"textColor,omitempty"`
+	Bold            bool         `yaml:"bold,omitempty" json:"bold,omitempty"`
+	Italic          bool         `yaml:"italic,omitempty" json:"italic,omitempty"`
+	Underline       bool         `yaml:"underline,omitempty" json:"underline,omitempty"`
+	Strikethrough   bool         `yaml:"strikethrough,omitempty" json:"strikethrough,omitempty"`
+	Domain          *Domain      `yaml:"domain,omitempty" json:"domain,omitempty"` // gradient anchors (array = raw values, or {unit, anchors})
+	Scheme          string       `yaml:"scheme,omitempty" json:"scheme,omitempty"` // named built-in palette
+	Rules           []FormatRule `yaml:"rules,omitempty" json:"rules,omitempty"`
 }
 
-const (
-	StopTypeMin        = "min"
-	StopTypeMax        = "max"
-	StopTypeNumber     = "number"
-	StopTypePercent    = "percent"
-	StopTypePercentile = "percentile"
-)
-
-type ColorStop struct {
-	Type  string   `yaml:"type,omitempty" json:"type,omitempty"`   // min|max|number|percent|percentile
-	Value *float64 `yaml:"value,omitempty" json:"value,omitempty"` // for number|percent|percentile
-	Color string   `yaml:"color,omitempty" json:"color,omitempty"`
+// Domain places gradient anchors.
+type Domain struct {
+	Unit    string    `yaml:"unit,omitempty" json:"unit,omitempty"`
+	Anchors []float64 `yaml:"anchors,omitempty" json:"anchors,omitempty"`
 }
 
-func (s *ColorStop) UnmarshalYAML(node *yaml.Node) error {
-	if node.Kind == yaml.ScalarNode {
-		s.Color = node.Value
-		return nil
+func (d *Domain) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.SequenceNode {
+		return node.Decode(&d.Anchors)
 	}
-	type raw ColorStop
+	type raw Domain
 	var r raw
 	if err := node.Decode(&r); err != nil {
 		return err
 	}
-	*s = ColorStop(r)
+	*d = Domain(r)
 	return nil
 }
 
-func (s *ColorStop) UnmarshalJSON(data []byte) error {
-	var str string
-	if err := json.Unmarshal(data, &str); err == nil {
-		s.Color = str
+func (d *Domain) UnmarshalJSON(data []byte) error {
+	var vals []float64
+	if err := json.Unmarshal(data, &vals); err == nil {
+		d.Anchors = vals
 		return nil
 	}
-	type raw ColorStop
+	type raw Domain
 	var r raw
 	if err := json.Unmarshal(data, &r); err != nil {
 		return err
 	}
-	*s = ColorStop(r)
+	*d = Domain(r)
 	return nil
 }
 
+func (f *Format) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		f.Number = node.Value
+		return nil
+	}
+	type raw Format
+	var r raw
+	if err := node.Decode(&r); err != nil {
+		return err
+	}
+	*f = Format(r)
+	return nil
+}
+
+func (f *Format) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		f.Number = s
+		return nil
+	}
+	type raw Format
+	var r raw
+	if err := json.Unmarshal(data, &r); err != nil {
+		return err
+	}
+	*f = Format(r)
+	return nil
+}
+
+// Condition operators for conditional-formatting rules.
 const (
 	CondIsEmpty            = "is_empty"
 	CondIsNotEmpty         = "is_not_empty"
@@ -224,15 +253,16 @@ const (
 	CondIsNotBetween       = "is_not_between"
 )
 
-type SingleColorRule struct {
-	If            string `yaml:"if" json:"if"`
-	Value         any    `yaml:"value,omitempty" json:"value,omitempty"`
-	Bold          bool   `yaml:"bold,omitempty" json:"bold,omitempty"`
-	Italic        bool   `yaml:"italic,omitempty" json:"italic,omitempty"`
-	Underline     bool   `yaml:"underline,omitempty" json:"underline,omitempty"`
-	Strikethrough bool   `yaml:"strikethrough,omitempty" json:"strikethrough,omitempty"`
-	TextColor     string `yaml:"textColor,omitempty" json:"textColor,omitempty"`
-	Background    string `yaml:"background,omitempty" json:"background,omitempty"`
+// FormatRule applies a fixed style to cells matching a condition.
+type FormatRule struct {
+	If              string `yaml:"if" json:"if"`
+	Value           any    `yaml:"value,omitempty" json:"value,omitempty"`
+	BackgroundColor string `yaml:"backgroundColor,omitempty" json:"backgroundColor,omitempty"`
+	TextColor       string `yaml:"textColor,omitempty" json:"textColor,omitempty"`
+	Bold            bool   `yaml:"bold,omitempty" json:"bold,omitempty"`
+	Italic          bool   `yaml:"italic,omitempty" json:"italic,omitempty"`
+	Underline       bool   `yaml:"underline,omitempty" json:"underline,omitempty"`
+	Strikethrough   bool   `yaml:"strikethrough,omitempty" json:"strikethrough,omitempty"`
 }
 
 // WidgetData holds inline result data for a widget so it can render without a

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -150,6 +150,89 @@ type TableColumn struct {
 	Name   string `yaml:"name" json:"name"`
 	Label  string `yaml:"label,omitempty" json:"label,omitempty"`
 	Format string `yaml:"format,omitempty" json:"format,omitempty"`
+	ColorScale *ColorScale `yaml:"colorScale,omitempty" json:"colorScale,omitempty"`
+	SingleColor []SingleColorRule `yaml:"singleColor,omitempty" json:"singleColor,omitempty"`
+}
+
+type ColorScale struct {
+	Min *ColorStop `yaml:"min,omitempty" json:"min,omitempty"`
+	Mid *ColorStop `yaml:"mid,omitempty" json:"mid,omitempty"`
+	Max *ColorStop `yaml:"max,omitempty" json:"max,omitempty"`
+}
+
+const (
+	StopTypeMin        = "min"
+	StopTypeMax        = "max"
+	StopTypeNumber     = "number"
+	StopTypePercent    = "percent"
+	StopTypePercentile = "percentile"
+)
+
+type ColorStop struct {
+	Type  string   `yaml:"type,omitempty" json:"type,omitempty"`   // min|max|number|percent|percentile
+	Value *float64 `yaml:"value,omitempty" json:"value,omitempty"` // for number|percent|percentile
+	Color string   `yaml:"color,omitempty" json:"color,omitempty"`
+}
+
+func (s *ColorStop) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		s.Color = node.Value
+		return nil
+	}
+	type raw ColorStop
+	var r raw
+	if err := node.Decode(&r); err != nil {
+		return err
+	}
+	*s = ColorStop(r)
+	return nil
+}
+
+func (s *ColorStop) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		s.Color = str
+		return nil
+	}
+	type raw ColorStop
+	var r raw
+	if err := json.Unmarshal(data, &r); err != nil {
+		return err
+	}
+	*s = ColorStop(r)
+	return nil
+}
+
+const (
+	CondIsEmpty            = "is_empty"
+	CondIsNotEmpty         = "is_not_empty"
+	CondTextContains       = "text_contains"
+	CondTextNotContains    = "text_does_not_contain"
+	CondTextStartsWith     = "text_starts_with"
+	CondTextEndsWith       = "text_ends_with"
+	CondTextIsExactly      = "text_is_exactly"
+	CondDateIs             = "date_is"
+	CondDateBefore         = "date_before"
+	CondDateAfter          = "date_after"
+	CondGreaterThan        = "greater_than"
+	CondGreaterThanOrEqual = "greater_than_or_equal"
+	CondLessThan           = "less_than"
+	CondLessThanOrEqual    = "less_than_or_equal"
+	CondIsEqualTo          = "is_equal_to"
+	CondIsNotEqualTo       = "is_not_equal_to"
+	CondIsBetween          = "is_between"
+	CondIsNotBetween       = "is_not_between"
+)
+
+type SingleColorRule struct {
+	If            string `yaml:"if" json:"if"`
+	Value         any    `yaml:"value,omitempty" json:"value,omitempty"`
+	Bold          bool   `yaml:"bold,omitempty" json:"bold,omitempty"`
+	Italic        bool   `yaml:"italic,omitempty" json:"italic,omitempty"`
+	Underline     bool   `yaml:"underline,omitempty" json:"underline,omitempty"`
+	Strikethrough bool   `yaml:"strikethrough,omitempty" json:"strikethrough,omitempty"`
+	TextColor     string `yaml:"textColor,omitempty" json:"textColor,omitempty"`
+	Background    string `yaml:"background,omitempty" json:"background,omitempty"`
 }
 
 // WidgetData holds inline result data for a widget so it can render without a

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -147,87 +147,11 @@ type Widget struct {
 }
 
 type TableColumn struct {
-	Name   string  `yaml:"name" json:"name"`
-	Label  string  `yaml:"label,omitempty" json:"label,omitempty"`
-	Format *Format `yaml:"format,omitempty" json:"format,omitempty"`
-}
-
-// Format controls a column's value display and conditional coloring.
-type Format struct {
-	Like            string       `yaml:"like,omitempty" json:"like,omitempty"` // mirror another column's format + per-row value
-	Number          string       `yaml:"number,omitempty" json:"number,omitempty"`
-	BackgroundColor any          `yaml:"backgroundColor,omitempty" json:"backgroundColor,omitempty"` // string | []string
-	TextColor       string       `yaml:"textColor,omitempty" json:"textColor,omitempty"`
-	Bold            bool         `yaml:"bold,omitempty" json:"bold,omitempty"`
-	Italic          bool         `yaml:"italic,omitempty" json:"italic,omitempty"`
-	Underline       bool         `yaml:"underline,omitempty" json:"underline,omitempty"`
-	Strikethrough   bool         `yaml:"strikethrough,omitempty" json:"strikethrough,omitempty"`
-	Domain          *Domain      `yaml:"domain,omitempty" json:"domain,omitempty"` // gradient anchors (array = raw values, or {unit, anchors})
-	Scheme          string       `yaml:"scheme,omitempty" json:"scheme,omitempty"` // named built-in palette
-	Rules           []FormatRule `yaml:"rules,omitempty" json:"rules,omitempty"`
-}
-
-// Domain places gradient anchors.
-type Domain struct {
-	Unit    string    `yaml:"unit,omitempty" json:"unit,omitempty"`
-	Anchors []float64 `yaml:"anchors,omitempty" json:"anchors,omitempty"`
-}
-
-func (d *Domain) UnmarshalYAML(node *yaml.Node) error {
-	if node.Kind == yaml.SequenceNode {
-		return node.Decode(&d.Anchors)
-	}
-	type raw Domain
-	var r raw
-	if err := node.Decode(&r); err != nil {
-		return err
-	}
-	*d = Domain(r)
-	return nil
-}
-
-func (d *Domain) UnmarshalJSON(data []byte) error {
-	var vals []float64
-	if err := json.Unmarshal(data, &vals); err == nil {
-		d.Anchors = vals
-		return nil
-	}
-	type raw Domain
-	var r raw
-	if err := json.Unmarshal(data, &r); err != nil {
-		return err
-	}
-	*d = Domain(r)
-	return nil
-}
-
-func (f *Format) UnmarshalYAML(node *yaml.Node) error {
-	if node.Kind == yaml.ScalarNode {
-		f.Number = node.Value
-		return nil
-	}
-	type raw Format
-	var r raw
-	if err := node.Decode(&r); err != nil {
-		return err
-	}
-	*f = Format(r)
-	return nil
-}
-
-func (f *Format) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err == nil {
-		f.Number = s
-		return nil
-	}
-	type raw Format
-	var r raw
-	if err := json.Unmarshal(data, &r); err != nil {
-		return err
-	}
-	*f = Format(r)
-	return nil
+	Name   string        `yaml:"name" json:"name"`
+	Label  string        `yaml:"label,omitempty" json:"label,omitempty"`
+	Number string        `yaml:"number,omitempty" json:"number,omitempty"` // value display: currency | number | d3-format spec
+	Like   string        `yaml:"like,omitempty" json:"like,omitempty"`     // mirror another column's coloring + per-row value
+	Format []FormatLayer `yaml:"format,omitempty" json:"format,omitempty"` // ordered style layers; first match wins
 }
 
 // Condition operators for conditional-formatting rules.
@@ -252,16 +176,22 @@ const (
 	CondIsNotBetween       = "is_not_between"
 )
 
-// FormatRule applies a fixed style to cells matching a condition.
-type FormatRule struct {
-	If              string `yaml:"if" json:"if"`
-	Value           any    `yaml:"value,omitempty" json:"value,omitempty"`
-	BackgroundColor string `yaml:"backgroundColor,omitempty" json:"backgroundColor,omitempty"`
-	TextColor       string `yaml:"textColor,omitempty" json:"textColor,omitempty"`
-	Bold            bool   `yaml:"bold,omitempty" json:"bold,omitempty"`
-	Italic          bool   `yaml:"italic,omitempty" json:"italic,omitempty"`
-	Underline       bool   `yaml:"underline,omitempty" json:"underline,omitempty"`
-	Strikethrough   bool   `yaml:"strikethrough,omitempty" json:"strikethrough,omitempty"`
+// FormatLayer is one entry in a column's ordered `format` list; the first
+// layer that matches a cell wins. A layer with `If` set is a condition (applies
+// to matching cells). A layer without `If` always applies — a gradient (array
+// backgroundColor, optional range/unit) or a flat fill (string backgroundColor);
+// place it last as the fallback base.
+type FormatLayer struct {
+	If              string    `yaml:"if,omitempty" json:"if,omitempty"`
+	Value           any       `yaml:"value,omitempty" json:"value,omitempty"`                    // scalar, [low, high], or {column: X}
+	BackgroundColor any       `yaml:"backgroundColor,omitempty" json:"backgroundColor,omitempty"` // string (flat/single) | []string (gradient)
+	Range           []float64 `yaml:"range,omitempty" json:"range,omitempty"`                    // gradient anchors, paired with Unit
+	Unit            string    `yaml:"unit,omitempty" json:"unit,omitempty"`                      // absolute | percent | percentile
+	TextColor       string    `yaml:"textColor,omitempty" json:"textColor,omitempty"`
+	Bold            bool      `yaml:"bold,omitempty" json:"bold,omitempty"`
+	Italic          bool      `yaml:"italic,omitempty" json:"italic,omitempty"`
+	Underline       bool      `yaml:"underline,omitempty" json:"underline,omitempty"`
+	Strikethrough   bool      `yaml:"strikethrough,omitempty" json:"strikethrough,omitempty"`
 }
 
 // WidgetData holds inline result data for a widget so it can render without a

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -24,16 +24,15 @@ const (
 
 // Dashboard represents a complete dashboard definition loaded from YAML.
 type Dashboard struct {
-	Schema      string              `yaml:"schema,omitempty" json:"schema,omitempty"`
-	Name        string              `yaml:"name" json:"name"`
-	Description string              `yaml:"description,omitempty" json:"description,omitempty"`
-	Connection  string              `yaml:"connection,omitempty" json:"connection,omitempty"`
-	Model       string              `yaml:"model,omitempty" json:"model,omitempty"`
-	Models      map[string]string   `yaml:"models,omitempty" json:"models,omitempty"`
-	Filters     []Filter            `yaml:"filters,omitempty" json:"filters,omitempty"`
-	Queries     map[string]Query    `yaml:"queries,omitempty" json:"queries,omitempty"`
-	Palettes    map[string][]string `yaml:"palettes,omitempty" json:"palettes,omitempty"`
-	Rows        []Row               `yaml:"rows" json:"rows"`
+	Schema      string            `yaml:"schema,omitempty" json:"schema,omitempty"`
+	Name        string            `yaml:"name" json:"name"`
+	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Connection  string            `yaml:"connection,omitempty" json:"connection,omitempty"`
+	Model       string            `yaml:"model,omitempty" json:"model,omitempty"`
+	Models      map[string]string `yaml:"models,omitempty" json:"models,omitempty"`
+	Filters     []Filter          `yaml:"filters,omitempty" json:"filters,omitempty"`
+	Queries     map[string]Query  `yaml:"queries,omitempty" json:"queries,omitempty"`
+	Rows        []Row             `yaml:"rows" json:"rows"`
 
 	// FilePath is the source file path, not serialized to JSON for API consumers.
 	FilePath string `yaml:"-" json:"-"`

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -183,10 +183,10 @@ const (
 // place it last as the fallback base.
 type FormatLayer struct {
 	If              string    `yaml:"if,omitempty" json:"if,omitempty"`
-	Value           any       `yaml:"value,omitempty" json:"value,omitempty"`                    // scalar, [low, high], or {column: X}
+	Value           any       `yaml:"value,omitempty" json:"value,omitempty"`                     // scalar, [low, high], or {column: X}
 	BackgroundColor any       `yaml:"backgroundColor,omitempty" json:"backgroundColor,omitempty"` // string (flat/single) | []string (gradient)
-	Range           []float64 `yaml:"range,omitempty" json:"range,omitempty"`                    // gradient anchors, paired with Unit
-	Unit            string    `yaml:"unit,omitempty" json:"unit,omitempty"`                      // absolute | percent | percentile
+	Range           []float64 `yaml:"range,omitempty" json:"range,omitempty"`                     // gradient anchors, paired with Unit
+	Unit            string    `yaml:"unit,omitempty" json:"unit,omitempty"`                       // absolute | percent | percentile
 	TextColor       string    `yaml:"textColor,omitempty" json:"textColor,omitempty"`
 	Bold            bool      `yaml:"bold,omitempty" json:"bold,omitempty"`
 	Italic          bool      `yaml:"italic,omitempty" json:"italic,omitempty"`

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -46,21 +46,6 @@ func Validate(d *Dashboard) error {
 		errs = append(errs, "at least one row is required")
 	}
 
-	// Custom palettes: each is a reusable gradient, referenced by name via
-	// `format.scheme`.
-	for name, colors := range d.Palettes {
-		if name == "" {
-			errs = append(errs, "palettes: a palette name cannot be empty")
-			continue
-		}
-		if _, ok := validSchemes[name]; ok {
-			errs = append(errs, fmt.Sprintf("palettes: %q collides with a built-in scheme; pick a different name", name))
-		}
-		if len(colors) < 2 {
-			errs = append(errs, fmt.Sprintf("palettes: %q needs at least 2 colors to form a gradient", name))
-		}
-	}
-
 	for i, row := range d.Rows {
 		if len(row.Widgets) == 0 {
 			errs = append(errs, fmt.Sprintf("row %d: at least one widget is required", i+1))
@@ -88,7 +73,7 @@ func Validate(d *Dashboard) error {
 			case WidgetTypeTable:
 				// Table widgets just need a query source.
 				errs = append(errs, validateQuerySource(prefix, &w, d)...)
-				validateTableColumns(prefix, &w, d.Palettes, &errs)
+				validateTableColumns(prefix, &w, &errs)
 			case WidgetTypeText:
 				if w.Content == "" {
 					errs = append(errs, fmt.Sprintf("%s: content is required for text widgets", prefix))
@@ -480,7 +465,7 @@ var validSchemes = map[string]int{
 	"white-green": 2, "white-red": 2, "white-blue": 2,
 }
 
-func validateTableColumns(prefix string, w *Widget, palettes map[string][]string, errs *[]string) {
+func validateTableColumns(prefix string, w *Widget, errs *[]string) {
 	names := make(map[string]bool, len(w.Columns))
 	for _, c := range w.Columns {
 		names[c.Name] = true
@@ -497,16 +482,14 @@ func validateTableColumns(prefix string, w *Widget, palettes map[string][]string
 				*errs = append(*errs, fmt.Sprintf("%s.format.like: references unknown column %q", cp, c.Format.Like))
 			}
 		}
-		validateFormat(cp, c.Format, palettes, errs)
+		validateFormat(cp, c.Format, errs)
 	}
 }
 
-func validateFormat(prefix string, f *Format, palettes map[string][]string, errs *[]string) {
+func validateFormat(prefix string, f *Format, errs *[]string) {
 	if f.Scheme != "" {
-		_, isBuiltin := validSchemes[f.Scheme]
-		_, isPalette := palettes[f.Scheme]
-		if !isBuiltin && !isPalette {
-			*errs = append(*errs, fmt.Sprintf("%s.format.scheme: unknown scheme %q (not a built-in or a defined palette)", prefix, f.Scheme))
+		if _, ok := validSchemes[f.Scheme]; !ok {
+			*errs = append(*errs, fmt.Sprintf("%s.format.scheme: unknown scheme %q", prefix, f.Scheme))
 		}
 	}
 	// A gradient (array backgroundColor) needs at least two colors to blend.
@@ -514,14 +497,14 @@ func validateFormat(prefix string, f *Format, palettes map[string][]string, errs
 		*errs = append(*errs, fmt.Sprintf("%s.format.backgroundColor: a gradient needs at least 2 colors (use a single string for a flat fill)", prefix))
 	}
 	if f.Domain != nil {
-		validateDomain(prefix, f, palettes, errs)
+		validateDomain(prefix, f, errs)
 	}
 	for i, r := range f.Rules {
 		validateFormatRule(fmt.Sprintf("%s.format.rules[%d]", prefix, i), r, errs)
 	}
 }
 
-func validateDomain(prefix string, f *Format, palettes map[string][]string, errs *[]string) {
+func validateDomain(prefix string, f *Format, errs *[]string) {
 	d := f.Domain
 	// unit must be a known kind.
 	if d.Unit != "" && d.Unit != "value" && d.Unit != "percent" && d.Unit != "percentile" {
@@ -537,16 +520,14 @@ func validateDomain(prefix string, f *Format, palettes map[string][]string, errs
 		}
 	}
 	// A domain pins the anchors of a gradient, whose colors come from an explicit
-	// backgroundColor array, a built-in scheme, or a custom palette.
+	// backgroundColor array or a built-in scheme.
 	colorCount := 0
 	if colors, ok := f.BackgroundColor.([]interface{}); ok {
 		colorCount = len(colors)
 	} else if c, ok := validSchemes[f.Scheme]; ok {
 		colorCount = c
-	} else if p, ok := palettes[f.Scheme]; ok {
-		colorCount = len(p)
 	} else {
-		*errs = append(*errs, fmt.Sprintf("%s.format.domain: requires a gradient (a backgroundColor list, a scheme, or a palette)", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s.format.domain: requires a gradient (a backgroundColor list or a scheme)", prefix))
 		return
 	}
 	// When explicit anchors are given they must match the gradient's color count.

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -73,6 +73,7 @@ func Validate(d *Dashboard) error {
 			case WidgetTypeTable:
 				// Table widgets just need a query source.
 				errs = append(errs, validateQuerySource(prefix, &w, d)...)
+				validateTableColumns(prefix, &w, &errs)
 			case WidgetTypeText:
 				if w.Content == "" {
 					errs = append(errs, fmt.Sprintf("%s: content is required for text widgets", prefix))
@@ -444,4 +445,101 @@ func validateSemanticJob(job *SemanticJob) error {
 	}
 	_, err = engine.GenerateSQL(&job.Query)
 	return err
+}
+
+var validSingleColorOps = map[string]bool{
+	CondIsEmpty: true, CondIsNotEmpty: true,
+	CondTextContains: true, CondTextNotContains: true, CondTextStartsWith: true,
+	CondTextEndsWith: true, CondTextIsExactly: true,
+	CondDateIs: true, CondDateBefore: true, CondDateAfter: true,
+	CondGreaterThan: true, CondGreaterThanOrEqual: true, CondLessThan: true,
+	CondLessThanOrEqual: true, CondIsEqualTo: true, CondIsNotEqualTo: true,
+	CondIsBetween: true, CondIsNotBetween: true,
+}
+
+func validateTableColumns(prefix string, w *Widget, errs *[]string) {
+	for _, c := range w.Columns {
+		cp := fmt.Sprintf("%s: column %q", prefix, c.Name)
+		if cs := c.ColorScale; cs != nil {
+			// The min stop may not use type "max" and the max stop may not use
+			// type "min"; the mid stop is number/percent/percentile only.
+			validateColorStop(cp, "min", cs.Min, []string{StopTypeMin, StopTypeNumber, StopTypePercent, StopTypePercentile}, StopTypeMin, errs)
+			validateColorStop(cp, "mid", cs.Mid, []string{StopTypeNumber, StopTypePercent, StopTypePercentile}, StopTypePercentile, errs)
+			validateColorStop(cp, "max", cs.Max, []string{StopTypeMax, StopTypeNumber, StopTypePercent, StopTypePercentile}, StopTypeMax, errs)
+		}
+		for i, r := range c.SingleColor {
+			validateSingleColorRule(fmt.Sprintf("%s singleColor[%d]", cp, i), r, errs)
+		}
+	}
+}
+
+func validateColorStop(prefix, role string, stop *ColorStop, allowed []string, defaultType string, errs *[]string) {
+	if stop == nil {
+		return
+	}
+	if stop.Type != "" && !containsString(allowed, stop.Type) {
+		*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: type %q not allowed (expected one of: %s)", prefix, role, stop.Type, strings.Join(allowed, ", ")))
+		return
+	}
+	eff := stop.Type
+	if eff == "" {
+		eff = defaultType
+	}
+	switch eff {
+	case StopTypeMin, StopTypeMax:
+		if stop.Value != nil {
+			*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: value is not allowed for type %q", prefix, role, eff))
+		}
+	case StopTypeNumber:
+		if stop.Type != "" && stop.Value == nil {
+			*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: value is required for type %q", prefix, role, eff))
+		}
+	case StopTypePercent, StopTypePercentile:
+		if stop.Type != "" && stop.Value == nil {
+			*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: value is required for type %q", prefix, role, eff))
+		}
+		if stop.Value != nil && (*stop.Value < 0 || *stop.Value > 100) {
+			*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: %s value must be between 0 and 100", prefix, role, eff))
+		}
+	}
+}
+
+func validateSingleColorRule(prefix string, r SingleColorRule, errs *[]string) {
+	if r.If == "" {
+		*errs = append(*errs, fmt.Sprintf("%s: if (operator) is required", prefix))
+		return
+	}
+	if !validSingleColorOps[r.If] {
+		*errs = append(*errs, fmt.Sprintf("%s: unknown operator %q", prefix, r.If))
+		return
+	}
+	switch r.If {
+	case CondIsEmpty, CondIsNotEmpty:
+		// No value expected.
+	case CondIsBetween, CondIsNotBetween:
+		if !isPairValue(r.Value) {
+			*errs = append(*errs, fmt.Sprintf("%s: %q requires a two-element value list [low, high]", prefix, r.If))
+		}
+	default:
+		if r.Value == nil {
+			*errs = append(*errs, fmt.Sprintf("%s: %q requires a value", prefix, r.If))
+		}
+	}
+	if !r.Bold && !r.Italic && !r.Underline && !r.Strikethrough && r.TextColor == "" && r.Background == "" {
+		*errs = append(*errs, fmt.Sprintf("%s: at least one style (background, textColor, bold, italic, underline, strikethrough) is required", prefix))
+	}
+}
+
+func isPairValue(v any) bool {
+	arr, ok := v.([]interface{})
+	return ok && len(arr) == 2
+}
+
+func containsString(list []string, s string) bool {
+	for _, item := range list {
+		if item == s {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -46,6 +46,21 @@ func Validate(d *Dashboard) error {
 		errs = append(errs, "at least one row is required")
 	}
 
+	// Custom palettes: each is a reusable gradient, referenced by name via
+	// `format.scheme`.
+	for name, colors := range d.Palettes {
+		if name == "" {
+			errs = append(errs, "palettes: a palette name cannot be empty")
+			continue
+		}
+		if _, ok := validSchemes[name]; ok {
+			errs = append(errs, fmt.Sprintf("palettes: %q collides with a built-in scheme; pick a different name", name))
+		}
+		if len(colors) < 2 {
+			errs = append(errs, fmt.Sprintf("palettes: %q needs at least 2 colors to form a gradient", name))
+		}
+	}
+
 	for i, row := range d.Rows {
 		if len(row.Widgets) == 0 {
 			errs = append(errs, fmt.Sprintf("row %d: at least one widget is required", i+1))
@@ -73,7 +88,7 @@ func Validate(d *Dashboard) error {
 			case WidgetTypeTable:
 				// Table widgets just need a query source.
 				errs = append(errs, validateQuerySource(prefix, &w, d)...)
-				validateTableColumns(prefix, &w, &errs)
+				validateTableColumns(prefix, &w, d.Palettes, &errs)
 			case WidgetTypeText:
 				if w.Content == "" {
 					errs = append(errs, fmt.Sprintf("%s: content is required for text widgets", prefix))
@@ -447,7 +462,7 @@ func validateSemanticJob(job *SemanticJob) error {
 	return err
 }
 
-var validSingleColorOps = map[string]bool{
+var validFormatOps = map[string]bool{
 	CondIsEmpty: true, CondIsNotEmpty: true,
 	CondTextContains: true, CondTextNotContains: true, CondTextStartsWith: true,
 	CondTextEndsWith: true, CondTextIsExactly: true,
@@ -457,59 +472,95 @@ var validSingleColorOps = map[string]bool{
 	CondIsBetween: true, CondIsNotBetween: true,
 }
 
-func validateTableColumns(prefix string, w *Widget, errs *[]string) {
+// validSchemes maps each built-in gradient to its color count, so a domain's
+// value count can be checked against the gradient it anchors.
+var validSchemes = map[string]int{
+	"red-white-green": 3, "green-white-red": 3,
+	"red-amber-green": 3, "green-amber-red": 3,
+	"white-green": 2, "white-red": 2, "white-blue": 2,
+}
+
+func validateTableColumns(prefix string, w *Widget, palettes map[string][]string, errs *[]string) {
+	names := make(map[string]bool, len(w.Columns))
 	for _, c := range w.Columns {
+		names[c.Name] = true
+	}
+	for _, c := range w.Columns {
+		if c.Format == nil {
+			continue
+		}
 		cp := fmt.Sprintf("%s: column %q", prefix, c.Name)
-		if cs := c.ColorScale; cs != nil {
-			// The min stop may not use type "max" and the max stop may not use
-			// type "min"; the mid stop is number/percent/percentile only.
-			validateColorStop(cp, "min", cs.Min, []string{StopTypeMin, StopTypeNumber, StopTypePercent, StopTypePercentile}, StopTypeMin, errs)
-			validateColorStop(cp, "mid", cs.Mid, []string{StopTypeNumber, StopTypePercent, StopTypePercentile}, StopTypePercentile, errs)
-			validateColorStop(cp, "max", cs.Max, []string{StopTypeMax, StopTypeNumber, StopTypePercent, StopTypePercentile}, StopTypeMax, errs)
+		if c.Format.Like != "" {
+			if c.Format.Like == c.Name {
+				*errs = append(*errs, cp+".format.like: cannot reference itself")
+			} else if !names[c.Format.Like] {
+				*errs = append(*errs, fmt.Sprintf("%s.format.like: references unknown column %q", cp, c.Format.Like))
+			}
 		}
-		for i, r := range c.SingleColor {
-			validateSingleColorRule(fmt.Sprintf("%s singleColor[%d]", cp, i), r, errs)
-		}
+		validateFormat(cp, c.Format, palettes, errs)
 	}
 }
 
-func validateColorStop(prefix, role string, stop *ColorStop, allowed []string, defaultType string, errs *[]string) {
-	if stop == nil {
-		return
+func validateFormat(prefix string, f *Format, palettes map[string][]string, errs *[]string) {
+	if f.Scheme != "" {
+		_, isBuiltin := validSchemes[f.Scheme]
+		_, isPalette := palettes[f.Scheme]
+		if !isBuiltin && !isPalette {
+			*errs = append(*errs, fmt.Sprintf("%s.format.scheme: unknown scheme %q (not a built-in or a defined palette)", prefix, f.Scheme))
+		}
 	}
-	if stop.Type != "" && !containsString(allowed, stop.Type) {
-		*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: type %q not allowed (expected one of: %s)", prefix, role, stop.Type, strings.Join(allowed, ", ")))
-		return
+	// A gradient (array backgroundColor) needs at least two colors to blend.
+	if colors, ok := f.BackgroundColor.([]interface{}); ok && len(colors) < 2 {
+		*errs = append(*errs, fmt.Sprintf("%s.format.backgroundColor: a gradient needs at least 2 colors (use a single string for a flat fill)", prefix))
 	}
-	eff := stop.Type
-	if eff == "" {
-		eff = defaultType
+	if f.Domain != nil {
+		validateDomain(prefix, f, palettes, errs)
 	}
-	switch eff {
-	case StopTypeMin, StopTypeMax:
-		if stop.Value != nil {
-			*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: value is not allowed for type %q", prefix, role, eff))
-		}
-	case StopTypeNumber:
-		if stop.Type != "" && stop.Value == nil {
-			*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: value is required for type %q", prefix, role, eff))
-		}
-	case StopTypePercent, StopTypePercentile:
-		if stop.Type != "" && stop.Value == nil {
-			*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: value is required for type %q", prefix, role, eff))
-		}
-		if stop.Value != nil && (*stop.Value < 0 || *stop.Value > 100) {
-			*errs = append(*errs, fmt.Sprintf("%s.colorScale.%s: %s value must be between 0 and 100", prefix, role, eff))
-		}
+	for i, r := range f.Rules {
+		validateFormatRule(fmt.Sprintf("%s.format.rules[%d]", prefix, i), r, errs)
 	}
 }
 
-func validateSingleColorRule(prefix string, r SingleColorRule, errs *[]string) {
+func validateDomain(prefix string, f *Format, palettes map[string][]string, errs *[]string) {
+	d := f.Domain
+	// unit must be a known kind.
+	if d.Unit != "" && d.Unit != "value" && d.Unit != "percent" && d.Unit != "percentile" {
+		*errs = append(*errs, fmt.Sprintf("%s.format.domain.unit: unknown unit %q (expected value, percent, or percentile)", prefix, d.Unit))
+	}
+	// percent/percentile anchors are 0–100.
+	if d.Unit == "percent" || d.Unit == "percentile" {
+		for _, v := range d.Anchors {
+			if v < 0 || v > 100 {
+				*errs = append(*errs, fmt.Sprintf("%s.format.domain: %s anchors must be between 0 and 100", prefix, d.Unit))
+				break
+			}
+		}
+	}
+	// A domain pins the anchors of a gradient, whose colors come from an explicit
+	// backgroundColor array, a built-in scheme, or a custom palette.
+	colorCount := 0
+	if colors, ok := f.BackgroundColor.([]interface{}); ok {
+		colorCount = len(colors)
+	} else if c, ok := validSchemes[f.Scheme]; ok {
+		colorCount = c
+	} else if p, ok := palettes[f.Scheme]; ok {
+		colorCount = len(p)
+	} else {
+		*errs = append(*errs, fmt.Sprintf("%s.format.domain: requires a gradient (a backgroundColor list, a scheme, or a palette)", prefix))
+		return
+	}
+	// When explicit anchors are given they must match the gradient's color count.
+	if len(d.Anchors) > 0 && len(d.Anchors) != colorCount {
+		*errs = append(*errs, fmt.Sprintf("%s.format.domain: has %d anchors but the gradient has %d colors (must match)", prefix, len(d.Anchors), colorCount))
+	}
+}
+
+func validateFormatRule(prefix string, r FormatRule, errs *[]string) {
 	if r.If == "" {
 		*errs = append(*errs, fmt.Sprintf("%s: if (operator) is required", prefix))
 		return
 	}
-	if !validSingleColorOps[r.If] {
+	if !validFormatOps[r.If] {
 		*errs = append(*errs, fmt.Sprintf("%s: unknown operator %q", prefix, r.If))
 		return
 	}
@@ -525,21 +576,12 @@ func validateSingleColorRule(prefix string, r SingleColorRule, errs *[]string) {
 			*errs = append(*errs, fmt.Sprintf("%s: %q requires a value", prefix, r.If))
 		}
 	}
-	if !r.Bold && !r.Italic && !r.Underline && !r.Strikethrough && r.TextColor == "" && r.Background == "" {
-		*errs = append(*errs, fmt.Sprintf("%s: at least one style (background, textColor, bold, italic, underline, strikethrough) is required", prefix))
+	if !r.Bold && !r.Italic && !r.Underline && !r.Strikethrough && r.TextColor == "" && r.BackgroundColor == "" {
+		*errs = append(*errs, fmt.Sprintf("%s: at least one style (backgroundColor, textColor, bold, italic, underline, strikethrough) is required", prefix))
 	}
 }
 
 func isPairValue(v any) bool {
 	arr, ok := v.([]interface{})
 	return ok && len(arr) == 2
-}
-
-func containsString(list []string, s string) bool {
-	for _, item := range list {
-		if item == s {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -457,108 +457,78 @@ var validFormatOps = map[string]bool{
 	CondIsBetween: true, CondIsNotBetween: true,
 }
 
-// validSchemes maps each built-in gradient to its color count, so a domain's
-// value count can be checked against the gradient it anchors.
-var validSchemes = map[string]int{
-	"red-white-green": 3, "green-white-red": 3,
-	"red-amber-green": 3, "green-amber-red": 3,
-	"white-green": 2, "white-red": 2, "white-blue": 2,
-}
-
 func validateTableColumns(prefix string, w *Widget, errs *[]string) {
 	names := make(map[string]bool, len(w.Columns))
 	for _, c := range w.Columns {
 		names[c.Name] = true
 	}
 	for _, c := range w.Columns {
-		if c.Format == nil {
-			continue
-		}
 		cp := fmt.Sprintf("%s: column %q", prefix, c.Name)
-		if c.Format.Like != "" {
-			if c.Format.Like == c.Name {
-				*errs = append(*errs, cp+".format.like: cannot reference itself")
-			} else if !names[c.Format.Like] {
-				*errs = append(*errs, fmt.Sprintf("%s.format.like: references unknown column %q", cp, c.Format.Like))
+		if c.Like != "" {
+			if c.Like == c.Name {
+				*errs = append(*errs, cp+".like: cannot reference itself")
+			} else if !names[c.Like] {
+				*errs = append(*errs, fmt.Sprintf("%s.like: references unknown column %q", cp, c.Like))
 			}
 		}
-		validateFormat(cp, c.Format, errs)
-	}
-}
-
-func validateFormat(prefix string, f *Format, errs *[]string) {
-	if f.Scheme != "" {
-		if _, ok := validSchemes[f.Scheme]; !ok {
-			*errs = append(*errs, fmt.Sprintf("%s.format.scheme: unknown scheme %q", prefix, f.Scheme))
+		for i, layer := range c.Format {
+			validateFormatLayer(fmt.Sprintf("%s.format[%d]", cp, i), layer, errs)
 		}
 	}
-	// A gradient (array backgroundColor) needs at least two colors to blend.
-	if colors, ok := f.BackgroundColor.([]interface{}); ok && len(colors) < 2 {
-		*errs = append(*errs, fmt.Sprintf("%s.format.backgroundColor: a gradient needs at least 2 colors (use a single string for a flat fill)", prefix))
-	}
-	if f.Domain != nil {
-		validateDomain(prefix, f, errs)
-	}
-	for i, r := range f.Rules {
-		validateFormatRule(fmt.Sprintf("%s.format.rules[%d]", prefix, i), r, errs)
-	}
 }
 
-func validateDomain(prefix string, f *Format, errs *[]string) {
-	d := f.Domain
-	// unit must be a known kind.
-	if d.Unit != "" && d.Unit != "value" && d.Unit != "percent" && d.Unit != "percentile" {
-		*errs = append(*errs, fmt.Sprintf("%s.format.domain.unit: unknown unit %q (expected value, percent, or percentile)", prefix, d.Unit))
-	}
-	// percent/percentile anchors are 0–100.
-	if d.Unit == "percent" || d.Unit == "percentile" {
-		for _, v := range d.Anchors {
-			if v < 0 || v > 100 {
-				*errs = append(*errs, fmt.Sprintf("%s.format.domain: %s anchors must be between 0 and 100", prefix, d.Unit))
-				break
+// validateFormatLayer checks one entry of a column's `format` list. A layer is
+// either a condition (`if` set) or a base gradient/flat fill (no `if`).
+func validateFormatLayer(prefix string, l FormatLayer, errs *[]string) {
+	if l.If != "" {
+		if !validFormatOps[l.If] {
+			*errs = append(*errs, fmt.Sprintf("%s.if: unknown operator %q", prefix, l.If))
+		} else {
+			switch l.If {
+			case CondIsEmpty, CondIsNotEmpty:
+				// No value expected.
+			case CondIsBetween, CondIsNotBetween:
+				if !isPairValue(l.Value) {
+					*errs = append(*errs, fmt.Sprintf("%s: %q requires a two-element value list [low, high]", prefix, l.If))
+				}
+			default:
+				if l.Value == nil {
+					*errs = append(*errs, fmt.Sprintf("%s: %q requires a value", prefix, l.If))
+				}
 			}
 		}
 	}
-	// A domain pins the anchors of a gradient, whose colors come from an explicit
-	// backgroundColor array or a built-in scheme.
-	colorCount := 0
-	if colors, ok := f.BackgroundColor.([]interface{}); ok {
-		colorCount = len(colors)
-	} else if c, ok := validSchemes[f.Scheme]; ok {
-		colorCount = c
-	} else {
-		*errs = append(*errs, fmt.Sprintf("%s.format.domain: requires a gradient (a backgroundColor list or a scheme)", prefix))
-		return
-	}
-	// When explicit anchors are given they must match the gradient's color count.
-	if len(d.Anchors) > 0 && len(d.Anchors) != colorCount {
-		*errs = append(*errs, fmt.Sprintf("%s.format.domain: has %d anchors but the gradient has %d colors (must match)", prefix, len(d.Anchors), colorCount))
-	}
-}
 
-func validateFormatRule(prefix string, r FormatRule, errs *[]string) {
-	if r.If == "" {
-		*errs = append(*errs, fmt.Sprintf("%s: if (operator) is required", prefix))
-		return
+	// A gradient is an array backgroundColor (needs >= 2 colors); a string is a flat/single fill.
+	colors, isGradient := l.BackgroundColor.([]interface{})
+	if isGradient && len(colors) < 2 {
+		*errs = append(*errs, fmt.Sprintf("%s.backgroundColor: a gradient needs at least 2 colors (use a single string for a flat fill)", prefix))
 	}
-	if !validFormatOps[r.If] {
-		*errs = append(*errs, fmt.Sprintf("%s: unknown operator %q", prefix, r.If))
-		return
-	}
-	switch r.If {
-	case CondIsEmpty, CondIsNotEmpty:
-		// No value expected.
-	case CondIsBetween, CondIsNotBetween:
-		if !isPairValue(r.Value) {
-			*errs = append(*errs, fmt.Sprintf("%s: %q requires a two-element value list [low, high]", prefix, r.If))
+
+	// range/unit describe a gradient's anchors and only apply to a gradient.
+	if len(l.Range) > 0 || l.Unit != "" {
+		if !isGradient {
+			*errs = append(*errs, fmt.Sprintf("%s.range: requires a gradient (a backgroundColor list)", prefix))
+		} else {
+			if l.Unit != "" && l.Unit != "absolute" && l.Unit != "percent" && l.Unit != "percentile" {
+				*errs = append(*errs, fmt.Sprintf("%s.unit: unknown unit %q (expected absolute, percent, or percentile)", prefix, l.Unit))
+			}
+			if len(l.Range) > 0 && len(l.Range) != len(colors) {
+				*errs = append(*errs, fmt.Sprintf("%s.range: has %d anchors but the gradient has %d colors (must match)", prefix, len(l.Range), len(colors)))
+			}
+			if l.Unit == "percent" || l.Unit == "percentile" {
+				for _, v := range l.Range {
+					if v < 0 || v > 100 {
+						*errs = append(*errs, fmt.Sprintf("%s.range: %s anchors must be between 0 and 100", prefix, l.Unit))
+						break
+					}
+				}
+			}
 		}
-	default:
-		if r.Value == nil {
-			*errs = append(*errs, fmt.Sprintf("%s: %q requires a value", prefix, r.If))
-		}
 	}
-	if !r.Bold && !r.Italic && !r.Underline && !r.Strikethrough && r.TextColor == "" && r.BackgroundColor == "" {
-		*errs = append(*errs, fmt.Sprintf("%s: at least one style (backgroundColor, textColor, bold, italic, underline, strikethrough) is required", prefix))
+
+	if !l.Bold && !l.Italic && !l.Underline && !l.Strikethrough && l.TextColor == "" && l.BackgroundColor == nil {
+		*errs = append(*errs, fmt.Sprintf("%s: a layer needs at least one style (backgroundColor, textColor, bold, italic, underline, strikethrough)", prefix))
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -44,8 +44,8 @@ func TestListDashboards(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
 	}
-	// 5 YAML + 2 TSX = 7
-	assertEqual(t, len(resp.Dashboards), 7)
+	// 6 YAML + 2 TSX = 8
+	assertEqual(t, len(resp.Dashboards), 8)
 }
 
 func TestGetDashboard(t *testing.T) {

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -445,8 +445,15 @@
         "label": {
           "type": "string"
         },
+        "number": {
+          "type": "string"
+        },
+        "like": {
+          "type": "string"
+        },
         "format": {
-          "$ref": "#/$defs/format"
+          "type": "array",
+          "items": { "$ref": "#/$defs/formatLayer" }
         }
       },
       "patternProperties": {
@@ -454,73 +461,8 @@
       },
       "additionalProperties": false
     },
-    "format": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "like": {
-              "type": "string"
-            },
-            "number": {
-              "type": "string"
-            },
-            "backgroundColor": {
-              "oneOf": [
-                { "type": "string" },
-                { "type": "array", "items": { "type": "string" } }
-              ]
-            },
-            "textColor": {
-              "type": "string"
-            },
-            "bold": { "type": "boolean" },
-            "italic": { "type": "boolean" },
-            "underline": { "type": "boolean" },
-            "strikethrough": { "type": "boolean" },
-            "domain": {
-              "oneOf": [
-                { "type": "array", "items": { "type": "number" } },
-                {
-                  "type": "object",
-                  "properties": {
-                    "unit": { "enum": ["value", "percent", "percentile"] },
-                    "anchors": { "type": "array", "items": { "type": "number" } }
-                  },
-                  "patternProperties": { "^x-": true },
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "scheme": {
-              "enum": [
-                "red-white-green",
-                "green-white-red",
-                "red-amber-green",
-                "green-amber-red",
-                "white-green",
-                "white-red",
-                "white-blue"
-              ]
-            },
-            "rules": {
-              "type": "array",
-              "items": { "$ref": "#/$defs/formatRule" }
-            }
-          },
-          "patternProperties": {
-            "^x-": true
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "formatRule": {
+    "formatLayer": {
       "type": "object",
-      "required": ["if"],
       "properties": {
         "if": {
           "enum": [
@@ -545,16 +487,21 @@
           ]
         },
         "value": true,
-        "bold": { "type": "boolean" },
-        "italic": { "type": "boolean" },
-        "underline": { "type": "boolean" },
-        "strikethrough": { "type": "boolean" },
+        "backgroundColor": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        },
+        "range": { "type": "array", "items": { "type": "number" } },
+        "unit": { "enum": ["absolute", "percent", "percentile"] },
         "textColor": {
           "type": "string"
         },
-        "backgroundColor": {
-          "type": "string"
-        }
+        "bold": { "type": "boolean" },
+        "italic": { "type": "boolean" },
+        "underline": { "type": "boolean" },
+        "strikethrough": { "type": "boolean" }
       },
       "patternProperties": {
         "^x-": true

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -447,6 +447,109 @@
         },
         "format": {
           "type": "string"
+        },
+        "colorScale": {
+          "$ref": "#/$defs/colorScale"
+        },
+        "singleColor": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/singleColorRule"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": true
+      },
+      "additionalProperties": false
+    },
+    "colorScale": {
+      "type": "object",
+      "properties": {
+        "min": {
+          "$ref": "#/$defs/colorStop"
+        },
+        "mid": {
+          "$ref": "#/$defs/colorStop"
+        },
+        "max": {
+          "$ref": "#/$defs/colorStop"
+        }
+      },
+      "patternProperties": {
+        "^x-": true
+      },
+      "additionalProperties": false
+    },
+    "colorStop": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": ["min", "max", "number", "percent", "percentile"]
+            },
+            "value": {
+              "type": "number"
+            },
+            "color": {
+              "type": "string"
+            }
+          },
+          "patternProperties": {
+            "^x-": true
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "singleColorRule": {
+      "type": "object",
+      "required": ["if"],
+      "properties": {
+        "if": {
+          "enum": [
+            "is_empty",
+            "is_not_empty",
+            "text_contains",
+            "text_does_not_contain",
+            "text_starts_with",
+            "text_ends_with",
+            "text_is_exactly",
+            "date_is",
+            "date_before",
+            "date_after",
+            "greater_than",
+            "greater_than_or_equal",
+            "less_than",
+            "less_than_or_equal",
+            "is_equal_to",
+            "is_not_equal_to",
+            "is_between",
+            "is_not_between"
+          ]
+        },
+        "value": true,
+        "bold": {
+          "type": "boolean"
+        },
+        "italic": {
+          "type": "boolean"
+        },
+        "underline": {
+          "type": "boolean"
+        },
+        "strikethrough": {
+          "type": "boolean"
+        },
+        "textColor": {
+          "type": "string"
+        },
+        "background": {
+          "type": "string"
         }
       },
       "patternProperties": {

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -39,15 +39,6 @@
         "$ref": "#/$defs/query"
       }
     },
-    "palettes": {
-      "type": "object",
-      "description": "Reusable named gradients. A column references one with format.scheme: <name>.",
-      "additionalProperties": {
-        "type": "array",
-        "items": { "type": "string" },
-        "minItems": 2
-      }
-    },
     "rows": {
       "type": "array",
       "minItems": 1,
@@ -505,9 +496,15 @@
               ]
             },
             "scheme": {
-              "type": "string",
-              "description": "A built-in gradient (red-white-green, green-white-red, red-amber-green, green-amber-red, white-green, white-red, white-blue) or the name of a dashboard-level custom palette. Validated against known names by dac validate.",
-              "minLength": 1
+              "enum": [
+                "red-white-green",
+                "green-white-red",
+                "red-amber-green",
+                "green-amber-red",
+                "white-green",
+                "white-red",
+                "white-blue"
+              ]
             },
             "rules": {
               "type": "array",

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -39,6 +39,15 @@
         "$ref": "#/$defs/query"
       }
     },
+    "palettes": {
+      "type": "object",
+      "description": "Reusable named gradients. A column references one with format.scheme: <name>.",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" },
+        "minItems": 2
+      }
+    },
     "rows": {
       "type": "array",
       "minItems": 1,
@@ -446,16 +455,7 @@
           "type": "string"
         },
         "format": {
-          "type": "string"
-        },
-        "colorScale": {
-          "$ref": "#/$defs/colorScale"
-        },
-        "singleColor": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/singleColorRule"
-          }
+          "$ref": "#/$defs/format"
         }
       },
       "patternProperties": {
@@ -463,25 +463,7 @@
       },
       "additionalProperties": false
     },
-    "colorScale": {
-      "type": "object",
-      "properties": {
-        "min": {
-          "$ref": "#/$defs/colorStop"
-        },
-        "mid": {
-          "$ref": "#/$defs/colorStop"
-        },
-        "max": {
-          "$ref": "#/$defs/colorStop"
-        }
-      },
-      "patternProperties": {
-        "^x-": true
-      },
-      "additionalProperties": false
-    },
-    "colorStop": {
+    "format": {
       "oneOf": [
         {
           "type": "string"
@@ -489,14 +471,47 @@
         {
           "type": "object",
           "properties": {
-            "type": {
-              "enum": ["min", "max", "number", "percent", "percentile"]
-            },
-            "value": {
-              "type": "number"
-            },
-            "color": {
+            "like": {
               "type": "string"
+            },
+            "number": {
+              "type": "string"
+            },
+            "backgroundColor": {
+              "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            },
+            "textColor": {
+              "type": "string"
+            },
+            "bold": { "type": "boolean" },
+            "italic": { "type": "boolean" },
+            "underline": { "type": "boolean" },
+            "strikethrough": { "type": "boolean" },
+            "domain": {
+              "oneOf": [
+                { "type": "array", "items": { "type": "number" } },
+                {
+                  "type": "object",
+                  "properties": {
+                    "unit": { "enum": ["value", "percent", "percentile"] },
+                    "anchors": { "type": "array", "items": { "type": "number" } }
+                  },
+                  "patternProperties": { "^x-": true },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "scheme": {
+              "type": "string",
+              "description": "A built-in gradient (red-white-green, green-white-red, red-amber-green, green-amber-red, white-green, white-red, white-blue) or the name of a dashboard-level custom palette. Validated against known names by dac validate.",
+              "minLength": 1
+            },
+            "rules": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/formatRule" }
             }
           },
           "patternProperties": {
@@ -506,7 +521,7 @@
         }
       ]
     },
-    "singleColorRule": {
+    "formatRule": {
       "type": "object",
       "required": ["if"],
       "properties": {
@@ -533,22 +548,14 @@
           ]
         },
         "value": true,
-        "bold": {
-          "type": "boolean"
-        },
-        "italic": {
-          "type": "boolean"
-        },
-        "underline": {
-          "type": "boolean"
-        },
-        "strikethrough": {
-          "type": "boolean"
-        },
+        "bold": { "type": "boolean" },
+        "italic": { "type": "boolean" },
+        "underline": { "type": "boolean" },
+        "strikethrough": { "type": "boolean" },
         "textColor": {
           "type": "string"
         },
-        "background": {
+        "backgroundColor": {
           "type": "string"
         }
       },

--- a/testdata/dashboards/business-summary.yml
+++ b/testdata/dashboards/business-summary.yml
@@ -218,6 +218,6 @@ rows:
             label: Payment Method
           - name: amount
             label: Amount
-            format: currency
+            number: currency
           - name: created_at
             label: Order Date

--- a/testdata/dashboards/conditional-formatting.yml
+++ b/testdata/dashboards/conditional-formatting.yml
@@ -1,11 +1,7 @@
 name: Conditional Formatting
 
-# Custom palette: a reusable gradient, referenced by name with `scheme` below.
-palettes:
-  risk: [red, amber, green]
-
 rows:
-  # 1. Coloring: flat fill, auto gradient, pinned domain, built-in scheme, custom palette
+  # 1. Coloring: flat fill, auto gradient, pinned domain, built-in schemes
   - widgets:
       - name: Coloring
         type: table
@@ -42,7 +38,7 @@ rows:
             label: Rating
             format:
               number: number
-              scheme: risk                                        # custom palette, by name
+              scheme: red-amber-green                             # built-in scheme
 
   # 2. Domain units: percent of the range vs percentile of the data
   - widgets:

--- a/testdata/dashboards/conditional-formatting.yml
+++ b/testdata/dashboards/conditional-formatting.yml
@@ -1,91 +1,145 @@
 name: Conditional Formatting
+
+# Custom palette: a reusable gradient, referenced by name with `scheme` below.
+palettes:
+  risk: [red, amber, green]
+
 rows:
+  # 1. Coloring: flat fill, auto gradient, pinned domain, built-in scheme, custom palette
   - widgets:
-      - name: Colour scale + single colour
+      - name: Coloring
         type: table
         col: 12
         data:
-          columns: [region, revenue, growth, status]
+          columns: [region, revenue, growth, health, rating]
           rows:
-            - [North, 1200, 12, closed]
-            - [South, 4800, -5, overdue]
-            - [East, 3100, 8, pending]
-            - [West, 900, 22, overdue]
-            - [Central, 2500, 0, closed]
+            - [North,   1200,  12, 0.98, 4]
+            - [South,   4800,  -5, 0.40, 2]
+            - [East,    3100,   8, 0.72, 3]
+            - [West,     900,  22, 0.15, 1]
+            - [Central, 2500,   0, 0.55, 5]
         columns:
           - name: region
             label: Region
+            format: { backgroundColor: "#F8FAFC", textColor: "#334155", bold: true }   # flat fill + text style
           - name: revenue
             label: Revenue
-            format: currency
-            colorScale: {}                   
+            format:
+              number: currency
+              backgroundColor: [red, white, green]                # gradient, auto min to max
           - name: growth
             label: Growth %
-            format: number
-            colorScale:
-              min: { type: number, value: -25, color: "#E67C73" }
-              mid: { type: number, value: 0,   color: "#FFFFFF" }
-              max: { type: number, value: 25,  color: "#57BB8A" }
-          - name: status
-            label: Status
-            singleColor:
-              - if: text_is_exactly
-                value: overdue
-                background: "#FEE2E2"
-                textColor: "#991B1B"
-                bold: true
-              - if: text_is_exactly
-                value: closed
-                background: "#DCFCE7"
+            format:
+              number: number
+              domain: [-25, 0, 25]                                # pinned anchors, 0 = neutral middle
+              backgroundColor: [red, white, green]
+          - name: health
+            label: Health
+            format:
+              number: ".0%"
+              scheme: red-white-green                             # built-in scheme
+          - name: rating
+            label: Rating
+            format:
+              number: number
+              scheme: risk                                        # custom palette, by name
+
+  # 2. Domain units: percent of the range vs percentile of the data
   - widgets:
-      - name: Single-colour operators
+      - name: Domain units
         type: table
         col: 12
         data:
-          columns: [task, note, score, due, owner]
+          columns: [item, percent, percentile]
           rows:
-            - [T1, "URGENT fix", 92, "2026-07-01", alice]
-            - [T2, "routine check", 45, "2026-07-20", ""]
-            - [T3, "urgent review", 68, "2026-08-01", bob]
-            - [T4, "cleanup", 30, "2026-07-22", ""]
-            - [T5, "normal task", 80, "2026-07-25", carol]
+            - [P1, 20,  20]
+            - [P2, 10,  10]
+            - [P3, 200,  200]
+            - [P4, 30,  30]
+            - [P5, 40, 40]      
+        columns:
+          - name: percent
+            label: "percent (white lands at mid-range = 105)"
+            format:
+              backgroundColor: [red, white, green]
+              domain: { unit: percent, anchors: [0, 50, 100] }
+          - name: percentile
+            label: "percentile (white lands at median = 30)"
+            format:
+              backgroundColor: [red, white, green]
+              domain: { unit: percentile, anchors: [0, 50, 100] }
+
+  # 3. Rules: text, numeric, range, empty, date, cross-column, and every text style
+  - widgets:
+      - name: Rules
+        type: table
+        col: 12
+        data:
+          columns: [task, note, score, actual, target, due, owner]
+          rows:
+            - [T1, "URGENT fix",    92, 920,  1000, "2026-07-01", alice]
+            - [T2, "routine check", 45, 1100, 1000, "2026-07-20", ""]
+            - [T3, "urgent review", 68, 680,  900,  "2026-08-01", bob]
+            - [T4, "cleanup",       30, 300,  500,  "2026-07-22", ""]
         columns:
           - name: task
             label: Task
           - name: note
-            label: "Note — text_contains 'urgent' (case-insensitive)"
-            singleColor:
-              - if: text_contains
-                value: urgent
-                background: "#FEF9C3"
-                bold: true
+            label: "Note (text_contains 'urgent')"
+            format:
+              rules:
+                - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
           - name: score
-            label: "Score — >=80 / <50 / between 50–79"
-            format: number
-            singleColor:
-              - if: greater_than_or_equal
-                value: 80
-                background: "#DCFCE7"
-              - if: less_than
-                value: 50
-                background: "#FEE2E2"
-                strikethrough: true
-              - if: is_between
-                value: [50, 79]
-                background: "#FEF9C3"
+            label: "Score (>=80 / 50-79 / <50)"
+            format:
+              number: number
+              rules:
+                - { if: greater_than_or_equal, value: 80, backgroundColor: green }
+                - { if: is_between, value: [50, 79], backgroundColor: indigo, textColor: white }
+                - { if: less_than, value: 50, textColor: red, strikethrough: true }
+          - name: actual
+            label: "Actual (cross-column vs target)"
+            format:
+              number: number
+              rules:
+                - { if: less_than, value: { column: target }, backgroundColor: red }
+                - { if: greater_than, value: { column: target }, backgroundColor: green }
+          - name: target
+            label: Target
+            format: { number: number }
           - name: due
-            label: "Due — date_before / date_after 2026-07-22"
-            singleColor:
-              - if: date_before
-                value: "2026-07-22"
-                textColor: "#DC2626"
-                bold: true
-              - if: date_after
-                value: "2026-07-22"
-                textColor: "#16A34A"
+            label: "Due (date_before / date_after)"
+            format:
+              rules:
+                - { if: date_before, value: "2026-07-22", textColor: red, underline: true }
+                - { if: date_after, value: "2026-07-22", textColor: green }
           - name: owner
-            label: "Owner — is_empty"
-            singleColor:
-              - if: is_empty
-                background: "#F3F4F6"
-                italic: true
+            label: "Owner (is_empty)"
+            format:
+              rules:
+                - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }
+
+  # 4. Mirror another column: amount is colored exactly like status, keeps its own currency
+  - widgets:
+      - name: Mirror (like)
+        type: table
+        col: 12
+        data:
+          columns: [status, amount]
+          rows:
+            - [overdue, 1200]
+            - [closed,  4800]
+            - [pending, 3100]
+            - [overdue,  900]
+        columns:
+          - name: status
+            label: Status
+            format:
+              rules:
+                - { if: text_is_exactly, value: overdue, backgroundColor: red, bold: true }
+                - { if: text_is_exactly, value: closed, backgroundColor: green }
+          - name: amount
+            label: "Amount (like: status)"
+            format:
+              number: currency
+              like: status

--- a/testdata/dashboards/conditional-formatting.yml
+++ b/testdata/dashboards/conditional-formatting.yml
@@ -1,0 +1,91 @@
+name: Conditional Formatting
+rows:
+  - widgets:
+      - name: Colour scale + single colour
+        type: table
+        col: 12
+        data:
+          columns: [region, revenue, growth, status]
+          rows:
+            - [North, 1200, 12, closed]
+            - [South, 4800, -5, overdue]
+            - [East, 3100, 8, pending]
+            - [West, 900, 22, overdue]
+            - [Central, 2500, 0, closed]
+        columns:
+          - name: region
+            label: Region
+          - name: revenue
+            label: Revenue
+            format: currency
+            colorScale: {}                   
+          - name: growth
+            label: Growth %
+            format: number
+            colorScale:
+              min: { type: number, value: -25, color: "#E67C73" }
+              mid: { type: number, value: 0,   color: "#FFFFFF" }
+              max: { type: number, value: 25,  color: "#57BB8A" }
+          - name: status
+            label: Status
+            singleColor:
+              - if: text_is_exactly
+                value: overdue
+                background: "#FEE2E2"
+                textColor: "#991B1B"
+                bold: true
+              - if: text_is_exactly
+                value: closed
+                background: "#DCFCE7"
+  - widgets:
+      - name: Single-colour operators
+        type: table
+        col: 12
+        data:
+          columns: [task, note, score, due, owner]
+          rows:
+            - [T1, "URGENT fix", 92, "2026-07-01", alice]
+            - [T2, "routine check", 45, "2026-07-20", ""]
+            - [T3, "urgent review", 68, "2026-08-01", bob]
+            - [T4, "cleanup", 30, "2026-07-22", ""]
+            - [T5, "normal task", 80, "2026-07-25", carol]
+        columns:
+          - name: task
+            label: Task
+          - name: note
+            label: "Note — text_contains 'urgent' (case-insensitive)"
+            singleColor:
+              - if: text_contains
+                value: urgent
+                background: "#FEF9C3"
+                bold: true
+          - name: score
+            label: "Score — >=80 / <50 / between 50–79"
+            format: number
+            singleColor:
+              - if: greater_than_or_equal
+                value: 80
+                background: "#DCFCE7"
+              - if: less_than
+                value: 50
+                background: "#FEE2E2"
+                strikethrough: true
+              - if: is_between
+                value: [50, 79]
+                background: "#FEF9C3"
+          - name: due
+            label: "Due — date_before / date_after 2026-07-22"
+            singleColor:
+              - if: date_before
+                value: "2026-07-22"
+                textColor: "#DC2626"
+                bold: true
+              - if: date_after
+                value: "2026-07-22"
+                textColor: "#16A34A"
+          - name: owner
+            label: "Owner — is_empty"
+            singleColor:
+              - if: is_empty
+                background: "#F3F4F6"
+                italic: true

--- a/testdata/dashboards/conditional-formatting.yml
+++ b/testdata/dashboards/conditional-formatting.yml
@@ -1,7 +1,7 @@
 name: Conditional Formatting
 
 rows:
-  # 1. Coloring: flat fill, auto gradient, and gradients with an explicit range/unit
+  # 1. Coloring: flat fill, auto gradient, and gradients.
   - widgets:
       - name: Coloring
         type: table
@@ -18,35 +18,65 @@ rows:
           - name: region
             label: Region
             format:
-              - { backgroundColor: "#F8FAFC", textColor: "#334155", bold: true }   # flat fill + text style
+              - { backgroundColor: "#F8FAFC", textColor: "#334155", bold: true }                # flat fill + text style
           - name: revenue
             label: Revenue
             number: currency
             format:
-              - { backgroundColor: [red, white, green] }        # gradient, range omitted → auto min→max
+              - { backgroundColor: [red, white, green] }                                        # gradient, no range → auto min→max
           - name: growth
             label: Growth %
             number: number
             format:
-              - backgroundColor: [red, white, green]
-                range: [-25, 0, 25]
-                unit: absolute                                  # pinned anchors, 0 = neutral middle
+              - { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }   # absolute anchors, 0 = neutral
           - name: health
             label: Health
             number: ".0%"
             format:
-              - backgroundColor: [red, white, green]
-                range: [0, 50, 100]
-                unit: percent                                   # percent of the min..max range
+              - { backgroundColor: [red, white, green], range: [0, 50, 100], unit: percent }    # percent of the min..max range
           - name: rating
             label: Rating
             number: number
             format:
-              - backgroundColor: [red, amber, green]
-                range: [0, 50, 100]
-                unit: percentile                                # percentile of the data
+              - { backgroundColor: [red, amber, green], range: [0, 50, 100], unit: percentile } # percentile of the data
 
-  # 2. Range units: percent of the range vs percentile of the data (outlier shifts the range, not the median)
+  # 2. More range + unit examples: 2-stop gradients, custom absolute thresholds, reversed percentile
+  - widgets:
+      - name: More ranges
+        type: table
+        col: 12
+        data:
+          columns: [item, score, load, headroom, rank]
+          rows:
+            - [A, 20, 0.20,  40, 5]
+            - [B, 55, 0.50,  75, 12]
+            - [C, 80, 0.80,  90, 30]
+            - [D, 95, 0.95, 100, 48]
+            - [E, 40, 0.40,  55, 60]
+        columns:
+          - name: score
+            label: "Score (absolute 0/60/90)"
+            number: number
+            format:
+              - { backgroundColor: [red, amber, green], range: [0, 60, 90], unit: absolute }    # custom thresholds
+          - name: load
+            label: "Load (2-stop percent)"
+            number: ".0%"
+            format:
+              - { backgroundColor: [white, red], range: [0, 100], unit: percent }               # 2 colors, white → red
+          - name: headroom
+            label: "Headroom (2-stop absolute)"
+            number: number
+            format:
+              - { backgroundColor: [red, green], range: [40, 100], unit: absolute }             # 2 colors, absolute
+          - name: rank
+            label: "Rank (reversed percentile)"
+            number: number
+            format:
+              - { backgroundColor: [green, white, red], range: [0, 50, 100], unit: percentile } # low rank = good
+
+  # 3. Range units side by side: percent of the range vs percentile of the data
+  #    (the 200 outlier stretches the range but not the median)
   - widgets:
       - name: Range units
         type: table
@@ -63,18 +93,13 @@ rows:
           - name: percent
             label: "percent (white lands at mid-range = 105)"
             format:
-              - backgroundColor: [red, white, green]
-                range: [0, 50, 100]
-                unit: percent
+              - { backgroundColor: [red, white, green], range: [0, 50, 100], unit: percent }
           - name: percentile
             label: "percentile (white lands at median = 30)"
             format:
-              - backgroundColor: [red, white, green]
-                range: [0, 50, 100]
-                unit: percentile
+              - { backgroundColor: [red, white, green], range: [0, 50, 100], unit: percentile }
 
-  # 3. Conditions: text, numeric, range, empty, date, cross-column, and every text style.
-  #    Layers are first-match-wins.
+  # 4. Conditions: text, numeric, range, empty, date, cross-column; first match wins
   - widgets:
       - name: Conditions
         type: table
@@ -94,12 +119,12 @@ rows:
             format:
               - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
           - name: score
-            label: "Score (>=80 / 50-79 / <50)"
+            label: "Score (fill + text styles)"
             number: number
             format:
-              - { if: greater_than_or_equal, value: 80, backgroundColor: green }
-              - { if: is_between, value: [50, 79], backgroundColor: indigo, textColor: white }
-              - { if: less_than, value: 50, textColor: red, strikethrough: true }
+              - { if: greater_than_or_equal, value: 80, backgroundColor: green, textColor: white, bold: true }
+              - { if: is_between, value: [50, 79], backgroundColor: amber }
+              - { if: less_than, value: 50, backgroundColor: "#FEE2E2", textColor: red, strikethrough: true }
           - name: actual
             label: "Actual (cross-column vs target)"
             number: number
@@ -112,14 +137,14 @@ rows:
           - name: due
             label: "Due (date_before / date_after)"
             format:
-              - { if: date_before, value: "2026-07-22", textColor: red, underline: true }
-              - { if: date_after, value: "2026-07-22", textColor: green }
+              - { if: date_before, value: "2026-07-22", backgroundColor: red, textColor: white, bold: true }
+              - { if: date_after, value: "2026-07-22", backgroundColor: green, textColor: white }
           - name: owner
             label: "Owner (is_empty)"
             format:
               - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }
 
-  # 4. Mirror another column (`like`), and first-match: a condition wins over the gradient base below it
+  # 5. Mirror another column (`like`), and first-match: a condition wins over the gradient base below it
   - widgets:
       - name: Mirror & first match
         type: table
@@ -136,7 +161,7 @@ rows:
             label: Status
             format:
               - { if: text_is_exactly, value: overdue, backgroundColor: red, bold: true }
-              - { if: text_is_exactly, value: closed, backgroundColor: green }
+              - { backgroundColor: green }                                                      # no if → the rest (closed, pending)
           - name: amount
             label: "Amount (like: status)"
             number: currency
@@ -145,5 +170,5 @@ rows:
             label: "Score (rule wins, else gradient)"
             number: number
             format:
-              - { if: greater_than_or_equal, value: 90, backgroundColor: green, bold: true }   # first match wins
-              - { backgroundColor: [red, white, green] }                                       # gradient base, last
+              - { if: greater_than_or_equal, value: 90, backgroundColor: green, bold: true }    # first match wins
+              - { backgroundColor: [red, white, green], range: [0, 50, 100], unit: percent }    # gradient base, last

--- a/testdata/dashboards/conditional-formatting.yml
+++ b/testdata/dashboards/conditional-formatting.yml
@@ -1,7 +1,7 @@
 name: Conditional Formatting
 
 rows:
-  # 1. Coloring: flat fill, auto gradient, pinned domain, built-in schemes
+  # 1. Coloring: flat fill, auto gradient, and gradients with an explicit range/unit
   - widgets:
       - name: Coloring
         type: table
@@ -17,32 +17,38 @@ rows:
         columns:
           - name: region
             label: Region
-            format: { backgroundColor: "#F8FAFC", textColor: "#334155", bold: true }   # flat fill + text style
+            format:
+              - { backgroundColor: "#F8FAFC", textColor: "#334155", bold: true }   # flat fill + text style
           - name: revenue
             label: Revenue
+            number: currency
             format:
-              number: currency
-              backgroundColor: [red, white, green]                # gradient, auto min to max
+              - { backgroundColor: [red, white, green] }        # gradient, range omitted → auto min→max
           - name: growth
             label: Growth %
+            number: number
             format:
-              number: number
-              domain: [-25, 0, 25]                                # pinned anchors, 0 = neutral middle
-              backgroundColor: [red, white, green]
+              - backgroundColor: [red, white, green]
+                range: [-25, 0, 25]
+                unit: absolute                                  # pinned anchors, 0 = neutral middle
           - name: health
             label: Health
+            number: ".0%"
             format:
-              number: ".0%"
-              scheme: red-white-green                             # built-in scheme
+              - backgroundColor: [red, white, green]
+                range: [0, 50, 100]
+                unit: percent                                   # percent of the min..max range
           - name: rating
             label: Rating
+            number: number
             format:
-              number: number
-              scheme: red-amber-green                             # built-in scheme
+              - backgroundColor: [red, amber, green]
+                range: [0, 50, 100]
+                unit: percentile                                # percentile of the data
 
-  # 2. Domain units: percent of the range vs percentile of the data
+  # 2. Range units: percent of the range vs percentile of the data (outlier shifts the range, not the median)
   - widgets:
-      - name: Domain units
+      - name: Range units
         type: table
         col: 12
         data:
@@ -50,24 +56,27 @@ rows:
           rows:
             - [P1, 20,  20]
             - [P2, 10,  10]
-            - [P3, 200,  200]
+            - [P3, 200, 200]
             - [P4, 30,  30]
-            - [P5, 40, 40]      
+            - [P5, 40,  40]
         columns:
           - name: percent
             label: "percent (white lands at mid-range = 105)"
             format:
-              backgroundColor: [red, white, green]
-              domain: { unit: percent, anchors: [0, 50, 100] }
+              - backgroundColor: [red, white, green]
+                range: [0, 50, 100]
+                unit: percent
           - name: percentile
             label: "percentile (white lands at median = 30)"
             format:
-              backgroundColor: [red, white, green]
-              domain: { unit: percentile, anchors: [0, 50, 100] }
+              - backgroundColor: [red, white, green]
+                range: [0, 50, 100]
+                unit: percentile
 
-  # 3. Rules: text, numeric, range, empty, date, cross-column, and every text style
+  # 3. Conditions: text, numeric, range, empty, date, cross-column, and every text style.
+  #    Layers are first-match-wins.
   - widgets:
-      - name: Rules
+      - name: Conditions
         type: table
         col: 12
         data:
@@ -83,59 +92,58 @@ rows:
           - name: note
             label: "Note (text_contains 'urgent')"
             format:
-              rules:
-                - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
+              - { if: text_contains, value: urgent, backgroundColor: amber, bold: true }
           - name: score
             label: "Score (>=80 / 50-79 / <50)"
+            number: number
             format:
-              number: number
-              rules:
-                - { if: greater_than_or_equal, value: 80, backgroundColor: green }
-                - { if: is_between, value: [50, 79], backgroundColor: indigo, textColor: white }
-                - { if: less_than, value: 50, textColor: red, strikethrough: true }
+              - { if: greater_than_or_equal, value: 80, backgroundColor: green }
+              - { if: is_between, value: [50, 79], backgroundColor: indigo, textColor: white }
+              - { if: less_than, value: 50, textColor: red, strikethrough: true }
           - name: actual
             label: "Actual (cross-column vs target)"
+            number: number
             format:
-              number: number
-              rules:
-                - { if: less_than, value: { column: target }, backgroundColor: red }
-                - { if: greater_than, value: { column: target }, backgroundColor: green }
+              - { if: less_than, value: { column: target }, backgroundColor: red }
+              - { if: greater_than, value: { column: target }, backgroundColor: green }
           - name: target
             label: Target
-            format: { number: number }
+            number: number
           - name: due
             label: "Due (date_before / date_after)"
             format:
-              rules:
-                - { if: date_before, value: "2026-07-22", textColor: red, underline: true }
-                - { if: date_after, value: "2026-07-22", textColor: green }
+              - { if: date_before, value: "2026-07-22", textColor: red, underline: true }
+              - { if: date_after, value: "2026-07-22", textColor: green }
           - name: owner
             label: "Owner (is_empty)"
             format:
-              rules:
-                - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }
+              - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }
 
-  # 4. Mirror another column: amount is colored exactly like status, keeps its own currency
+  # 4. Mirror another column (`like`), and first-match: a condition wins over the gradient base below it
   - widgets:
-      - name: Mirror (like)
+      - name: Mirror & first match
         type: table
         col: 12
         data:
-          columns: [status, amount]
+          columns: [status, amount, score]
           rows:
-            - [overdue, 1200]
-            - [closed,  4800]
-            - [pending, 3100]
-            - [overdue,  900]
+            - [overdue, 1200, 95]
+            - [closed,  4800, 60]
+            - [pending, 3100, 40]
+            - [overdue,  900, 88]
         columns:
           - name: status
             label: Status
             format:
-              rules:
-                - { if: text_is_exactly, value: overdue, backgroundColor: red, bold: true }
-                - { if: text_is_exactly, value: closed, backgroundColor: green }
+              - { if: text_is_exactly, value: overdue, backgroundColor: red, bold: true }
+              - { if: text_is_exactly, value: closed, backgroundColor: green }
           - name: amount
             label: "Amount (like: status)"
+            number: currency
+            like: status
+          - name: score
+            label: "Score (rule wins, else gradient)"
+            number: number
             format:
-              number: currency
-              like: status
+              - { if: greater_than_or_equal, value: 90, backgroundColor: green, bold: true }   # first match wins
+              - { backgroundColor: [red, white, green] }                                       # gradient base, last

--- a/testdata/dashboards/sales.yml
+++ b/testdata/dashboards/sales.yml
@@ -164,13 +164,13 @@ rows:
             label: Customer
           - name: orders
             label: Orders
-            format: number
+            number: number
           - name: total_spent
             label: Total Spent
-            format: currency
+            number: currency
           - name: avg_order
             label: Average Order
-            format: currency
+            number: currency
       - name: Revenue by Region & Month
         type: table
         col: 6
@@ -195,10 +195,10 @@ rows:
             label: Month
           - name: sales_count
             label: Sales
-            format: number
+            number: number
           - name: revenue
             label: Revenue
-            format: currency
+            number: currency
 
   # Recent orders
   - widgets:
@@ -218,7 +218,7 @@ rows:
             label: Customer
           - name: amount
             label: Amount
-            format: currency
+            number: currency
           - name: status
             label: Status
           - name: created_at

--- a/testdata/dashboards/semantic-sales.yml
+++ b/testdata/dashboards/semantic-sales.yml
@@ -152,8 +152,8 @@ rows:
             label: Channel
           - name: revenue
             label: Revenue
-            format: currency
+            number: currency
           - name: sales_count
             label: Sales
-            format: number
+            number: number
         col: 12


### PR DESCRIPTION
## Summary

Adds table conditional formatting: a per-column `format` (string shorthand or object) that combines number display with value-based coloring. Supports flat fills, gradients with `domain` anchors (value / percent / percentile), built-in schemes and dashboard-level custom `palettes`, rule-based styling (all operators, cross-column comparisons, text styles), and `like` to mirror another column. Works in both YAML and TSX, is validated by `dac validate`, and named colors adapt to light/dark mode.
