### PR TITLE
Hidden table columns

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -767,12 +767,13 @@ Data table with optional column configuration.
 
 If `columns` is omitted, all result columns are shown with their SQL names as headers.
 
-**Conditional formatting.** A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
+**Conditional formatting.** A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, `hidden`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
 
 - With `if` (+ `value`), the layer styles only the cells that match. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
 - With no `if`, the layer styles every cell — a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put it last as the fallback.
 - Styles on any layer: `backgroundColor`, `textColor`, `bold`, `italic`, `underline`, `strikethrough`.
 - `like`: mirror another column's coloring, driven by that column's per-row value, while keeping this column's own `number`.
+- `hidden: true`: keep the column in the result but don't render it. Optional. Coloring reads a column whether or not it's shown, so hide only to drop it from the display, e.g. a `like` source you must declare but don't want visible.
 
 Each layer is a YAML object, so `- { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }` and the same keys written as an indented block are identical — use whichever reads better.
 
@@ -810,8 +811,10 @@ rows:
               - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }   # flat fill (string)
           - name: actual
             number: number
-            format:                                                     # cross-column, same row (target need not be displayed)
+            format:                                                     # cross-column, same row
               - { if: greater_than, value: { column: target }, backgroundColor: green }
+          - name: target
+            hidden: true                                                # in the result for the rule above, not rendered
           - name: bonus
             number: currency
             like: score                                                 # mirror score's colors, keep own number

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -2,7 +2,7 @@
 name: create-dashboard
 description: Create DAC dashboards by writing YAML or TSX dashboard definition files. Use when the user wants to create, modify, review, or understand DAC dashboards, widgets, filters, SQL queries, semantic models, or CLI validation workflows.
 argument-hint: "[dashboard request]"
-version: 6
+version: 7
 ---
 
 # Create Dashboard
@@ -103,12 +103,13 @@ rows:
 
 Widget types are `metric`, `chart`, `table`, `text`, `divider`, and `image`.
 
-A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
+A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `like`, `hidden`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
 
 - With `if` (+ `value`), the layer styles only the cells that match. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
 - With no `if`, the layer styles every cell — a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put it last as the fallback.
 - Styles on any layer: `backgroundColor`, `textColor`, `bold`, `italic`, `underline`, `strikethrough`.
 - `like`: mirror another column's coloring, driven by that column's per-row value, while keeping this column's own `number`.
+- `hidden: true`: keep the column in the result but don't render it. Optional. Coloring reads a column whether or not it's shown, so hide only to drop it from the display, e.g. a `like` source you must declare but don't want visible.
 
 Each layer is a YAML object, so `- { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }` and the same keys written as an indented block are identical — use whichever reads better.
 
@@ -146,8 +147,10 @@ rows:
               - { if: is_empty, backgroundColor: "#F3F4F6", italic: true }   # flat fill (string)
           - name: actual
             number: number
-            format:                                                     # cross-column, same row (target need not be displayed)
+            format:                                                     # cross-column, same row
               - { if: greater_than, value: { column: target }, backgroundColor: green }
