### PR TITLE
fix(server): restrict CORS to VS Code webviews

### DIFF
--- a/docs/commands/serve.md
+++ b/docs/commands/serve.md
@@ -55,6 +55,10 @@ When `--password` is set, the server exposes admin endpoints for managing databa
 
 The server exposes a REST API used by the frontend:
 
+The local API rejects requests from arbitrary browser origins. Cross-origin
+access is limited to Bruin's VS Code webview embed; same-origin browser and
+non-browser clients continue to work normally.
+
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/v1/dashboards` | List all dashboards |

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -197,18 +198,45 @@ func spaHandler(fsys fs.FS) http.Handler {
 	})
 }
 
-// corsMiddleware lets the VS Code webview embed (a different origin) reach the server.
+// corsMiddleware lets VS Code webviews reach the server without exposing the
+// local API to arbitrary websites.
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		origin := r.Header.Get("Origin")
+		if origin == "" || sameOrigin(origin, r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if !isVSCodeWebviewOrigin(origin) {
+			http.Error(w, "cross-origin request denied", http.StatusForbidden)
+			return
+		}
+
+		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Cache-Control, Accept")
+		w.Header().Add("Vary", "Origin")
 		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func sameOrigin(origin string, r *http.Request) bool {
+	u, err := url.Parse(origin)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return false
+	}
+	return u.Host == r.Host
+}
+
+func isVSCodeWebviewOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	return err == nil && u.Scheme == "vscode-webview" && u.Host != "" &&
+		u.User == nil && u.Path == "" && u.RawQuery == "" && u.Fragment == ""
 }
 
 // Start begins listening and serving.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -130,6 +130,43 @@ func TestListThemes(t *testing.T) {
 	}
 }
 
+func TestCORSMiddleware(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := corsMiddleware(next)
+
+	tests := []struct {
+		name       string
+		method     string
+		origin     string
+		wantStatus int
+		wantOrigin string
+	}{
+		{name: "no origin", method: http.MethodGet, wantStatus: http.StatusOK},
+		{name: "same origin", method: http.MethodPost, origin: "http://localhost:8321", wantStatus: http.StatusOK},
+		{name: "VS Code webview", method: http.MethodPost, origin: "vscode-webview://dashboard-id", wantStatus: http.StatusOK, wantOrigin: "vscode-webview://dashboard-id"},
+		{name: "VS Code preflight", method: http.MethodOptions, origin: "vscode-webview://dashboard-id", wantStatus: http.StatusNoContent, wantOrigin: "vscode-webview://dashboard-id"},
+		{name: "arbitrary website", method: http.MethodPost, origin: "https://evil.example", wantStatus: http.StatusForbidden},
+		{name: "spoofed scheme", method: http.MethodPost, origin: "vscode-webview.example://dashboard-id", wantStatus: http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "http://localhost:8321/api/v1/query", nil)
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			assertEqual(t, w.Code, tt.wantStatus)
+			assertEqual(t, w.Header().Get("Access-Control-Allow-Origin"), tt.wantOrigin)
+		})
+	}
+}
+
 func TestNew_AllowsRegularDashboardsWithInvalidSemanticModels(t *testing.T) {
 	projectDir := t.TempDir()
 

--- a/pkg/server/watcher.go
+++ b/pkg/server/watcher.go
@@ -128,7 +128,6 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	ch := s.watcher.subscribe()
 	defer s.watcher.unsubscribe(ch)


### PR DESCRIPTION
### Motivation
- A previously-added global wildcard CORS policy exposed unauthenticated, sensitive endpoints (including `POST /api/v1/query`) to arbitrary browser origins, enabling cross-origin data exfiltration. 
- The intent is to allow the Bruin VS Code extension's webview to call the local server while preventing arbitrary websites from reading local API responses.

### Description
- Replace unconditional `Access-Control-Allow-Origin: *` middleware with origin validation that permits same-origin and non-browser clients and only allows validated `vscode-webview://` origins, reflecting the exact origin and adding `Vary: Origin` (changes in `pkg/server/server.go`).
- Add helper functions `sameOrigin` and `isVSCodeWebviewOrigin` to validate origins and return HTTP 403 for disallowed cross-origin requests, and respond to authorized preflights with HTTP 204.
- Remove the wildcard CORS header from the SSE handler so the SSE stream cannot override the restricted policy (change in `pkg/server/watcher.go`).
- Add a regression test `TestCORSMiddleware` covering no-origin, same-origin, VS Code webview (including preflight), malicious website, and spoofed-scheme cases (change in `pkg/server/server_test.go`).
- Document the restricted cross-origin behavior in `docs/commands/serve.md` so users know the local API rejects arbitrary browser origins.

### Testing
- Ran `make test`, which executed the Go unit test suite including the updated `pkg/server` tests and completed successfully. 
- Ran `make format` where Go formatting and `go vet` passed, but frontend type checks could not be completed due to missing frontend dependencies in the environment. 
- Attempting `make deps` failed to fetch modules from `proxy.golang.org` (HTTP 403 in this environment), so full dependency installation and a complete `make build` were not possible here. 
- `git diff --check` and repository checks were run and reported no whitespace or diff-check issues for the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dfd3b23888320b6187a39d11bf345)