### PR TITLE
ci: add manual bump-version workflow

### DIFF
--- a/.github/workflows/bump-version-minor.yml
+++ b/.github/workflows/bump-version-minor.yml
@@ -8,6 +8,11 @@ jobs:
     name: Bump Version (minor)
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure dispatched from main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Bump Version must be dispatched from main (got ${{ github.ref }})."
+          exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: "0"

--- a/.github/workflows/bump-version-minor.yml
+++ b/.github/workflows/bump-version-minor.yml
@@ -1,11 +1,11 @@
-name: Bump Version (patch)
+name: Bump Version (minor)
 
 on:
   workflow_dispatch:
 
 jobs:
   bump_version:
-    name: Bump Version (patch)
+    name: Bump Version (minor)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -17,6 +17,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           TAG_PREFIX: v
-          DEFAULT_BUMP: patch
+          DEFAULT_BUMP: minor
           PRERELEASE: false
           RELEASE_BRANCHES: main

--- a/.github/workflows/bump-version-minor.yml
+++ b/.github/workflows/bump-version-minor.yml
@@ -10,8 +10,10 @@ jobs:
     steps:
       - name: Ensure dispatched from main
         if: github.ref != 'refs/heads/main'
+        env:
+          REF: ${{ github.ref }}
         run: |
-          echo "::error::Bump Version must be dispatched from main (got ${{ github.ref }})."
+          echo "::error::Bump Version must be dispatched from main (got ${REF})."
           exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/.github/workflows/bump-version-patch.yml
+++ b/.github/workflows/bump-version-patch.yml
@@ -10,8 +10,10 @@ jobs:
     steps:
       - name: Ensure dispatched from main
         if: github.ref != 'refs/heads/main'
+        env:
+          REF: ${{ github.ref }}
         run: |
-          echo "::error::Bump Version must be dispatched from main (got ${{ github.ref }})."
+          echo "::error::Bump Version must be dispatched from main (got ${REF})."
           exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,25 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump_version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: "0"
+      - name: Set branch name
+        id: extract_branch
+        run: echo "branch_name=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}})" >> $GITHUB_OUTPUT
+      - name: Bump version and push tag
+        id: bump_version
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG_PREFIX: v
+          DEFAULT_BUMP: patch
+          PRERELEASE: false
+          RELEASE_BRANCHES: ${{ steps.extract_branch.outputs.branch_name }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,9 +11,6 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: "0"
-      - name: Set branch name
-        id: extract_branch
-        run: echo "branch_name=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}})" >> $GITHUB_OUTPUT
       - name: Bump version and push tag
         id: bump_version
         uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
@@ -22,4 +19,4 @@ jobs:
           TAG_PREFIX: v
           DEFAULT_BUMP: patch
           PRERELEASE: false
-          RELEASE_BRANCHES: ${{ steps.extract_branch.outputs.branch_name }}
+          RELEASE_BRANCHES: main

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -8,6 +8,11 @@ jobs:
     name: Bump Version (patch)
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure dispatched from main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Bump Version must be dispatched from main (got ${{ github.ref }})."
+          exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: "0"


### PR DESCRIPTION
Adds a manually-triggered `Bump Version` workflow that patch-bumps the version and pushes a clean `vX.Y.Z` tag, which in turn triggers the existing `release.yml`. Uses a `RELEASE_TOKEN` PAT so the pushed tag actually fires the release workflow.