+          - name: target
+            hidden: true                                                # in the result for the rule above, not rendered
           - name: bonus
             number: currency
             like: score                                                 # mirror score's colors, keep own number

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -162,7 +162,7 @@ func TestParseSkillVersion(t *testing.T) {
 		content string
 		want    int
 	}{
-		{"bundled skill", createDashboardSkill, 6},
+		{"bundled skill", createDashboardSkill, 7},
 		{"explicit version", "---\nname: x\nversion: 7\n---\nbody", 7},
 		{"missing version", "---\nname: x\n---\nbody", 0},
 		{"no frontmatter", "# just a heading\n", 0},

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -255,6 +255,7 @@ Table column fields:
 |-------|------|-------------|
 | `name` | string | Result column name (must match the SQL output) |
 | `label` | string | Display header (defaults to `name`) |
+| `hidden` | boolean | Keep the column in the result but don't render it, see [Hidden columns](#hidden-columns) |
 | `format` | string \| object | Value display and conditional coloring, see below |
 
 ## Conditional formatting
@@ -285,6 +286,7 @@ the condition; without `if`, the layer styles every cell.
 |-----|--------------|
 | `number` | Value display: `currency`, `number`, or a d3-format string. |
 | `like` | Mirror another column's coloring, driven by that column's per-row value (keeps own `number`). |
+| `hidden` | Keep the column in the result (so it can drive cross-column rules or be a `like` source) but don't render it. |
 | `format` | Ordered list of style layers; first match wins. |
 
 **Layer keys** (the `Group` column shows which keys belong together):
@@ -381,6 +383,9 @@ rows:
               - { if: less_than, value: { column: target }, backgroundColor: red }   # cross-column, same row
               - { if: greater_than, value: { column: target }, backgroundColor: green }
 
+          - name: target
+            hidden: true                                                # in the result for the rule above, not rendered
+
           - name: bonus
             number: currency
             like: score                                                 # mirror score's colors, keep own number
@@ -410,6 +415,7 @@ How the example reads, column by column:
 - `score`: numeric conditions covering two `value` forms, a scalar (`>= 80`) and a `[low, high]` range (`50 to 79`); each layer combines a `backgroundColor` fill with text styles (`< 50` gets a light-red fill plus red struck-through text).
 - `status`: text conditions checked in order, first match wins (contains "urgent", exactly "overdue", or empty).
 - `actual`: cross-column conditions, compared to `target` in the same row (explained next).
+- `target`: `hidden: true`, so it stays in the result to drive `actual`'s comparison but is not rendered as its own column.
 - `bonus`: `like: score`, so it takes score's colors per row but keeps its own currency display.
 - `due`: date conditions, before or after a cutoff day.
 - `health`: a condition (`= 0` turns red) checked first, then a `percent`-range gradient with no `if` last, for every other value.
@@ -420,7 +426,23 @@ Cross column, step by step. Look at the `actual` rule:
 { if: less_than, value: { column: target }, backgroundColor: red }
 ```
 
-The cell being colored is `actual`. `value: { column: target }` means "compare it to the `target` column in the same row", not to a fixed number. So for every row independently: if that row's `actual` is less than that row's `target`, the `actual` cell turns red. Row 1 uses row 1's target, row 2 uses row 2's target, and so on. `target` can even be a column you do not display in the table, because its data is still available for the comparison. (Writing `value: 100` instead would compare against the constant 100.)
+The cell being colored is `actual`. `value: { column: target }` means "compare it to the `target` column in the same row", not to a fixed number. So for every row independently: if that row's `actual` is less than that row's `target`, the `actual` cell turns red. Row 1 uses row 1's target, row 2 uses row 2's target, and so on. `target` is marked `hidden: true` here, so it drives the comparison without taking up a column of its own. (Writing `value: 100` instead would compare against the constant 100.)
+
+## Hidden columns
+
+A column with `hidden: true` stays in the query result but is not rendered. It is optional: coloring reads a column whether or not it's shown. Hide only to drop a column from the display.
+
+```yaml
+columns:
+  - name: actual
+    number: number
+    format:
+      - { if: less_than, value: { column: target }, backgroundColor: red }
+  - name: target
+    hidden: true      # feeds the rule above, never rendered
+```
+
+Hidden columns are still in the underlying data, so they appear in CSV exports. `hidden` has no effect on non-table widgets.
 
 ## Inline data
 

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -38,6 +38,7 @@ export function TableWidget({ widget, data }: Props) {
           label: col.label || col.name,
           number: col.number,
           like: col.like,
+          hidden: col.hidden ?? false,
           format: col.format,
           idx: data.columns.findIndex((c) => c.name === col.name),
         }))
@@ -46,6 +47,7 @@ export function TableWidget({ widget, data }: Props) {
           label: col.name,
           number: undefined as string | undefined,
           like: undefined as string | undefined,
+          hidden: false,
           format: undefined as FormatLayer[] | undefined,
           idx,
         }));
@@ -63,13 +65,16 @@ export function TableWidget({ widget, data }: Props) {
       // Exited on a cycle (src still points at a `like` column) → no valid source.
       return src?.like ? undefined : src;
     };
-    return raw.map((c) => {
-      const src = c.like ? likeSource(c) : undefined;
-      if (src) {
-        return { ...c, format: src.format, colorIdx: src.idx };
-      }
-      return { ...c, colorIdx: c.idx };
-    });
+
+    return raw
+      .map((c) => {
+        const src = c.like ? likeSource(c) : undefined;
+        if (src) {
+          return { ...c, format: src.format, colorIdx: src.idx };
+        }
+        return { ...c, colorIdx: c.idx };
+      })
+      .filter((c) => !c.hidden);
   }, [widget.columns, data?.columns]);
 
   const rows = data?.rows ?? [];

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -114,6 +114,8 @@ export interface TableColumn {
   number?: string;
   /** Mirror another column's coloring, driven by that column's per-row value. */
   like?: string;
+  /** Keep the column in the result (for cross-column rules / `like`) but don't render it. */
+  hidden?: boolean;
   /** Ordered style layers; the first layer that matches a cell wins. */
   format?: FormatLayer[];
 }

--- a/pkg/dashboard/color_scale_test.go
+++ b/pkg/dashboard/color_scale_test.go
@@ -334,6 +334,48 @@ func TestValidate_LikeUnknownColumn(t *testing.T) {
 	}
 }
 
+func TestFormat_YAML_Hidden(t *testing.T) {
+	yamlBody := `
+columns:
+  - name: actual
+    number: number
+    format:
+      - { if: less_than, value: { column: target }, backgroundColor: red }
+  - name: target
+    number: number
+    hidden: true
+`
+	var w Widget
+	if err := yaml.Unmarshal([]byte(yamlBody), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if w.Columns[0].Hidden {
+		t.Fatalf("actual should not be hidden")
+	}
+	if !w.Columns[1].Hidden {
+		t.Fatalf("target should be hidden")
+	}
+}
+
+func TestValidate_LikeHiddenColumn(t *testing.T) {
+	// A `like` source may be a hidden column: it stays in the result (and the
+	// declared column set) so the reference resolves even though it isn't rendered.
+	d := &Dashboard{
+		Name: "d",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "t", Type: WidgetTypeTable, SQL: "SELECT 1",
+			Columns: []TableColumn{
+				{Name: "score", Hidden: true, Format: []FormatLayer{{BackgroundColor: []interface{}{"red", "green"}}}},
+				{Name: "bonus", Like: "score"},
+			},
+		}}}},
+	}
+	errs := runValidate(d)
+	if hasErrContaining(errs, "unknown column") {
+		t.Errorf("hidden column should be a valid like source, got %v", errs)
+	}
+}
+
 func TestValidate_LikeSelfReference(t *testing.T) {
 	d := &Dashboard{
 		Name: "d",

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -831,6 +831,7 @@ func asTableColumns(v interface{}) []TableColumn {
 				Label:  asString(m["label"]),
 				Number: asString(m["number"]),
 				Like:   asString(m["like"]),
+				Hidden: asBool(m["hidden"]),
 			}
 			// `format` is polymorphic: a string is the legacy value-display
 			// shorthand (== `number`), a list is the style layers.

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -360,6 +360,7 @@ export default (
         columns={[
           { name: "id", label: "Order ID" },
           { name: "amount", label: "Amount", number: "currency" },
+          { name: "target", hidden: true },
         ]} />
     </Row>
   </Dashboard>
@@ -369,14 +370,17 @@ export default (
 	assertNoErr(t, err)
 
 	w := d.Rows[0].Widgets[0]
-	if len(w.Columns) != 2 {
-		t.Fatalf("expected 2 columns, got %d", len(w.Columns))
+	if len(w.Columns) != 3 {
+		t.Fatalf("expected 3 columns, got %d", len(w.Columns))
 	}
 	if w.Columns[0].Name != "id" || w.Columns[0].Label != "Order ID" {
 		t.Errorf("unexpected column 0: %+v", w.Columns[0])
 	}
 	if w.Columns[1].Number != "currency" {
 		t.Errorf("expected number %q, got %+v", "currency", w.Columns[1].Number)
+	}
+	if !w.Columns[2].Hidden {
+		t.Errorf("expected target column to be hidden, got %+v", w.Columns[2])
 	}
 }
 

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -151,6 +151,7 @@ type TableColumn struct {
 	Label  string        `yaml:"label,omitempty" json:"label,omitempty"`
 	Number string        `yaml:"number,omitempty" json:"number,omitempty"` // value display: currency | number | d3-format spec
 	Like   string        `yaml:"like,omitempty" json:"like,omitempty"`     // mirror another column's coloring + per-row value
+	Hidden bool          `yaml:"hidden,omitempty" json:"hidden,omitempty"` // keep the column in the result (for cross-column rules / like) but don't render it
 	Format []FormatLayer `yaml:"format,omitempty" json:"format,omitempty"` // ordered conditional-format style layers; first match wins
 }
 
@@ -168,12 +169,13 @@ func (c *TableColumn) UnmarshalYAML(node *yaml.Node) error {
 		Label  string    `yaml:"label,omitempty"`
 		Number string    `yaml:"number,omitempty"`
 		Like   string    `yaml:"like,omitempty"`
+		Hidden bool      `yaml:"hidden,omitempty"`
 		Format yaml.Node `yaml:"format,omitempty"`
 	}
 	if err := node.Decode(&tmp); err != nil {
 		return err
 	}
-	*c = TableColumn{Name: tmp.Name, Label: tmp.Label, Number: tmp.Number, Like: tmp.Like}
+	*c = TableColumn{Name: tmp.Name, Label: tmp.Label, Number: tmp.Number, Like: tmp.Like, Hidden: tmp.Hidden}
 
 	// Follow a YAML alias to its target, then: a scalar is the legacy value-display
 	// shorthand (folds into `number`); a list is the style layers.

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -452,6 +452,9 @@
         "like": {
           "type": "string"
         },
+        "hidden": {
+          "type": "boolean"
+        },
         "format": {
           "oneOf": [
             { "type": "string" },

--- a/testdata/dashboards/conditional-formatting.yml
+++ b/testdata/dashboards/conditional-formatting.yml
@@ -99,7 +99,7 @@ rows:
             format:
               - { backgroundColor: [red, white, green], range: [0, 50, 100], unit: percentile }
 
-  # 4. Conditions: text, numeric, range, empty, date, cross-column; first match wins
+  # 4. Conditions: text, numeric, range, empty, date, cross-column (target hidden); first match wins
   - widgets:
       - name: Conditions
         type: table
@@ -126,14 +126,14 @@ rows:
               - { if: is_between, value: [50, 79], backgroundColor: amber }
               - { if: less_than, value: 50, backgroundColor: "#FEE2E2", textColor: red, strikethrough: true }
           - name: actual
-            label: "Actual (cross-column vs target)"
+            label: "Actual (cross-column vs hidden target)"
             number: number
             format:
               - { if: less_than, value: { column: target }, backgroundColor: red }
               - { if: greater_than, value: { column: target }, backgroundColor: green }
           - name: target
             label: Target
-            number: number
+            number: number                                                 
           - name: due
             label: "Due (date_before / date_after)"
             format:

--- a/testdata/dashboards/conditional-formatting.yml
+++ b/testdata/dashboards/conditional-formatting.yml
@@ -99,7 +99,7 @@ rows:
             format:
               - { backgroundColor: [red, white, green], range: [0, 50, 100], unit: percentile }
 
-  # 4. Conditions: text, numeric, range, empty, date, cross-column (target hidden); first match wins
+  # 4. Conditions: text, numeric, range, empty, date, cross-column; first match wins
   - widgets:
       - name: Conditions
         type: table
@@ -126,14 +126,14 @@ rows:
               - { if: is_between, value: [50, 79], backgroundColor: amber }
               - { if: less_than, value: 50, backgroundColor: "#FEE2E2", textColor: red, strikethrough: true }
           - name: actual
-            label: "Actual (cross-column vs hidden target)"
+            label: "Actual (cross-column vs target)"
             number: number
             format:
               - { if: less_than, value: { column: target }, backgroundColor: red }
               - { if: greater_than, value: { column: target }, backgroundColor: green }
           - name: target
             label: Target
-            number: number                                                 
+            number: number
           - name: due
             label: "Due (date_before / date_after)"
             format:


### PR DESCRIPTION
Adds a `hidden: true` flag on table columns so a column can stay in the query result, driving cross-column conditional formatting and `like` sources, without being rendered in the table.

Covers the YAML/TSX loaders, JSON schema, and the renderer, plus docs and the create-dashboard skill.