### PR TITLE
Accept a scalar table-column `format` as a legacy alias for `number`

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -767,7 +767,7 @@ Data table with optional column configuration.
 
 If `columns` is omitted, all result columns are shown with their SQL names as headers.
 
-**Conditional formatting.** A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**.
+**Conditional formatting.** A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
 
 - With `if` (+ `value`), the layer styles only the cells that match. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
 - With no `if`, the layer styles every cell — a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put it last as the fallback.

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -103,7 +103,7 @@ rows:
 
 Widget types are `metric`, `chart`, `table`, `text`, `divider`, and `image`.
 
-A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**.
+A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
 
 - With `if` (+ `value`), the layer styles only the cells that match. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
 - With no `if`, the layer styles every cell — a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put it last as the fallback.

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -263,6 +263,11 @@ A column sets value display with `number` and coloring with `format`. `number`
 is `currency`, `number`, or a d3-format string. `format` is an **ordered list of
 layers**, and for each cell the **first layer that matches wins**.
 
+`format` is polymorphic for backward compatibility: a scalar string (e.g.
+`format: currency`) is the older value-display shorthand and is treated as an
+alias for `number`; a list is the conditional-format layers. Prefer `number`
+in new dashboards, and use a list `format` for coloring (the two can coexist).
+
 A layer's `if` is optional: with `if`, the layer styles only the cells that match
 the condition; without `if`, the layer styles every cell.
 

--- a/pkg/dashboard/color_scale_test.go
+++ b/pkg/dashboard/color_scale_test.go
@@ -36,6 +36,33 @@ columns:
 	}
 }
 
