### PR TITLE
Conversion funnel widget

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -570,6 +570,12 @@ Client-side quartile computation from raw data rows.
 
 #### Funnel
 
+Conversion funnel: one bar per stage showing each stage's share of the top of
+the funnel and the step-to-step conversion between stages. Rows render in query
+order, so put the top of the funnel first (`ORDER BY count DESC`). Bar labels
+honor `value.format`, so a revenue funnel can render currency. Set
+`horizontal: true` to lay the stages left-to-right instead of top-to-bottom.
+
 ```yaml
 - name: Conversion Funnel
   type: chart
@@ -1560,7 +1566,7 @@ rows:
 | `combo` | `x`, `y`, `lines` | | Mixed bar + line chart |
 | `histogram` | `x` | `bins` | Histogram (client-side binning) |
 | `boxplot` | `x`, `y` | | Box-and-whisker plot (client-side quartiles) |
-| `funnel` | `label`, `value` | | Funnel chart |
+| `funnel` | `label`, `value` | `horizontal` | Conversion funnel: one bar per stage with its share of the top and step-to-step conversion; bar labels honor `value.format`; `horizontal: true` lays stages left-to-right |
 | `sankey` | `source`, `target`, `value` | | Sankey/flow diagram |
 | `heatmap` | `x`, `y`, `value` | | Grid heatmap |
 | `calendar` | `x`, `value` | | Calendar heatmap (GitHub-style) |

--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -570,12 +570,6 @@ Client-side quartile computation from raw data rows.
 
 #### Funnel
 
-Conversion funnel: one bar per stage showing each stage's share of the top of
-the funnel and the step-to-step conversion between stages. Rows render in query
-order, so put the top of the funnel first (`ORDER BY count DESC`). Bar labels
-honor `value.format`, so a revenue funnel can render currency. Set
-`horizontal: true` to lay the stages left-to-right instead of top-to-bottom.
-
 ```yaml
 - name: Conversion Funnel
   type: chart
@@ -1566,7 +1560,7 @@ rows:
 | `combo` | `x`, `y`, `lines` | | Mixed bar + line chart |
 | `histogram` | `x` | `bins` | Histogram (client-side binning) |
 | `boxplot` | `x`, `y` | | Box-and-whisker plot (client-side quartiles) |
-| `funnel` | `label`, `value` | `horizontal` | Conversion funnel: one bar per stage with its share of the top and step-to-step conversion; bar labels honor `value.format`; `horizontal: true` lays stages left-to-right |
+| `funnel` | `label`, `value` | | Funnel chart |
 | `sankey` | `source`, `target`, `value` | | Sankey/flow diagram |
 | `heatmap` | `x`, `y`, `value` | | Grid heatmap |
 | `calendar` | `x`, `value` | | Calendar heatmap (GitHub-style) |

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -2,7 +2,7 @@
 name: create-dashboard
 description: Create DAC dashboards by writing YAML or TSX dashboard definition files. Use when the user wants to create, modify, review, or understand DAC dashboards, widgets, filters, SQL queries, semantic models, or CLI validation workflows.
 argument-hint: "[dashboard request]"
-version: 5
+version: 6
 ---
 
 # Create Dashboard
