### PR TITLE
Add copy button to the YAML panel

### DIFF
--- a/frontend/src/components/YamlPanel.tsx
+++ b/frontend/src/components/YamlPanel.tsx
@@ -40,10 +40,13 @@ export function YamlPanel({ dashboardName, fileType, isOpen, onClose, onResize, 
 
   useEffect(() => {
     if (!isOpen || !dashboardName) return;
+    let cancelled = false;
     setError(null);
+    setYaml(null);
     getDashboardRaw(dashboardName)
-      .then(setYaml)
-      .catch((err) => setError(err.message));
+      .then((raw) => { if (!cancelled) setYaml(raw); })
+      .catch((err) => { if (!cancelled) setError(err.message); });
+    return () => { cancelled = true; };
   }, [isOpen, dashboardName]);
 
   const handleCopy = () => {

--- a/frontend/src/components/YamlPanel.tsx
+++ b/frontend/src/components/YamlPanel.tsx
@@ -13,9 +13,27 @@ interface YamlPanelProps {
   onResizeEnd: () => void;
 }
 
+function CopyIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
 export function YamlPanel({ dashboardName, fileType, isOpen, onClose, onResize, onResizeStart, onResizeEnd }: YamlPanelProps) {
   const [yaml, setYaml] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const lang = fileType === "tsx" ? "tsx" : "yaml";
   const html = useShikiHighlight(yaml, lang);
@@ -28,11 +46,27 @@ export function YamlPanel({ dashboardName, fileType, isOpen, onClose, onResize, 
       .catch((err) => setError(err.message));
   }, [isOpen, dashboardName]);
 
+  const handleCopy = () => {
+    if (yaml === null) return;
+    navigator.clipboard.writeText(yaml).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
   return (
     <div
       className={`yaml-sidebar ${isOpen ? "" : "yaml-sidebar-closed"}`}
     >
       {isOpen && <ResizeHandle side="left" onResize={onResize} onResizeStart={onResizeStart} onResizeEnd={onResizeEnd} />}
+      <button
+        onClick={handleCopy}
+        disabled={yaml === null}
+        title={copied ? "Copied" : "Copy"}
+        className="absolute top-2.5 right-10 z-10 w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--dac-surface-hover)] text-[var(--dac-text-muted)] hover:text-[var(--dac-text-secondary)] transition-colors disabled:opacity-40 disabled:cursor-default"
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+      </button>
       <button
         onClick={onClose}
         className="absolute top-2.5 right-2.5 z-10 w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--dac-surface-hover)] text-[var(--dac-text-muted)] hover:text-[var(--dac-text-secondary)] transition-colors"


### PR DESCRIPTION
## Summary

Adds a copy button to the YAML panel that copies the dashboard's YAML (or TSX) to the clipboard, next to the existing close button. It briefly shows a check icon after copying and stays disabled while the content is still loading.