+func TestFormat_YAML_Alias(t *testing.T) {
+	// A YAML alias (`format: *anchor`) to an anchored scalar or sequence must
+	// resolve to its target, not be rejected.
+	yamlBody := `
+columns:
+  - name: a
+    format: &fmt currency
+  - name: b
+    format: *fmt
+  - name: c
+    format: &layers
+      - { if: greater_than, value: 0, backgroundColor: green }
+  - name: d
+    format: *layers
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if w.Columns[1].Number != "currency" {
+		t.Fatalf("aliased scalar format should map to Number, got %q", w.Columns[1].Number)
+	}
+	if len(w.Columns[3].Format) != 1 {
+		t.Fatalf("aliased sequence format should decode to layers, got %d", len(w.Columns[3].Format))
+	}
+}
+
 func TestFormat_YAML_Layers(t *testing.T) {
 	yamlBody := `
 columns:

--- a/pkg/dashboard/color_scale_test.go
+++ b/pkg/dashboard/color_scale_test.go
@@ -8,6 +8,34 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestFormat_YAML_LegacyScalar(t *testing.T) {
+	// Backward compatibility: a scalar `format` is the old value-display
+	// shorthand, now equivalent to `number`. It maps into Number with no layers.
+	// `number` and an array `format` may coexist (value display + coloring).
+	yamlBody := `
+columns:
+  - name: revenue
+    format: currency
+  - name: score
+    number: number
+    format:
+      - { if: greater_than_or_equal, value: 80, backgroundColor: green }
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if w.Columns[0].Number != "currency" {
+		t.Fatalf("scalar format should map to Number, got %q", w.Columns[0].Number)
+	}
+	if len(w.Columns[0].Format) != 0 {
+		t.Fatalf("scalar format should not populate layers, got %d", len(w.Columns[0].Format))
+	}
+	if w.Columns[1].Number != "number" || len(w.Columns[1].Format) != 1 {
+		t.Fatalf("number+layers should coexist: number=%q layers=%d", w.Columns[1].Number, len(w.Columns[1].Format))
+	}
+}
+
 func TestFormat_YAML_Layers(t *testing.T) {
 	yamlBody := `
 columns:

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -826,13 +826,22 @@ func asTableColumns(v interface{}) []TableColumn {
 	var cols []TableColumn
 	for _, item := range arr {
 		if m, ok := item.(map[string]interface{}); ok {
-			cols = append(cols, TableColumn{
+			col := TableColumn{
 				Name:   asString(m["name"]),
 				Label:  asString(m["label"]),
 				Number: asString(m["number"]),
 				Like:   asString(m["like"]),
-				Format: asFormatLayers(m["format"]),
-			})
+			}
+			// `format` is polymorphic: a string is the legacy value-display
+			// shorthand (== `number`), a list is the style layers.
+			if s, ok := m["format"].(string); ok {
+				if col.Number == "" {
+					col.Number = s
+				}
+			} else {
+				col.Format = asFormatLayers(m["format"])
+			}
+			cols = append(cols, col)
 		}
 	}
 	return cols

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -161,39 +161,33 @@ type TableColumn struct {
 // (unless Number is set explicitly); a list is decoded as the style layers. Value
 // display (`number`, or a scalar `format`) and coloring (`format: [...]`) coexist.
 func (c *TableColumn) UnmarshalYAML(node *yaml.Node) error {
-	if node.Kind != yaml.MappingNode {
-		return fmt.Errorf("table column must be a mapping")
-	}
-	type tableColumnFields struct {
+	// Decode the plain fields, capturing `format` as a raw node (a nested struct
+	// with no UnmarshalYAML, so this doesn't recurse).
+	var tmp struct {
 		Name   string    `yaml:"name"`
 		Label  string    `yaml:"label,omitempty"`
 		Number string    `yaml:"number,omitempty"`
 		Like   string    `yaml:"like,omitempty"`
 		Format yaml.Node `yaml:"format,omitempty"`
 	}
-	var tmp tableColumnFields
 	if err := node.Decode(&tmp); err != nil {
 		return err
 	}
-	c.Name = tmp.Name
-	c.Label = tmp.Label
-	c.Number = tmp.Number
-	c.Like = tmp.Like
-	c.Format = nil
-	switch tmp.Format.Kind {
-	case 0:
-		// no `format` key
+	*c = TableColumn{Name: tmp.Name, Label: tmp.Label, Number: tmp.Number, Like: tmp.Like}
+
+	// Follow a YAML alias to its target, then: a scalar is the legacy value-display
+	// shorthand (folds into `number`); a list is the style layers.
+	f := &tmp.Format
+	for f.Kind == yaml.AliasNode && f.Alias != nil {
+		f = f.Alias
+	}
+	switch f.Kind {
 	case yaml.ScalarNode:
-		// Legacy `format: <string>` == value display, which is now `number`.
 		if c.Number == "" {
-			c.Number = tmp.Format.Value
+			c.Number = f.Value
 		}
 	case yaml.SequenceNode:
-		if err := tmp.Format.Decode(&c.Format); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("table column %q: format must be a string (value display) or a list of style layers", tmp.Name)
+		return f.Decode(&c.Format)
 	}
 	return nil
 }

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -151,7 +151,51 @@ type TableColumn struct {
 	Label  string        `yaml:"label,omitempty" json:"label,omitempty"`
 	Number string        `yaml:"number,omitempty" json:"number,omitempty"` // value display: currency | number | d3-format spec
 	Like   string        `yaml:"like,omitempty" json:"like,omitempty"`     // mirror another column's coloring + per-row value
-	Format []FormatLayer `yaml:"format,omitempty" json:"format,omitempty"` // ordered style layers; first match wins
+	Format []FormatLayer `yaml:"format,omitempty" json:"format,omitempty"` // ordered conditional-format style layers; first match wins
+}
+
+// UnmarshalYAML makes a column's `format` polymorphic for backward compatibility.
+// Originally `format` was a scalar value-display shorthand (`format: currency`);
+// that role is now `number`, and `format` is an ordered list of style layers. So
+// a scalar `format` is read as the legacy value format and folded into Number
+// (unless Number is set explicitly); a list is decoded as the style layers. Value
+// display (`number`, or a scalar `format`) and coloring (`format: [...]`) coexist.
+func (c *TableColumn) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("table column must be a mapping")
+	}
+	type tableColumnFields struct {
+		Name   string    `yaml:"name"`
+		Label  string    `yaml:"label,omitempty"`
+		Number string    `yaml:"number,omitempty"`
+		Like   string    `yaml:"like,omitempty"`
+		Format yaml.Node `yaml:"format,omitempty"`
+	}
+	var tmp tableColumnFields
+	if err := node.Decode(&tmp); err != nil {
+		return err
+	}
+	c.Name = tmp.Name
+	c.Label = tmp.Label
+	c.Number = tmp.Number
+	c.Like = tmp.Like
+	c.Format = nil
+	switch tmp.Format.Kind {
+	case 0:
+		// no `format` key
+	case yaml.ScalarNode:
+		// Legacy `format: <string>` == value display, which is now `number`.
+		if c.Number == "" {
+			c.Number = tmp.Format.Value
+		}
+	case yaml.SequenceNode:
+		if err := tmp.Format.Decode(&c.Format); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("table column %q: format must be a string (value display) or a list of style layers", tmp.Name)
+	}
+	return nil
 }
 
 // Condition operators for conditional-formatting rules.

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -452,8 +452,10 @@
           "type": "string"
         },
         "format": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/formatLayer" }
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "$ref": "#/$defs/formatLayer" } }
+          ]
         }
       },
       "patternProperties": {


### PR DESCRIPTION
Makes a table column's `format` polymorphic so pre-existing dashboards keep working.

- A scalar `format` string (e.g. `format: currency`) is the legacy value-display shorthand — a custom `UnmarshalYAML` folds it into `number` on load.
- A list `format` is the ordered conditional-format layers (unchanged).
- Schema: `format` is now `oneOf(string, array)`; `number` is retained, so `number` and a list `format` can coexist (value display + coloring on the same column).

Adds a backward-compat unmarshal test and documents the alias in the create-dashboard skill and dashboard docs.