@@ -218,6 +218,8 @@ rows:
 ```
 
 A chart's `x` and `y` are axis encoding objects with a required `field` (bare column names like `x: region` are invalid). `field` may be a single column or a list.
+
+The `funnel` chart shows conversion through ordered stages: one bar per stage with its share of the top of the funnel and the step-to-step conversion. Use `label` (stage) and `value` (count), and order rows top-of-funnel first in SQL. `horizontal: true` lays the stages left-to-right, and bar labels honor `value.format` (e.g. `"$,.0f"` for a revenue funnel).
 
 Every query is an inline `sql:` block or a named `query:` reference — YAML widgets do not take file paths. In TSX, `include("queries/revenue.sql")` reads a `.sql` file into an inline query at load time.
 

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -162,7 +162,7 @@ func TestParseSkillVersion(t *testing.T) {
 		content string
 		want    int
 	}{
-		{"bundled skill", createDashboardSkill, 5},
+		{"bundled skill", createDashboardSkill, 6},
 		{"explicit version", "---\nname: x\nversion: 7\n---\nbody", 7},
 		{"missing version", "---\nname: x\n---\nbody", 0},
 		{"no frontmatter", "# just a heading\n", 0},

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -86,7 +86,7 @@ Charts visualize one or more series. The `chart` field selects the chart type an
 | `combo` | `x`, `y` | `lines` | Mixed bar + line chart (y series in `lines` render as lines, the rest as bars) |
 | `histogram` | `x` | `bins` | Histogram (client-side binning) |
 | `boxplot` | `x`, `y` | | Box-and-whisker plot (client-side quartiles) |
-| `funnel` | `label`, `value` | | Funnel chart |
+| `funnel` | `label`, `value` | `horizontal` | Conversion funnel: one bar per stage with each stage's share of the top and step-to-step conversion. Rows render in query order — put the top of the funnel first. `horizontal: true` lays stages left-to-right |
 | `sankey` | `source`, `target`, `value` | | Sankey/flow diagram |
 | `heatmap` | `x`, `y`, `value` | | Grid heatmap |
 | `calendar` | `x`, `value` | | GitHub-style calendar heatmap |

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -188,7 +188,7 @@ Common chart fields:
 | `color` | object | Category column (`{ field: ... }`) that splits the single `y` series into one series per category — bar, line, and area charts |
 | `stacked` | boolean | Stack the color series (bar charts only; requires `color`) |
 | `normalized` | boolean | Render stacked bars as percentages of the row total (requires `stacked`) |
-| `horizontal` | boolean | Horizontal bars: categories on the vertical axis (bar charts only) |
+| `horizontal` | boolean | Horizontal layout: bar charts put categories on the vertical axis; funnel charts lay stages left-to-right |
 | `size` | string | Bubble size column for bubble charts |
 | `lines` | string[] | Which `y` series render as lines (rest as bars) for combo charts |
 | `bins` | integer | Number of bins for histogram charts (default 10) |

--- a/examples/basic-yaml/dashboards/marketing-funnel.yml
+++ b/examples/basic-yaml/dashboards/marketing-funnel.yml
@@ -69,6 +69,23 @@ rows:
             - ["Completed setup", 3930]
             - ["Activated", 2240]
 
+  # Formatted funnel 
+  - widgets:
+      - name: Pipeline Value
+        type: chart
+        chart: funnel
+        col: 12
+        description: Revenue reaching each pipeline stage, formatted as currency
+        label: stage
+        value: { field: amount, format: "$,.0f" }
+        data:
+          columns: [stage, amount]
+          rows:
+            - ["Qualified", 4820000]
+            - ["Proposal sent", 2610000]
+            - ["Negotiation", 1340000]
+            - ["Closed won", 612000]
+
   # SQL-backed funnel — same widget, but the stages come from a live query
   # against the example DuckDB. The query returns (stage, value) rows already
   # ordered top-of-funnel first; the funnel does the rest.

--- a/examples/basic-yaml/dashboards/marketing-funnel.yml
+++ b/examples/basic-yaml/dashboards/marketing-funnel.yml
@@ -1,0 +1,92 @@
+schema: https://getbruin.com/schemas/dac/dashboard/v1
+name: Marketing Onboarding Funnel
+description: Signup-to-activation funnel with per-stage conversion and drop-off
+connection: local_duckdb
+
+# Most widgets here carry inline `data`, so the onboarding story renders without
+# a warehouse. The funnel chart is source-agnostic, though — it just needs a
+# `label` column and a `value` column. The last row runs live SQL against the
+# example DuckDB to show the exact same widget backed by a query.
+
+rows:
+  # Headline funnel — the full onboarding journey, top of funnel first.
+  - widgets:
+      - name: Onboarding Funnel
+        type: chart
+        chart: funnel
+        col: 8
+        description: Visitors → paid, last 30 days. Rows are top-of-funnel first.
+        label: stage
+        value: { field: users }
+        data:
+          columns: [stage, users]
+          rows:
+            - ["Visited site", 48200]
+            - ["Signed up", 18640]
+            - ["Verified email", 14210]
+            - ["Completed setup", 9080]
+            - ["Activated (first value)", 5720]
+            - ["Upgraded to paid", 1890]
+
+      # Overall conversion headline next to the funnel.
+      - name: Visitor → Paid
+        type: metric
+        col: 4
+        description: End-to-end onboarding conversion
+        value: { field: rate, format: ".1%" }
+        data:
+          columns: [rate]
+          rows:
+            - [0.0392]
+
+  # Segmented funnels — compare where each acquisition channel loses people.
+  - widgets:
+      - name: Organic Signups
+        type: chart
+        chart: funnel
+        col: 6
+        label: stage
+        value: { field: users }
+        data:
+          columns: [stage, users]
+          rows:
+            - ["Signed up", 9200]
+            - ["Verified email", 7360]
+            - ["Completed setup", 5150]
+            - ["Activated", 3480]
+
+      - name: Paid Ads Signups
+        type: chart
+        chart: funnel
+        col: 6
+        label: stage
+        value: { field: users }
+        data:
+          columns: [stage, users]
+          rows:
+            - ["Signed up", 9440]
+            - ["Verified email", 6850]
+            - ["Completed setup", 3930]
+            - ["Activated", 2240]
+
+  # SQL-backed funnel — same widget, but the stages come from a live query
+  # against the example DuckDB. The query returns (stage, value) rows already
+  # ordered top-of-funnel first; the funnel does the rest.
+  - widgets:
+      - name: Order Value Funnel (SQL)
+        type: chart
+        chart: funnel
+        col: 12
+        description: Orders surviving each spend threshold, queried from DuckDB
+        connection: local_duckdb
+        horizontal: true # lay stages left-to-right; well suited to a wide widget
+        label: stage
+        value: { field: orders }
+        sql: |
+          SELECT stage, orders FROM (
+            SELECT 'All orders' AS stage, COUNT(*) AS orders, 1 AS ord FROM orders
+            UNION ALL SELECT 'Over $50',  COUNT(*), 2 FROM orders WHERE amount >= 50
+            UNION ALL SELECT 'Over $100', COUNT(*), 3 FROM orders WHERE amount >= 100
+            UNION ALL SELECT 'Over $250', COUNT(*), 4 FROM orders WHERE amount >= 250
+            UNION ALL SELECT 'Over $500', COUNT(*), 5 FROM orders WHERE amount >= 500
+          ) ORDER BY ord

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -872,7 +872,7 @@ function FunnelChart({
 
   if (horizontal) {
     return (
-      <div className="flex items-stretch overflow-hidden px-1" style={{ height }}>
+      <div className="flex items-stretch overflow-x-auto px-1" style={{ height }}>
         {stages.map((s, i) => (
           <div key={i} className="flex min-w-0 flex-1 items-stretch">
             {i > 0 && s.stepConv !== null && (

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -2,7 +2,7 @@ import { useContext, useMemo, useState } from "react";
 import {
   LineChart, Line, BarChart, Bar, AreaChart, Area, PieChart, Pie, Cell,
   ScatterChart, Scatter, ZAxis,
-  ComposedChart, FunnelChart, Funnel, LabelList, Sankey,
+  ComposedChart, Sankey,
   Treemap,
   RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
   XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
@@ -810,6 +810,160 @@ function CandlestickChart({
   );
 }
 
+// --- Funnel rendering ---
+
+/**
+ * A conversion funnel: one centered, tapering bar per stage. Unlike a plain
+ * funnel chart, this surfaces the two numbers that matter for an onboarding
+ * funnel — each stage's share of the top of the funnel (overall conversion)
+ * and the step-to-step conversion between consecutive stages (drop-off).
+ *
+ * Rows are taken in the order the query returns them (top of funnel first);
+ * no sorting is applied so stages stay in their intended sequence.
+ *
+ * Orientation follows the widget's `horizontal` flag: the default stacks
+ * stages top-to-bottom (bars taper by width); `horizontal: true` lays them
+ * left-to-right (bars taper by height, like a column funnel).
+ */
+function FunnelChart({
+  data,
+  labelKey,
+  valueKey,
+  colors,
+  tokens,
+  height,
+  horizontal = false,
+}: {
+  data: Record<string, unknown>[];
+  labelKey: string;
+  valueKey: string;
+  colors: string[];
+  tokens: Record<string, string>;
+  height: number;
+  horizontal?: boolean;
+}) {
+  const raw = data
+    .map((d) => ({ label: String(d[labelKey] ?? ""), value: Number(d[valueKey]) || 0 }))
+    .filter((s) => s.label !== "");
+
+  if (raw.length === 0) {
+    return <div className="text-[var(--dac-text-muted)] text-xs py-6 text-center">No data</div>;
+  }
+
+  const topValue = raw[0].value || 1;
+  const maxValue = Math.max(...raw.map((s) => s.value)) || 1;
+  const textPrimary = tokens["text-primary"] || "#0A0D14";
+  const textMuted = tokens["text-muted"] || "#868C98";
+  const barColor = colors[0] || "#4338CA";
+
+  // Per-stage derived numbers, shared by both orientations. `extent` is the
+  // bar's share of the largest stage (width when vertical, height when
+  // horizontal); a floor keeps thin stages readable.
+  const stages = raw.map((s, i) => ({
+    ...s,
+    extent: Math.max(8, (s.value / maxValue) * 100),
+    pctOfTop: topValue > 0 ? (s.value / topValue) * 100 : 0,
+    stepConv: i === 0 ? null : raw[i - 1].value > 0 ? (s.value / raw[i - 1].value) * 100 : 0,
+    // Fade successive stages so depth reads without extra chrome.
+    opacity: 1 - (i / Math.max(raw.length, 1)) * 0.55,
+  }));
+
+  if (horizontal) {
+    return (
+      <div className="flex items-stretch overflow-hidden px-1" style={{ height }}>
+        {stages.map((s, i) => (
+          <div key={i} className="flex min-w-0 flex-1 items-stretch">
+            {i > 0 && s.stepConv !== null && (
+              <div
+                className="flex shrink-0 flex-col items-center justify-center px-0.5 text-[10px] font-medium leading-tight tabular-nums"
+                style={{ color: textMuted }}
+                title={`${s.stepConv.toFixed(1)}% of the previous stage continued`}
+              >
+                <span aria-hidden>→</span>
+                <span>{s.stepConv.toFixed(0)}%</span>
+              </div>
+            )}
+            <div className="flex min-w-0 flex-1 flex-col items-center">
+              <span
+                className="w-full truncate text-center text-[11px] font-medium leading-tight"
+                style={{ color: textPrimary }}
+                title={s.label}
+              >
+                {s.label}
+              </span>
+              <div className="flex w-full flex-1 items-center justify-center py-1">
+                <div
+                  className="flex w-[72%] items-center justify-center rounded-[3px]"
+                  style={{ height: `${s.extent}%`, background: barColor, opacity: s.opacity }}
+                  title={`${s.label}: ${formatTooltipValue(s.value)}`}
+                >
+                  <span
+                    className="px-1 text-[11px] font-semibold tabular-nums text-white"
+                    style={{ textShadow: "0 1px 2px rgba(0,0,0,0.25)" }}
+                  >
+                    {formatTooltipValue(s.value)}
+                  </span>
+                </div>
+              </div>
+              <span className="text-[10px] tabular-nums leading-tight" style={{ color: textMuted }}>
+                {Math.round(s.pctOfTop)}%
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col justify-center gap-0.5 overflow-hidden px-1"
+      style={{ minHeight: height }}
+    >
+      {stages.map((s, i) => (
+        <div key={i} className="flex flex-col items-center">
+          {i > 0 && s.stepConv !== null && (
+            <div
+              className="flex items-center gap-1 py-[3px] text-[10px] font-medium tabular-nums"
+              style={{ color: textMuted }}
+              title={`${s.stepConv.toFixed(1)}% of the previous stage continued`}
+            >
+              <span aria-hidden>↓</span>
+              <span>{s.stepConv.toFixed(1)}%</span>
+            </div>
+          )}
+          <div className="flex w-full items-baseline justify-between gap-2 leading-none">
+            <span
+              className="truncate text-[11px] font-medium"
+              style={{ color: textPrimary }}
+              title={s.label}
+            >
+              {s.label}
+            </span>
+            <span className="shrink-0 text-[10px] tabular-nums" style={{ color: textMuted }}>
+              {Math.round(s.pctOfTop)}%
+            </span>
+          </div>
+          <div className="mt-1 flex w-full justify-center">
+            <div
+              className="flex h-7 items-center justify-center rounded-[3px]"
+              style={{ width: `${s.extent}%`, background: barColor, opacity: s.opacity }}
+              title={`${s.label}: ${formatTooltipValue(s.value)}`}
+            >
+              <span
+                className="px-2 text-[11px] font-semibold tabular-nums text-white"
+                style={{ textShadow: "0 1px 2px rgba(0,0,0,0.25)" }}
+              >
+                {formatTooltipValue(s.value)}
+              </span>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 // --- Main chart component ---
 
 // Height consumed by the y-axis title line rendered above the plot.
@@ -1129,27 +1283,15 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
 
     case "funnel":
       return (
-        <ResponsiveContainer width="100%" height={chartHeight}>
-          <FunnelChart>
-            <Tooltip content={<CustomTooltip />} />
-            <Funnel
-              data={chartData.map((d, i) => ({
-                ...d,
-                fill: colors[i % colors.length],
-              }))}
-              dataKey={valueField(widget.value) || "value"}
-              nameKey={widget.label || "label"}
-              isAnimationActive={false}
-            >
-              <LabelList
-                position="center"
-                fill="#fff"
-                style={{ fontSize: 11, fontFamily: '"Geist", system-ui', fontWeight: 500 }}
-                formatter={(v: unknown) => formatTooltipValue(v)}
-              />
-            </Funnel>
-          </FunnelChart>
-        </ResponsiveContainer>
+        <FunnelChart
+          data={chartData}
+          labelKey={widget.label || "label"}
+          valueKey={valueField(widget.value) || "value"}
+          colors={colors}
+          tokens={tokens}
+          height={chartHeight}
+          horizontal={widget.horizontal}
+        />
       );
 
     case "sankey": {

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -833,6 +833,7 @@ function FunnelChart({
   tokens,
   height,
   horizontal = false,
+  valueFmt,
 }: {
   data: Record<string, unknown>[];
   labelKey: string;
@@ -841,6 +842,7 @@ function FunnelChart({
   tokens: Record<string, string>;
   height: number;
   horizontal?: boolean;
+  valueFmt: (val: unknown) => string;
 }) {
   const raw = data
     .map((d) => ({ label: String(d[labelKey] ?? ""), value: Number(d[valueKey]) || 0 }))
@@ -880,7 +882,7 @@ function FunnelChart({
                 title={`${s.stepConv.toFixed(1)}% of the previous stage continued`}
               >
                 <span aria-hidden>→</span>
-                <span>{s.stepConv.toFixed(0)}%</span>
+                <span>{s.stepConv.toFixed(1)}%</span>
               </div>
             )}
             <div className="flex min-w-0 flex-1 flex-col items-center">
@@ -895,13 +897,12 @@ function FunnelChart({
                 <div
                   className="flex w-[72%] items-center justify-center rounded-[3px]"
                   style={{ height: `${s.extent}%`, background: barColor, opacity: s.opacity }}
-                  title={`${s.label}: ${formatTooltipValue(s.value)}`}
                 >
                   <span
                     className="px-1 text-[11px] font-semibold tabular-nums text-white"
                     style={{ textShadow: "0 1px 2px rgba(0,0,0,0.25)" }}
                   >
-                    {formatTooltipValue(s.value)}
+                    {valueFmt(s.value)}
                   </span>
                 </div>
               </div>
@@ -948,13 +949,12 @@ function FunnelChart({
             <div
               className="flex h-7 items-center justify-center rounded-[3px]"
               style={{ width: `${s.extent}%`, background: barColor, opacity: s.opacity }}
-              title={`${s.label}: ${formatTooltipValue(s.value)}`}
             >
               <span
                 className="px-2 text-[11px] font-semibold tabular-nums text-white"
                 style={{ textShadow: "0 1px 2px rgba(0,0,0,0.25)" }}
               >
-                {formatTooltipValue(s.value)}
+                {valueFmt(s.value)}
               </span>
             </div>
           </div>
@@ -1291,6 +1291,7 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
           tokens={tokens}
           height={chartHeight}
           horizontal={widget.horizontal}
+          valueFmt={buildAxisFormatter(widget.value, formatTooltipValue)}
         />
       );
 

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -917,11 +917,11 @@ function FunnelChart({
   }
 
   return (
-    <div
-      className="flex flex-col justify-center gap-0.5 overflow-hidden px-1"
-      style={{ minHeight: height }}
-    >
-      {stages.map((s, i) => (
+    <div className="flex flex-col overflow-y-auto px-1" style={{ height }}>
+      {/* my-auto centers the stages when they fit; when they exceed the height
+          the container scrolls instead of clipping later stages. */}
+      <div className="my-auto flex flex-col gap-0.5">
+        {stages.map((s, i) => (
         <div key={i} className="flex flex-col items-center">
           {i > 0 && s.stepConv !== null && (
             <div
@@ -959,7 +959,8 @@ function FunnelChart({
             </div>
           </div>
         </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }

--- a/pkg/dashboard/color_encoding_test.go
+++ b/pkg/dashboard/color_encoding_test.go
@@ -156,8 +156,26 @@ func TestValidate_HorizontalOnlyOnBar(t *testing.T) {
 		}}}},
 	}
 	err := Validate(d)
-	if err == nil || !strings.Contains(err.Error(), "horizontal is only valid on bar charts") {
-		t.Fatalf("expected horizontal-bar-only error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "horizontal is only valid on bar and funnel charts") {
+		t.Fatalf("expected horizontal-not-on-line error, got: %v", err)
+	}
+}
+
+func TestValidate_HorizontalFunnelIsValid(t *testing.T) {
+	d := &Dashboard{
+		Name: "t",
+		Rows: []Row{{Widgets: []Widget{{
+			Name:       "w",
+			Type:       WidgetTypeChart,
+			Chart:      "funnel",
+			SQL:        "SELECT stage, users FROM funnel",
+			Label:      "stage",
+			Value:      &ValueEncoding{Field: "users"},
+			Horizontal: true,
+		}}}},
+	}
+	if err := Validate(d); err != nil {
+		t.Fatalf("expected no error for horizontal funnel, got: %v", err)
 	}
 }
 

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -122,7 +122,7 @@ type Widget struct {
 	Color      *ColorEncoding `yaml:"color,omitempty" json:"color,omitempty"`
 	Stacked    bool           `yaml:"stacked,omitempty" json:"stacked,omitempty"`
 	Normalized bool           `yaml:"normalized,omitempty" json:"normalized,omitempty"`
-	Horizontal bool           `yaml:"horizontal,omitempty" json:"horizontal,omitempty"`
+	Horizontal bool           `yaml:"horizontal,omitempty" json:"horizontal,omitempty"` // bar: horizontal bars; funnel: lay stages left-to-right
 	Size       string         `yaml:"size,omitempty" json:"size,omitempty"`
 	Source     string         `yaml:"source,omitempty" json:"source,omitempty"` // sankey: source column
 	Target     string         `yaml:"target,omitempty" json:"target,omitempty"` // sankey: target column, gauge: target (max) column

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -415,8 +415,8 @@ func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
 	if w.Normalized && w.Chart != "bar" {
 		errs = append(errs, fmt.Sprintf("%s: normalized is only valid on bar charts", prefix))
 	}
-	if w.Horizontal && w.Chart != "bar" {
-		errs = append(errs, fmt.Sprintf("%s: horizontal is only valid on bar charts", prefix))
+	if w.Horizontal && w.Chart != "bar" && w.Chart != "funnel" {
+		errs = append(errs, fmt.Sprintf("%s: horizontal is only valid on bar and funnel charts", prefix))
 	}
 
 	return errs

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -316,7 +316,8 @@
           "type": "boolean"
         },
         "horizontal": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Bar charts: render horizontal bars. Funnel charts: lay stages left-to-right instead of top-to-bottom."
         },
         "size": {
           "type": "string"


### PR DESCRIPTION
Burak's conversion funnel (one bar per stage showing its share of the top of the funnel and the step-to-step drop-off, vertical or horizontal), rebased onto main, plus a couple of fixes: bar labels honor `value.format` (so a revenue funnel renders currency) and step-to-step conversion shows one decimal in both orientations.

Supersedes #47 (same funnel, on current main).