### PR TITLE
Add CI bands, forest charts and reference lines/bands to dashboards

### DIFF
--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -224,6 +224,8 @@ A chart's `x` and `y` are axis encoding objects with a required `field` (bare co
 
 The `funnel` chart shows conversion through ordered stages: one bar per stage with its share of the top of the funnel and the step-to-step conversion. Use `label` (stage) and `value` (count), and order rows top-of-funnel first in SQL. `horizontal: true` lays the stages left-to-right, and bar labels honor `value.format` (e.g. `"$,.0f"` for a revenue funnel).
 
+Confidence intervals use `yMin`/`yMax` (the lower/upper bound columns): on `line`/`area` they shade a CI **band** behind the estimate line; on `bar` they become **error-bar caps**; the `forest` chart draws a point estimate + horizontal CI per category (grey when the interval spans 0, `horizontal: false` for a vertical dot-and-whisker). `y` is the estimate only. `yMin`/`yMax` are a single column, or a per-series map `{seriesColumn: boundColumn}` for multi-line bands. Compute the bounds in SQL (e.g. `effect ± 1.96*stderr`). Reference guides: `refLines: [{ axis: x|y, value, label? }]` (dashed line, e.g. a 0 "no-effect" mark) and `refBands: [{ axis: x|y, from, to, label? }]` (a shaded range, e.g. a ±MDE band).
+
 Every query is an inline `sql:` block or a named `query:` reference — YAML widgets do not take file paths. In TSX, `include("queries/revenue.sql")` reads a `.sql` file into an inline query at load time.
 
 ## Inline (Static) Data

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -77,9 +77,9 @@ Charts visualize one or more series. The `chart` field selects the chart type an
 
 | Chart | Required | Optional | Description |
 |-------|----------|----------|-------------|
-| `line` | `x`, `y` | `color` | Line chart |
-| `bar` | `x`, `y` | `color`, `stacked`, `normalized`, `horizontal` | Bar chart |
-| `area` | `x`, `y` | `color` | Area chart |
+| `line` | `x`, `y` | `color`, `yMin`, `yMax` | Line chart. `yMin`/`yMax` shade a CI band behind the line |
+| `bar` | `x`, `y` | `color`, `stacked`, `normalized`, `horizontal`, `yMin`, `yMax` | Bar chart. `yMin`/`yMax` add error-bar caps |
+| `area` | `x`, `y` | `color`, `yMin`, `yMax` | Area chart. `yMin`/`yMax` shade a CI band |
 | `pie` | `label`, `value` | | Pie/donut chart |
 | `scatter` | `x`, `y` | | Scatter plot |
 | `bubble` | `x`, `y`, `size` | | Bubble chart |
@@ -98,6 +98,7 @@ Charts visualize one or more series. The `chart` field selects the chart type an
 | `treemap` | `label`, `value` | | Rectangular part-to-whole hierarchy |
 | `radar` | `x`, `y` | | Multi-axis polar comparison |
 | `candlestick` | `x`, `open`, `high`, `low`, `close` | | OHLC chart |
+| `forest` | `x`, `y` | `yMin`, `yMax`, `horizontal` | Point estimate + CI interval per category (grey when the interval spans 0). `horizontal: false` → vertical dot-and-whisker; multiple `y` = grouped |
 
 SQL-backed example:
 
@@ -188,12 +189,14 @@ Common chart fields:
 | `color` | object | Category column (`{ field: ... }`) that splits the single `y` series into one series per category — bar, line, and area charts |
 | `stacked` | boolean | Stack the color series (bar charts only; requires `color`) |
 | `normalized` | boolean | Render stacked bars as percentages of the row total (requires `stacked`) |
-| `horizontal` | boolean | Horizontal layout: bar charts put categories on the vertical axis; funnel charts lay stages left-to-right |
+| `horizontal` | boolean | Horizontal layout: bar charts put categories on the vertical axis; funnel charts lay stages left-to-right; forest charts are horizontal by default (`false` = vertical) |
 | `size` | string | Bubble size column for bubble charts |
 | `lines` | string[] | Which `y` series render as lines (rest as bars) for combo charts |
 | `bins` | integer | Number of bins for histogram charts (default 10) |
-| `yMin` | string | Lower control limit column for xmr charts |
-| `yMax` | string | Upper control limit column for xmr charts |
+| `yMin` | string \| object | CI lower bound: xmr control limit, line/area CI band, bar error-bar cap, forest interval. A column name, or a per-series map `{ seriesColumn: boundColumn }` for multi-line/grouped charts |
+| `yMax` | string \| object | CI upper bound (see `yMin`) |
+| `refLines` | object[] | Reference guide lines: `[{ axis: x\|y, value, label?, color? }]` — dashed line (e.g. a 0 no-effect mark). line/area/bar/forest |
+| `refBands` | object[] | Shaded reference bands: `[{ axis: x\|y, from, to, label?, color? }]` — a translucent range (e.g. a ±MDE band). line/area/bar/forest |
 | `dimension` | string | Semantic dimension name |
 | `granularity` | string | Semantic time grain for `dimension` |
 | `metrics` | string[] | Semantic metric names |

--- a/examples/basic-yaml/dashboards/experiment-charts.yml
+++ b/examples/basic-yaml/dashboards/experiment-charts.yml
@@ -1,0 +1,326 @@
+schema: https://getbruin.com/schemas/dac/dashboard/v1
+name: Experiment Readout
+description: CI bands, forest plots, error-bar caps and reference lines/bands — mirrors the cloud demo gallery (inline data, no connection needed)
+
+rows:
+  - height: 340px
+    widgets:
+      - id: ex_line_band
+        name: Line + CI band
+        type: chart
+        chart: line
+        col: 6
+        x:
+          field: day
+          type: number
+          title: day K
+        y:
+          field: effect
+          type: number
+          title: "return Δ %"
+        yMin: lo
+        yMax: hi
+        refLines:
+          - axis: y
+            value: 0
+            label: no effect
+        data:
+          columns: [day, effect, lo, hi]
+          rows:
+            - [0, 2.0, -4.0, 8.0]
+            - [1, 4.0, -2.7, 10.7]
+            - [2, 6.0, -1.4, 13.4]
+            - [3, 8.0, -0.1, 16.1]
+            - [4, 10.0, 1.2, 18.8]
+            - [5, 12.0, 2.5, 21.5]
+            - [6, 14.0, 3.8, 24.2]
+      - id: ex_forest
+        name: Forest (horizontal)
+        type: chart
+        chart: forest
+        col: 6
+        x:
+          field: metric
+          type: category
+          title: metric
+        y:
+          field: effect
+          type: number
+          title: "treatment − control, %"
+        yMin: lo
+        yMax: hi
+        data:
+          columns: [metric, effect, lo, hi]
+          rows:
+            - ["in-app min", 8, -4, 20]
+            - ["board min", 9, -2, 20]
+            - ["sessions", 6, 1, 12]
+            - ["wins", 15, 6, 24]
+            - ["attempts", 11, 2, 21]
+            - ["revenue", -38, -70, 3]
+
+  - height: 340px
+    widgets:
+      - id: ex_perline
+        name: Per-line CI bands (2 lines)
+        type: chart
+        chart: line
+        col: 12
+        x:
+          field: day
+          type: number
+          title: day K
+        y:
+          field: [rv, inter]
+          type: number
+          title: "ads Δ, % of control"
+        yMin:
+          rv: rv_lo
+          inter: in_lo
+        yMax:
+          rv: rv_hi
+          inter: in_hi
+        refLines:
+          - axis: y
+            value: 0
+            label: no effect
+        data:
+          columns: [day, rv, inter, rv_lo, rv_hi, in_lo, in_hi]
+          rows:
+            - [0, 18, 25, 5, 30, 12, 40]
+            - [1, 20, 34, 6, 34, 18, 50]
+            - [2, 25, 41, 8, 42, 22, 60]
+            - [3, 40, 27, 15, 65, 10, 44]
+            - [4, 61, 33, 25, 97, 12, 54]
+            - [5, 86, 22, 40, 130, 0, 44]
+            - [6, 88, 0, 42, 134, -20, 20]
+
+  - height: 360px
+    widgets:
+      - id: ex_forest_vertical
+        name: Forest — vertical (dot + whisker)
+        type: chart
+        chart: forest
+        col: 6
+        horizontal: false
+        x:
+          field: cell
+          type: category
+          title: cell
+        y:
+          field: effect
+          type: number
+          title: "returned d1, %"
+        yMin: lo
+        yMax: hi
+        data:
+          columns: [cell, effect, lo, hi]
+          rows:
+            - ["A ref", 32.5, 28, 38]
+            - ["B", 28, 24, 33]
+            - ["C", 37, 32, 42]
+            - ["D", 34, 29, 39]
+      - id: ex_forest_dual
+        name: Forest — grouped (overlap vs whole)
+        type: chart
+        chart: forest
+        col: 6
+        x:
+          field: metric
+          type: category
+          title: metric
+        y:
+          field: [overlap, whole]
+          type: number
+          title: "treatment − control, %"
+        yMin:
+          overlap: o_lo
+          whole: w_lo
+        yMax:
+          overlap: o_hi
+          whole: w_hi
+        data:
+          columns: [metric, overlap, whole, o_lo, o_hi, w_lo, w_hi]
+          rows:
+            - ["in-app min", 34, 35, 15, 54, 14, 56]
+            - ["sessions", 19, 19, 7, 31, 6, 34]
+            - ["wins", 20, 19, 9, 32, 7, 32]
+            - ["revenue $", 32, 29, -17, 81, -16, 73]
+
+  - height: 360px
+    widgets:
+      - id: ex_forest_band
+        name: "Forest + reference band (±MDE, grey = below resolution)"
+        type: chart
+        chart: forest
+        col: 12
+        x:
+          field: metric
+          type: category
+          title: metric
+        y:
+          field: effect
+          type: number
+          title: "(D−C) − (B−A) in MDE units"
+        yMin: lo
+        yMax: hi
+        refBands:
+          - axis: x
+            from: -1
+            to: 1
+            label: below resolution
+        refLines:
+          - axis: x
+            value: -1
+          - axis: x
+            value: 1
+        data:
+          columns: [metric, effect, lo, hi]
+          rows:
+            - ["in-app min", 0.2, -0.6, 1.0]
+            - ["board min", 0.15, -0.6, 0.9]
+            - ["sessions", -0.1, -0.8, 0.6]
+            - ["wins", -0.15, -0.85, 0.55]
+            - ["attempts", 0.1, -0.6, 0.8]
+            - ["revenue $", -0.6, -1.35, 0.15]
+            - ["return d1", 0.15, -0.55, 0.85]
+
+  - height: 340px
+    widgets:
+      - id: ex_bar
+        name: Grouped bar (2 series)
+        type: chart
+        chart: bar
+        col: 6
+        horizontal: true
+        x:
+          field: arm
+          type: category
+          title: arm
+        y:
+          field: [control, treatment]
+          type: number
+          title: installs
+        yMin:
+          control: c_lo
+          treatment: t_lo
+        yMax:
+          control: c_hi
+          treatment: t_hi
+        data:
+          columns: [arm, control, treatment, c_lo, c_hi, t_lo, t_hi]
+          rows:
+            - ["New_Flow", 920, 910, 880, 960, 872, 948]
+            - ["Scale-Up", 1010, 1005, 968, 1052, 963, 1047]
+            - ["inters/no-ads", 990, 1050, 949, 1031, 1006, 1094]
+      - id: ex_bar_err
+        name: Bar + error-bar caps
+        type: chart
+        chart: bar
+        col: 6
+        x:
+          field: metric
+          type: category
+          title: metric
+        y:
+          field: treatment
+          type: number
+          title: "% of control"
+        yMin: t_lo
+        yMax: t_hi
+        refLines:
+          - axis: y
+            value: 100
+            label: control baseline
+        data:
+          columns: [metric, treatment, t_lo, t_hi]
+          rows:
+            - ["in-app min", 118, 100, 136]
+            - ["sessions", 109, 100, 118]
+            - ["wins", 128, 115, 141]
+            - ["revenue $", 88, 55, 120]
+
+  - height: 340px
+    widgets:
+      - id: ex_heatmap
+        name: Heatmap
+        type: chart
+        chart: heatmap
+        col: 6
+        x:
+          field: nf_arm
+          type: category
+          title: New_Flow arm
+        y:
+          field: su_arm
+          type: category
+          title: Scale-Up arm
+        value:
+          field: count
+        data:
+          columns: [nf_arm, su_arm, count]
+          rows:
+            - ["Control", "control", 482]
+            - ["Control", "treatment", 449]
+            - ["New_Flow", "control", 455]
+            - ["New_Flow", "treatment", 460]
+      - id: ex_scatter
+        name: Scatter
+        type: chart
+        chart: scatter
+        col: 6
+        x:
+          field: nf_effect
+          type: number
+          title: New_Flow effect
+        y:
+          field: su_effect
+          type: number
+          title: Scale-Up effect
+        data:
+          columns: [metric, nf_effect, su_effect]
+          rows:
+            - ["in-app", 12, 9]
+            - ["sessions", 3, 5]
+            - ["wins", 15, 11]
+            - ["revenue", -8, 2]
+            - ["return d1", 4, 6]
+
+  - height: 360px
+    widgets:
+      - id: ex_bar_grouped_err
+        name: "B1 · 2×2 cell means, indexed to A=100 (95% CI)"
+        type: chart
+        chart: bar
+        col: 12
+        x:
+          field: metric
+          type: category
+          title: metric
+        y:
+          field: [A, B, C, D]
+          type: number
+          title: "% of reference cell"
+        yMin:
+          A: a_lo
+          B: b_lo
+          C: c_lo
+          D: d_lo
+        yMax:
+          A: a_hi
+          B: b_hi
+          C: c_hi
+          D: d_hi
+        refLines:
+          - axis: y
+            value: 100
+            label: A = 100
+        data:
+          columns: [metric, A, B, C, D, a_lo, a_hi, b_lo, b_hi, c_lo, c_hi, d_lo, d_hi]
+          rows:
+            - ["in-app min", 100, 101, 131, 141, 84, 117, 87, 117, 110, 152, 116, 166]
+            - ["board min", 100, 105, 134, 145, 83, 117, 90, 120, 112, 157, 118, 173]
+            - ["sessions", 100, 102, 121, 121, 90, 110, 91, 113, 107, 135, 107, 135]
+            - ["wins", 100, 120, 125, 140, 90, 110, 107, 133, 112, 138, 125, 155]
+            - ["attempts", 100, 111, 123, 137, 88, 112, 99, 123, 109, 137, 120, 155]
+            - ["revenue $", 100, 94, 176, 83, 74, 128, 60, 128, 93, 207, 55, 110]

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -1,4 +1,5 @@
-import { useContext, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import {
   LineChart, Line, BarChart, Bar, AreaChart, Area, PieChart, Pie, Cell,
   ScatterChart, Scatter, ZAxis,
@@ -6,6 +7,7 @@ import {
   Treemap,
   RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
   XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
+  ReferenceLine, ReferenceArea, ErrorBar,
 } from "recharts";
 import type { TreemapNode } from "recharts";
 import type { Widget, WidgetData } from "../../types/dashboard";
@@ -16,6 +18,55 @@ import { RowHeightContext } from "../../themes/RowContext";
 const DEFAULT_CHART_HEIGHT = 240;
 // Approx pixels consumed by the widget frame's title/padding above the chart.
 const FRAME_OVERHEAD = 60;
+
+// CI / annotation helpers (mirror the cloud ApexCharts renderer) ───────────
+const CI_BAND_OPACITY = 0.18;
+const REF_LINE_COLOR = "#6B7280";
+const REF_BAND_COLOR = "#F59E0B";
+const FOREST_SIG = "#3B82F6";
+const FOREST_NOSIG = "#9CA3AF";
+
+// Resolve a yMin/yMax bound (a column name, or a per-series {seriesField: column}
+// map) to the bound column for a given series.
+function boundColumn(bound: string | Record<string, string> | undefined, field: string): string | undefined {
+  if (typeof bound === "string") return bound || undefined;
+  if (bound && typeof bound === "object") return bound[field];
+  return undefined;
+}
+
+// Reference guide lines (refLines) and shaded bands (refBands) as Recharts
+// <ReferenceLine>/<ReferenceArea> elements; dropped into any cartesian chart.
+function renderRefs(widget: Widget): ReactNode[] {
+  const els: ReactNode[] = [];
+  (widget.refLines ?? []).forEach((l, i) => {
+    const pos = l.axis === "y" ? { y: l.value } : { x: l.value };
+    els.push(
+      <ReferenceLine
+        key={`rl-${i}`}
+        {...pos}
+        stroke={l.color ?? REF_LINE_COLOR}
+        strokeDasharray="4 4"
+        label={l.label ? { value: l.label, position: "insideTopRight", fontSize: 10, fill: REF_LINE_COLOR } : undefined}
+      />,
+    );
+  });
+  (widget.refBands ?? []).forEach((b, i) => {
+    const pos = b.axis === "y" ? { y1: b.from, y2: b.to } : { x1: b.from, x2: b.to };
+    els.push(
+      <ReferenceArea
+        key={`rb-${i}`}
+        {...pos}
+        fill={b.color ?? REF_BAND_COLOR}
+        fillOpacity={0.12}
+        stroke={b.color ?? REF_BAND_COLOR}
+        strokeOpacity={0.4}
+        strokeDasharray="4 4"
+        label={b.label ? { value: b.label, position: "insideTop", fontSize: 10, fill: REF_LINE_COLOR } : undefined}
+      />,
+    );
+  });
+  return els;
+}
 
 interface Props {
   widget: Widget;
@@ -416,85 +467,135 @@ function CalendarHeatmap({
 
 // --- Heatmap rendering ---
 
+const HEATMAP_SHADES = [
+  { color: "#DBEAFE", name: "Low" },
+  { color: "#93C5FD", name: "Medium" },
+  { color: "#3B82F6", name: "High" },
+  { color: "#1E3A8A", name: "Very High" },
+];
+
 function HeatmapChart({
   data,
   xKey,
   yKey,
   valueKey,
-  colors,
+  xTitle,
   axisColor,
 }: {
   data: Record<string, unknown>[];
   xKey: string;
   yKey: string;
   valueKey: string;
-  colors: string[];
+  xTitle?: string;
   axisColor: string;
 }) {
   const [hover, setHover] = useState<{ x: number; y: number; xLabel: string; yLabel: string; value: number } | null>(null);
 
-  const { cells, xLabels, yLabels, maxVal } = useMemo(() => {
+  const { cells, xLabels, yLabels, minVal, maxVal } = useMemo(() => {
     const xs = [...new Set(data.map((d) => String(d[xKey])))];
     const ys = [...new Set(data.map((d) => String(d[yKey])))];
-    let maxV = 0;
+    let maxV = -Infinity;
+    let minV = Infinity;
     const cellMap = new Map<string, number>();
     for (const d of data) {
       const val = Number(d[valueKey]) || 0;
       cellMap.set(`${d[xKey]}_${d[yKey]}`, val);
       if (val > maxV) maxV = val;
+      if (val < minV) minV = val;
     }
-    return { cells: cellMap, xLabels: xs, yLabels: ys, maxVal: maxV };
+    if (!Number.isFinite(minV)) minV = 0;
+    if (!Number.isFinite(maxV)) maxV = 1;
+    return { cells: cellMap, xLabels: xs, yLabels: ys, minVal: minV, maxVal: maxV };
   }, [data, xKey, yKey, valueKey]);
 
-  const cellW = Math.max(20, Math.min(50, 600 / xLabels.length));
-  const cellH = Math.max(16, Math.min(30, 200 / yLabels.length));
-  const leftPad = 60;
-  const topPad = 24;
-  const width = leftPad + xLabels.length * cellW;
-  const height = topPad + yLabels.length * cellH;
-  const baseColor = colors[0] ?? "#4338CA";
+  // Discrete 4-bucket scale (equal-width min→max); a continuous opacity ramp made near-equal values indistinguishable.
+  const span = maxVal > minVal ? maxVal - minVal : 1;
+  const bucketOf = (v: number) => Math.min(3, Math.max(0, Math.floor(((v - minVal) / span) * 4)));
+
+  // Measure width to draw 1:1; a small viewBox scaled to 100% magnified fonts/cells.
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [boxW, setBoxW] = useState(720);
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w && w > 0) setBoxW(w);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // y-labels left, x-ticks + centred x-title below the grid (matches the cloud heatmap).
+  const leftPad = 92;
+  const rightPad = 16;
+  const topPad = 10;
+  const cellH = Math.max(28, Math.min(96, 220 / yLabels.length));
+  const gridBottom = topPad + yLabels.length * cellH;
+  const tickY = gridBottom + 18;
+  const titleY = gridBottom + 40;
+  const height = gridBottom + (xTitle ? 50 : 26);
+  const width = Math.max(240, boxW);
+  const gridW = Math.max(48, width - leftPad - rightPad);
+  const cellW = gridW / xLabels.length;
 
   return (
-    <svg width="100%" viewBox={`0 0 ${width} ${height}`} style={{ maxHeight: 240 }}
-      onMouseLeave={() => setHover(null)}>
-      {xLabels.map((x, i) => (
-        <text key={`x-${i}`} x={leftPad + i * cellW + cellW / 2} y={14} fill={axisColor} fontSize={9} fontFamily='"Geist", system-ui' textAnchor="middle">
-          {formatAxisTick(x)}
-        </text>
-      ))}
-      {yLabels.map((y, j) => (
-        <text key={`y-${j}`} x={leftPad - 4} y={topPad + j * cellH + cellH / 2 + 3} fill={axisColor} fontSize={9} fontFamily='"Geist", system-ui' textAnchor="end">
-          {String(y).slice(0, 8)}
-        </text>
-      ))}
-      {xLabels.map((x, i) =>
-        yLabels.map((y, j) => {
-          const val = cells.get(`${x}_${y}`) ?? 0;
-          const intensity = maxVal > 0 ? val / maxVal : 0;
-          const opacity = val === 0 ? 0.04 : 0.12 + intensity * 0.88;
-          const rx = leftPad + i * cellW + 1;
-          const ry = topPad + j * cellH + 1;
-          return (
-            <rect
-              key={`${i}-${j}`}
-              x={rx}
-              y={ry}
-              width={cellW - 2}
-              height={cellH - 2}
-              rx={2}
-              fill={baseColor}
-              opacity={opacity}
-              onMouseEnter={() => setHover({ x: rx + cellW, y: ry + cellH / 2, xLabel: x, yLabel: y, value: val })}
-              onMouseLeave={() => setHover(null)}
-            />
-          );
-        }),
-      )}
-      {hover && (
-        <SvgTooltip x={hover.x} y={hover.y}
-          lines={[`${formatAxisTick(hover.xLabel)}, ${hover.yLabel}`, formatTooltipValue(hover.value)]} />
-      )}
-    </svg>
+    <div ref={wrapRef} style={{ width: "100%" }}>
+      <div style={{ display: "flex", justifyContent: "center", gap: 16, marginBottom: 8, flexWrap: "wrap" }}>
+        {HEATMAP_SHADES.map((s) => (
+          <div key={s.name} style={{ display: "flex", alignItems: "center", gap: 5 }}>
+            <span style={{ width: 12, height: 12, borderRadius: 2, background: s.color, display: "inline-block" }} />
+            <span style={{ fontSize: 12, color: axisColor, fontFamily: '"Geist", system-ui' }}>{s.name}</span>
+          </div>
+        ))}
+      </div>
+      <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`}
+        onMouseLeave={() => setHover(null)}>
+        {yLabels.map((y, j) => (
+          <text key={`y-${j}`} x={leftPad - 8} y={topPad + j * cellH + cellH / 2 + 4} fill={axisColor} fontSize={12} fontFamily='"Geist", system-ui' textAnchor="end">
+            {String(y)}
+          </text>
+        ))}
+        {xLabels.map((x, i) =>
+          yLabels.map((y, j) => {
+            const raw = cells.get(`${x}_${y}`);
+            const present = raw !== undefined;
+            const val = raw ?? 0;
+            const fill = present ? HEATMAP_SHADES[bucketOf(val)].color : "#E5E7EB";
+            const rx = leftPad + i * cellW + 2;
+            const ry = topPad + j * cellH + 2;
+            return (
+              <rect
+                key={`${i}-${j}`}
+                x={rx}
+                y={ry}
+                width={Math.max(1, cellW - 4)}
+                height={Math.max(1, cellH - 4)}
+                rx={3}
+                fill={fill}
+                opacity={present ? 1 : 0.4}
+                onMouseEnter={() => setHover({ x: rx + cellW, y: ry + cellH / 2, xLabel: x, yLabel: y, value: val })}
+                onMouseLeave={() => setHover(null)}
+              />
+            );
+          }),
+        )}
+        {xLabels.map((x, i) => (
+          <text key={`xt-${i}`} x={leftPad + i * cellW + cellW / 2} y={tickY} fill={axisColor} fontSize={12} fontFamily='"Geist", system-ui' textAnchor="middle">
+            {formatAxisTick(x)}
+          </text>
+        ))}
+        {xTitle && (
+          <text x={leftPad + gridW / 2} y={titleY} fill={axisColor} fontSize={13} fontWeight={600} fontFamily='"Geist", system-ui' textAnchor="middle">
+            {xTitle}
+          </text>
+        )}
+        {hover && (
+          <SvgTooltip x={hover.x} y={hover.y}
+            lines={[`${formatAxisTick(hover.xLabel)}, ${hover.yLabel}`, formatTooltipValue(hover.value)]} />
+        )}
+      </svg>
+    </div>
   );
 }
 
@@ -1032,14 +1133,33 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
       const pivoted = colorKey && xKey && yKeys[0] ? pivotByColor(chartData, xKey, yKeys[0], colorKey) : null;
       const rows = pivoted ? pivoted.rows : chartData;
       const series = pivoted ? pivoted.series : yKeys;
+      // CI band: shade each series' yMin/yMax interval (a range <Area>) behind its
+      // line. Needs a ComposedChart to mix Area + Line. Scalar or per-series map.
+      const bandBounds = series.map((f) => ({ f, lo: boundColumn(widget.yMin, f), hi: boundColumn(widget.yMax, f) }));
+      const hasBand = !colorKey && bandBounds.some((b) => b.lo && b.hi);
+      const lineRows = hasBand
+        ? rows.map((r) => {
+            const o: Record<string, unknown> = { ...r };
+            for (const b of bandBounds) {
+              if (!b.lo || !b.hi) continue;
+              const lo = Number(r[b.lo]), hi = Number(r[b.hi]);
+              if (Number.isFinite(lo) && Number.isFinite(hi)) o[`__ci_${b.f}`] = [lo, hi];
+            }
+            return o;
+          })
+        : rows;
+      const LineOrComposed = hasBand ? ComposedChart : LineChart;
       return (
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <LineChart data={rows} margin={cartesianMargin}>
+          <LineOrComposed data={lineRows} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey={xKey} {...commonAxisProps} dy={6} tickFormatter={xTick} {...xLabelProps} />
             <YAxis {...commonAxisProps} dx={-4} tickFormatter={yTick} />
             <Tooltip content={cartesianTooltip} />
             {series.length > 1 && <Legend wrapperStyle={AXIS_STYLE} iconSize={7} />}
+            {hasBand && bandBounds.map((b, i) => (b.lo && b.hi ? (
+              <Area key={`ci-${b.f}`} type="monotone" dataKey={`__ci_${b.f}`} fill={colors[i % colors.length]} fillOpacity={CI_BAND_OPACITY} stroke="none" legendType="none" tooltipType="none" isAnimationActive={false} />
+            ) : null))}
             {series.map((field, i) => (
               <Line
                 key={field}
@@ -1052,7 +1172,8 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
                 isAnimationActive={false}
               />
             ))}
-          </LineChart>
+            {renderRefs(widget)}
+          </LineOrComposed>
         </ResponsiveContainer>
       );
     }
@@ -1069,9 +1190,27 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
       const valueTick = widget.normalized ? formatPercentTick : yTick;
       const valueTooltip = widget.normalized ? formatPercentTick : yTooltipValue;
       const lastRadius: [number, number, number, number] = horizontal ? [0, 2, 2, 0] : [2, 2, 0, 0];
+      // Error-bar caps: pair each series with its yMin/yMax columns (scalar for a
+      // single series, or a per-series map for grouped bars) and precompute the
+      // asymmetric offsets [value-lo, hi-value] that Recharts <ErrorBar> expects.
+      const errBounds = series.map((f) => ({ f, lo: boundColumn(widget.yMin, f), hi: boundColumn(widget.yMax, f) }));
+      const hasErr = !colorKey && errBounds.some((b) => b.lo && b.hi);
+      const barRows = hasErr
+        ? rows.map((r) => {
+            const o: Record<string, unknown> = { ...r };
+            for (const b of errBounds) {
+              if (!b.lo || !b.hi) continue;
+              const v = Number(r[b.f]), lo = Number(r[b.lo]), hi = Number(r[b.hi]);
+              // Clamp to ≥0: if the estimate falls outside its interval, a raw
+              // offset would go negative and Recharts draws an inverted cap.
+              if (Number.isFinite(v) && Number.isFinite(lo) && Number.isFinite(hi)) o[`__err_${b.f}`] = [Math.max(0, v - lo), Math.max(0, hi - v)];
+            }
+            return o;
+          })
+        : rows;
       return (
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <BarChart data={rows} layout={horizontal ? "vertical" : "horizontal"} margin={cartesianMargin}>
+          <BarChart data={barRows} layout={horizontal ? "vertical" : "horizontal"} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} vertical={horizontal} horizontal={!horizontal} />
             {horizontal ? (
               <>
@@ -1094,8 +1233,13 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
                 stackId={isStacked ? "stack" : undefined}
                 radius={isStacked && i < series.length - 1 ? undefined : lastRadius}
                 isAnimationActive={false}
-              />
+              >
+                {hasErr && errBounds[i].lo && errBounds[i].hi && (
+                  <ErrorBar dataKey={`__err_${field}`} width={4} strokeWidth={1} stroke="#374151" direction={horizontal ? "x" : "y"} />
+                )}
+              </Bar>
             ))}
+            {renderRefs(widget)}
           </BarChart>
         </ResponsiveContainer>
       );
@@ -1106,14 +1250,31 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
       const pivoted = colorKey && xKey && yKeys[0] ? pivotByColor(chartData, xKey, yKeys[0], colorKey) : null;
       const rows = pivoted ? pivoted.rows : chartData;
       const series = pivoted ? pivoted.series : yKeys;
+      // CI band: a translucent range <Area> per series (yMin/yMax) behind the fill.
+      const bandBounds = series.map((f) => ({ f, lo: boundColumn(widget.yMin, f), hi: boundColumn(widget.yMax, f) }));
+      const hasBand = !colorKey && bandBounds.some((b) => b.lo && b.hi);
+      const areaRows = hasBand
+        ? rows.map((r) => {
+            const o: Record<string, unknown> = { ...r };
+            for (const b of bandBounds) {
+              if (!b.lo || !b.hi) continue;
+              const lo = Number(r[b.lo]), hi = Number(r[b.hi]);
+              if (Number.isFinite(lo) && Number.isFinite(hi)) o[`__ci_${b.f}`] = [lo, hi];
+            }
+            return o;
+          })
+        : rows;
       return (
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <AreaChart data={rows} margin={cartesianMargin}>
+          <AreaChart data={areaRows} margin={cartesianMargin}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey={xKey} {...commonAxisProps} dy={6} tickFormatter={xTick} {...xLabelProps} />
             <YAxis {...commonAxisProps} dx={-4} tickFormatter={yTick} />
             <Tooltip content={cartesianTooltip} />
             {series.length > 1 && <Legend wrapperStyle={AXIS_STYLE} iconSize={7} />}
+            {hasBand && bandBounds.map((b, i) => (b.lo && b.hi ? (
+              <Area key={`ci-${b.f}`} type="monotone" dataKey={`__ci_${b.f}`} fill={colors[i % colors.length]} fillOpacity={CI_BAND_OPACITY} stroke="none" legendType="none" tooltipType="none" isAnimationActive={false} />
+            ) : null))}
             {series.map((field, i) => (
               <Area
                 key={field}
@@ -1126,6 +1287,7 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
                 isAnimationActive={false}
               />
             ))}
+            {renderRefs(widget)}
           </AreaChart>
         </ResponsiveContainer>
       );
@@ -1327,7 +1489,7 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
           xKey={xKey!}
           yKey={yKeys[0] ?? "y"}
           valueKey={valueField(widget.value) || "value"}
-          colors={colors}
+          xTitle={widget.x?.title}
           axisColor={axisColor}
         />
       );
@@ -1393,10 +1555,10 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
             <YAxis {...commonAxisProps} dx={-4} tickFormatter={yTick} />
             <Tooltip content={cartesianTooltip} />
             <Line type="monotone" dataKey={yField} stroke={colors[0]} strokeWidth={1.5} dot={{ r: 2, strokeWidth: 0, fill: colors[0] }} isAnimationActive={false} />
-            {widget.yMin && (
+            {typeof widget.yMin === "string" && (
               <Line type="monotone" dataKey={widget.yMin} stroke={colors[3] ?? "#DC2626"} strokeWidth={1} strokeDasharray="4 4" dot={false} isAnimationActive={false} />
             )}
-            {widget.yMax && (
+            {typeof widget.yMax === "string" && (
               <Line type="monotone" dataKey={widget.yMax} stroke={colors[3] ?? "#DC2626"} strokeWidth={1} strokeDasharray="4 4" dot={false} isAnimationActive={false} />
             )}
             {yKeys.length > 1 && (
@@ -1501,6 +1663,89 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
           gridColor={gridColor}
         />
       );
+
+    case "forest": {
+      // Point estimate + CI interval per category as a native dot + whisker
+      // (Recharts Scatter + ErrorBar). Horizontal (default, matches cloud) puts the
+      // value on x; horizontal: false gives a vertical dot-and-whisker (B1 style).
+      // Grey when the interval spans 0 (not significant); coloured by series when
+      // grouped.
+      const horizontal = widget.horizontal !== false;
+      const catField = xKey ?? "";
+      const multi = yKeys.length > 1;
+      // Grouped forests would draw every series on the same category line, so the
+      // dots/whiskers overlap. Recharts has no native dodge for Scatter, so the
+      // category axis runs as a numeric "slot" axis (one integer per category, ticks
+      // relabelled with the names) and each series gets a small offset within its
+      // slot. Single-series forests keep the plain category axis.
+      const cats: string[] = [];
+      for (const r of chartData) {
+        const c = String(r[catField] ?? "");
+        if (!cats.includes(c)) cats.push(c);
+      }
+      const n = yKeys.length;
+      const seriesOffset = (si: number) => (multi ? (si - (n - 1) / 2) * (0.3 / (n - 1)) : 0);
+      const forestSeries = yKeys.map((f, si) => {
+        const loCol = boundColumn(widget.yMin, f);
+        const hiCol = boundColumn(widget.yMax, f);
+        const off = seriesOffset(si);
+        const pts = chartData.map((r) => {
+          const est = Number(r[f]);
+          const lo = loCol ? Number(r[loCol]) : NaN;
+          const hi = hiCol ? Number(r[hiCol]) : NaN;
+          const cat = String(r[catField] ?? "");
+          const hasCI = Number.isFinite(lo) && Number.isFinite(hi);
+          const [low, high] = hasCI ? (lo <= hi ? [lo, hi] : [hi, lo]) : [est, est];
+          const spansZero = low <= 0 && high >= 0;
+          const err = hasCI ? [Math.max(0, est - low), Math.max(0, high - est)] : undefined;
+          const catPos: number | string = multi ? cats.indexOf(cat) + off : cat;
+          return horizontal ? { x: est, y: catPos, err, spansZero } : { x: catPos, y: est, err, spansZero };
+        });
+        return { field: f, pts, color: colors[si % colors.length] };
+      });
+      const slotAxisProps = {
+        type: "number" as const,
+        domain: [-0.5, cats.length - 0.5] as [number, number],
+        ticks: cats.map((_, i) => i),
+        tickFormatter: (v: unknown) => xTick(cats[Math.round(Number(v))] ?? ""),
+        allowDecimals: false,
+      };
+      return (
+        <ResponsiveContainer width="100%" height={chartHeight}>
+          <ScatterChart margin={cartesianMargin}>
+            <CartesianGrid {...gridProps} />
+            {horizontal ? (
+              <>
+                <XAxis type="number" dataKey="x" {...commonAxisProps} dy={6} tickFormatter={yTick} />
+                {multi
+                  ? <YAxis dataKey="y" {...commonAxisProps} dx={-4} width={80} {...slotAxisProps} />
+                  : <YAxis type="category" dataKey="y" {...commonAxisProps} dx={-4} width={80} tickFormatter={xTick} />}
+              </>
+            ) : (
+              <>
+                {multi
+                  ? <XAxis dataKey="x" {...commonAxisProps} dy={6} {...slotAxisProps} {...xLabelProps} />
+                  : <XAxis type="category" dataKey="x" {...commonAxisProps} dy={6} tickFormatter={xTick} {...xLabelProps} />}
+                <YAxis type="number" dataKey="y" {...commonAxisProps} dx={-4} tickFormatter={yTick} />
+              </>
+            )}
+            <ZAxis range={[36, 36]} />
+            <Tooltip content={cartesianTooltip} cursor={{ strokeDasharray: "3 3" }} />
+            {multi && <Legend wrapperStyle={AXIS_STYLE} iconSize={7} />}
+            {horizontal
+              ? <ReferenceLine x={0} stroke={REF_LINE_COLOR} strokeDasharray="4 4" />
+              : <ReferenceLine y={0} stroke={REF_LINE_COLOR} strokeDasharray="4 4" />}
+            {forestSeries.map((s) => (
+              <Scatter key={s.field} name={s.field} data={s.pts} fill={multi ? s.color : FOREST_SIG} isAnimationActive={false}>
+                {!multi && s.pts.map((p, pi) => <Cell key={pi} fill={p.spansZero ? FOREST_NOSIG : FOREST_SIG} />)}
+                <ErrorBar dataKey="err" width={4} strokeWidth={1.5} stroke={multi ? s.color : "#374151"} direction={horizontal ? "x" : "y"} />
+              </Scatter>
+            ))}
+            {renderRefs(widget)}
+          </ScatterChart>
+        </ResponsiveContainer>
+      );
+    }
 
     default:
       return <div className="text-[var(--dac-text-muted)] text-xs">Unknown chart: {widget.chart}</div>;

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -73,7 +73,7 @@ export interface Widget {
   sort?: SemanticSort[];
 
   // Chart
-  chart?: "line" | "bar" | "area" | "pie" | "scatter" | "bubble" | "combo" | "histogram" | "boxplot" | "funnel" | "sankey" | "heatmap" | "calendar" | "sparkline" | "waterfall" | "xmr" | "dumbbell" | "gauge" | "treemap" | "radar" | "candlestick";
+  chart?: "line" | "bar" | "area" | "pie" | "scatter" | "bubble" | "combo" | "histogram" | "boxplot" | "funnel" | "sankey" | "heatmap" | "calendar" | "sparkline" | "waterfall" | "xmr" | "dumbbell" | "gauge" | "treemap" | "radar" | "candlestick" | "forest";
   x?: AxisEncoding;
   y?: AxisEncoding;
   label?: string;
@@ -89,8 +89,12 @@ export interface Widget {
   target?: string;     // sankey: target column / gauge: target (max) column
   bins?: number;       // histogram: number of bins
   lines?: string[];    // combo: which y series are lines
-  yMin?: string;       // xmr: min control limit column
-  yMax?: string;       // xmr: max control limit column
+  // xmr control limit column; line/bar/forest CI bound — a column name, or a
+  // per-series map { series column: bound column } for multi-line CI bands.
+  yMin?: string | Record<string, string>;
+  yMax?: string | Record<string, string>;
+  refLines?: RefLine[];  // reference guide lines (axis + value + optional label)
+  refBands?: RefBand[];  // shaded reference bands (axis + from/to + optional label)
   open?: string;       // candlestick: open column
   high?: string;       // candlestick: high column
   low?: string;        // candlestick: low column
@@ -105,6 +109,21 @@ export interface Widget {
   // Image
   src?: string;
   alt?: string;
+}
+
+export interface RefLine {
+  axis: "x" | "y";
+  value: number;
+  label?: string;
+  color?: string;
+}
+
+export interface RefBand {
+  axis: "x" | "y";
+  from: number;
+  to: number;
+  label?: string;
+  color?: string;
 }
 
 export interface TableColumn {

--- a/pkg/dashboard/color_encoding_test.go
+++ b/pkg/dashboard/color_encoding_test.go
@@ -8,6 +8,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 func TestColorEncoding_YAML_ObjectForm(t *testing.T) {
 	yamlBody := `
 color:
@@ -152,11 +154,11 @@ func TestValidate_HorizontalOnlyOnBar(t *testing.T) {
 			SQL:        "SELECT 1 AS x, 1 AS y",
 			X:          &AxisEncoding{Field: "x"},
 			Y:          &AxisEncoding{Field: "y"},
-			Horizontal: true,
+			Horizontal: boolPtr(true),
 		}}}},
 	}
 	err := Validate(d)
-	if err == nil || !strings.Contains(err.Error(), "horizontal is only valid on bar and funnel charts") {
+	if err == nil || !strings.Contains(err.Error(), "horizontal is only valid on bar, funnel and forest charts") {
 		t.Fatalf("expected horizontal-not-on-line error, got: %v", err)
 	}
 }
@@ -171,7 +173,7 @@ func TestValidate_HorizontalFunnelIsValid(t *testing.T) {
 			SQL:        "SELECT stage, users FROM funnel",
 			Label:      "stage",
 			Value:      &ValueEncoding{Field: "users"},
-			Horizontal: true,
+			Horizontal: boolPtr(true),
 		}}}},
 	}
 	if err := Validate(d); err != nil {
@@ -192,7 +194,7 @@ func TestValidate_HappyPath_BarWithColorStackedNormalizedHorizontal(t *testing.T
 			Color:      &ColorEncoding{Field: "region"},
 			Stacked:    true,
 			Normalized: true,
-			Horizontal: true,
+			Horizontal: boolPtr(true),
 		}}}},
 	}
 	if err := Validate(d); err != nil {

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -531,14 +531,16 @@ func vnodeToWidget(n *vnode) Widget {
 		Color:      asColorEncoding(n.Props["color"]),
 		Stacked:    asBool(n.Props["stacked"]),
 		Normalized: asBool(n.Props["normalized"]),
-		Horizontal: asBool(n.Props["horizontal"]),
+		Horizontal: asBoolPtr(n.Props["horizontal"]),
 		Size:       asString(n.Props["size"]),
 		Source:     asString(n.Props["source"]),
 		Target:     asString(n.Props["target"]),
 		Bins:       asInt(n.Props["bins"]),
 		Lines:      asStringSlice(n.Props["lines"]),
-		YMin:       asString(n.Props["yMin"]),
-		YMax:       asString(n.Props["yMax"]),
+		YMin:       asBoundEncoding(n.Props["yMin"]),
+		YMax:       asBoundEncoding(n.Props["yMax"]),
+		RefLines:   asRefLines(n.Props["refLines"]),
+		RefBands:   asRefBands(n.Props["refBands"]),
 
 		// Table fields
 		Columns: asTableColumns(n.Props["columns"]),
@@ -586,6 +588,31 @@ func asString(v interface{}) string {
 	return fmt.Sprintf("%v", v)
 }
 
+// asBoundEncoding reads a yMin/yMax prop: a column-name string, or a per-series
+// map {series: column}. Returns nil when empty so omitempty drops it.
+func asBoundEncoding(v interface{}) *BoundEncoding {
+	switch t := v.(type) {
+	case string:
+		if t == "" {
+			return nil
+		}
+		return &BoundEncoding{Field: t}
+	case map[string]interface{}:
+		m := map[string]string{}
+		for k, vv := range t {
+			if s, ok := vv.(string); ok && s != "" {
+				m[k] = s
+			}
+		}
+		if len(m) == 0 {
+			return nil
+		}
+		return &BoundEncoding{Map: m}
+	default:
+		return nil
+	}
+}
+
 func asInt(v interface{}) int {
 	if v == nil {
 		return 0
@@ -610,6 +637,73 @@ func asBool(v interface{}) bool {
 		return b
 	}
 	return false
+}
+
+// asBoolPtr returns nil when the prop is absent so a distinct absent-vs-false can
+// survive (forest defaults to horizontal; an explicit false must not be dropped).
+func asBoolPtr(v interface{}) *bool {
+	if v == nil {
+		return nil
+	}
+	if b, ok := v.(bool); ok {
+		return &b
+	}
+	return nil
+}
+
+func asFloat(v interface{}) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	}
+	return 0
+}
+
+func asRefLines(v interface{}) []RefLine {
+	raw, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]RefLine, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		out = append(out, RefLine{
+			Axis:  asString(m["axis"]),
+			Value: asFloat(m["value"]),
+			Label: asString(m["label"]),
+			Color: asString(m["color"]),
+		})
+	}
+	return out
+}
+
+func asRefBands(v interface{}) []RefBand {
+	raw, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]RefBand, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		out = append(out, RefBand{
+			Axis:  asString(m["axis"]),
+			From:  asFloat(m["from"]),
+			To:    asFloat(m["to"]),
+			Label: asString(m["label"]),
+			Color: asString(m["color"]),
+		})
+	}
+	return out
 }
 
 func asStringSlice(v interface{}) []string {

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -114,7 +114,7 @@ type Widget struct {
 	Limit       int                    `yaml:"limit,omitempty" json:"limit,omitempty"` // LIMIT for dimensional queries
 
 	// Chart fields
-	Chart      string         `yaml:"chart,omitempty" json:"chart,omitempty"` // line, bar, area, pie, scatter, bubble, combo, histogram, boxplot, funnel, sankey, heatmap, calendar, sparkline, waterfall, xmr, dumbbell, gauge, treemap, radar, candlestick
+	Chart      string         `yaml:"chart,omitempty" json:"chart,omitempty"` // line, bar, area, pie, scatter, bubble, combo, histogram, boxplot, funnel, sankey, heatmap, calendar, sparkline, waterfall, xmr, dumbbell, gauge, treemap, radar, candlestick, forest
 	X          *AxisEncoding  `yaml:"x,omitempty" json:"x,omitempty"`
 	Y          *AxisEncoding  `yaml:"y,omitempty" json:"y,omitempty"`
 	Label      string         `yaml:"label,omitempty" json:"label,omitempty"` // for pie/funnel/treemap
@@ -122,18 +122,20 @@ type Widget struct {
 	Color      *ColorEncoding `yaml:"color,omitempty" json:"color,omitempty"`
 	Stacked    bool           `yaml:"stacked,omitempty" json:"stacked,omitempty"`
 	Normalized bool           `yaml:"normalized,omitempty" json:"normalized,omitempty"`
-	Horizontal bool           `yaml:"horizontal,omitempty" json:"horizontal,omitempty"` // bar: horizontal bars; funnel: lay stages left-to-right
+	Horizontal *bool          `yaml:"horizontal,omitempty" json:"horizontal,omitempty"` // bar/funnel: horizontal layout; forest: defaults horizontal, set false for a vertical dot-and-whisker. Pointer so an explicit false survives JSON marshaling.
 	Size       string         `yaml:"size,omitempty" json:"size,omitempty"`
-	Source     string         `yaml:"source,omitempty" json:"source,omitempty"` // sankey: source column
-	Target     string         `yaml:"target,omitempty" json:"target,omitempty"` // sankey: target column, gauge: target (max) column
-	Bins       int            `yaml:"bins,omitempty" json:"bins,omitempty"`     // histogram: number of bins
-	Lines      []string       `yaml:"lines,omitempty" json:"lines,omitempty"`   // combo: which y series render as lines
-	YMin       string         `yaml:"yMin,omitempty" json:"yMin,omitempty"`     // xmr: min control limit column
-	YMax       string         `yaml:"yMax,omitempty" json:"yMax,omitempty"`     // xmr: max control limit column
-	Open       string         `yaml:"open,omitempty" json:"open,omitempty"`     // candlestick: open price column
-	High       string         `yaml:"high,omitempty" json:"high,omitempty"`     // candlestick: high price column
-	Low        string         `yaml:"low,omitempty" json:"low,omitempty"`       // candlestick: low price column
-	Close      string         `yaml:"close,omitempty" json:"close,omitempty"`   // candlestick: close price column
+	Source     string         `yaml:"source,omitempty" json:"source,omitempty"`     // sankey: source column
+	Target     string         `yaml:"target,omitempty" json:"target,omitempty"`     // sankey: target column, gauge: target (max) column
+	Bins       int            `yaml:"bins,omitempty" json:"bins,omitempty"`         // histogram: number of bins
+	Lines      []string       `yaml:"lines,omitempty" json:"lines,omitempty"`       // combo: which y series render as lines
+	YMin       *BoundEncoding `yaml:"yMin,omitempty" json:"yMin,omitempty"`         // xmr: min control limit column; line/bar/forest: CI lower bound (column or per-series map)
+	YMax       *BoundEncoding `yaml:"yMax,omitempty" json:"yMax,omitempty"`         // xmr: max control limit column; line/bar/forest: CI upper bound (column or per-series map)
+	Open       string         `yaml:"open,omitempty" json:"open,omitempty"`         // candlestick: open price column
+	High       string         `yaml:"high,omitempty" json:"high,omitempty"`         // candlestick: high price column
+	Low        string         `yaml:"low,omitempty" json:"low,omitempty"`           // candlestick: low price column
+	Close      string         `yaml:"close,omitempty" json:"close,omitempty"`       // candlestick: close price column
+	RefLines   []RefLine      `yaml:"refLines,omitempty" json:"refLines,omitempty"` // reference guide lines (axis + value + optional label)
+	RefBands   []RefBand      `yaml:"refBands,omitempty" json:"refBands,omitempty"` // shaded reference bands (axis + from/to + optional label)
 
 	// Table fields
 	Columns []TableColumn `yaml:"columns,omitempty" json:"columns,omitempty"`
@@ -144,6 +146,64 @@ type Widget struct {
 	// Image fields
 	Src string `yaml:"src,omitempty" json:"src,omitempty"`
 	Alt string `yaml:"alt,omitempty" json:"alt,omitempty"`
+}
+
+// BoundEncoding is a CI bound (yMin/yMax): a single column name (scalar form) or a
+// per-series map {series column: bound column} for multi-line CI bands.
+type BoundEncoding struct {
+	Field string            // scalar: a single bound column
+	Map   map[string]string // per-series: {series column: bound column}
+}
+
+func (b *BoundEncoding) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return node.Decode(&b.Field)
+	case yaml.MappingNode:
+		return node.Decode(&b.Map)
+	default:
+		return fmt.Errorf("yMin/yMax: must be a column name or a {series: column} map")
+	}
+}
+
+func (b BoundEncoding) MarshalYAML() (any, error) {
+	if len(b.Map) > 0 {
+		return b.Map, nil
+	}
+	return b.Field, nil
+}
+
+func (b BoundEncoding) MarshalJSON() ([]byte, error) {
+	if len(b.Map) > 0 {
+		return json.Marshal(b.Map)
+	}
+	return json.Marshal(b.Field)
+}
+
+func (b *BoundEncoding) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		b.Field = s
+		return nil
+	}
+	return json.Unmarshal(data, &b.Map)
+}
+
+// RefLine is a reference guide line on a chart's x or y axis.
+type RefLine struct {
+	Axis  string  `yaml:"axis" json:"axis"` // "x" | "y"
+	Value float64 `yaml:"value" json:"value"`
+	Label string  `yaml:"label,omitempty" json:"label,omitempty"`
+	Color string  `yaml:"color,omitempty" json:"color,omitempty"`
+}
+
+// RefBand is a shaded reference band spanning from→to on a chart's x or y axis.
+type RefBand struct {
+	Axis  string  `yaml:"axis" json:"axis"` // "x" | "y"
+	From  float64 `yaml:"from" json:"from"`
+	To    float64 `yaml:"to" json:"to"`
+	Label string  `yaml:"label,omitempty" json:"label,omitempty"`
+	Color string  `yaml:"color,omitempty" json:"color,omitempty"`
 }
 
 type TableColumn struct {

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -265,7 +265,46 @@ var validChartTypes = map[string]bool{
 	"boxplot": true, "funnel": true, "sankey": true, "heatmap": true,
 	"calendar": true, "sparkline": true, "waterfall": true, "xmr": true,
 	"dumbbell": true, "gauge": true, "treemap": true, "radar": true,
-	"candlestick": true,
+	"candlestick": true, "forest": true,
+}
+
+// validateRefAnnotations checks widget.refLines / widget.refBands: axis must be
+// x or y, and a band's range must be non-empty.
+func validateRefAnnotations(prefix string, w *Widget) []string {
+	var errs []string
+	// Reference lines/bands only render on the cartesian charts that draw them;
+	// on other types they would validate but silently do nothing.
+	if len(w.RefLines) > 0 || len(w.RefBands) > 0 {
+		switch w.Chart {
+		case "line", "area", "bar", "forest":
+		default:
+			errs = append(errs, fmt.Sprintf("%s: refLines/refBands are only supported on line, area, bar and forest charts, got %q", prefix, w.Chart))
+		}
+	}
+	// xmr control limits are a single column per bound; a per-series map would be
+	// silently ignored by the renderer.
+	if w.Chart == "xmr" {
+		if w.YMin != nil && len(w.YMin.Map) > 0 {
+			errs = append(errs, fmt.Sprintf("%s: xmr yMin must be a single column, not a per-series map", prefix))
+		}
+		if w.YMax != nil && len(w.YMax.Map) > 0 {
+			errs = append(errs, fmt.Sprintf("%s: xmr yMax must be a single column, not a per-series map", prefix))
+		}
+	}
+	for i, l := range w.RefLines {
+		if l.Axis != "x" && l.Axis != "y" {
+			errs = append(errs, fmt.Sprintf("%s: refLines[%d].axis must be \"x\" or \"y\", got %q", prefix, i, l.Axis))
+		}
+	}
+	for i, b := range w.RefBands {
+		if b.Axis != "x" && b.Axis != "y" {
+			errs = append(errs, fmt.Sprintf("%s: refBands[%d].axis must be \"x\" or \"y\", got %q", prefix, i, b.Axis))
+		}
+		if b.From == b.To {
+			errs = append(errs, fmt.Sprintf("%s: refBands[%d] from and to must differ", prefix, i))
+		}
+	}
+	return errs
 }
 
 func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
@@ -278,6 +317,7 @@ func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
 		errs = append(errs, fmt.Sprintf("%s: unknown chart type %q", prefix, w.Chart))
 		return errs
 	}
+	errs = append(errs, validateRefAnnotations(prefix, w)...)
 
 	// Dimensional chart: uses dimension + metrics from a semantic model
 	// instead of x/y/sql.
@@ -415,8 +455,8 @@ func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
 	if w.Normalized && w.Chart != "bar" {
 		errs = append(errs, fmt.Sprintf("%s: normalized is only valid on bar charts", prefix))
 	}
-	if w.Horizontal && w.Chart != "bar" && w.Chart != "funnel" {
-		errs = append(errs, fmt.Sprintf("%s: horizontal is only valid on bar and funnel charts", prefix))
+	if w.Horizontal != nil && *w.Horizontal && w.Chart != "bar" && w.Chart != "funnel" && w.Chart != "forest" {
+		errs = append(errs, fmt.Sprintf("%s: horizontal is only valid on bar, funnel and forest charts", prefix))
 	}
 
 	return errs

--- a/pkg/importer/metabase/convert.go
+++ b/pkg/importer/metabase/convert.go
@@ -1506,7 +1506,8 @@ func widgetForDisplay(name, display, sql string, settings map[string]any, column
 		base.Chart = chartType(display)
 		base.X, base.Y = xyEncodings(display, settings, columns)
 		if display == "row" {
-			base.Horizontal = true
+			t := true
+			base.Horizontal = &t
 		}
 		if display == "combo" {
 			base.Lines = comboLineFields(base.Y)

--- a/pkg/importer/metabase/semantic.go
+++ b/pkg/importer/metabase/semantic.go
@@ -230,7 +230,8 @@ func semanticWidgetForCard(cardRoot, card map[string]any, name, display string, 
 			Limit:       limit,
 		}
 		if display == "row" {
-			widget.Horizontal = true
+			t := true
+			widget.Horizontal = &t
 		}
 		if display == "combo" && len(metrics) > 1 {
 			widget.Lines = []string{metrics[len(metrics)-1]}

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -291,7 +291,8 @@
             "gauge",
             "treemap",
             "radar",
-            "candlestick"
+            "candlestick",
+            "forest"
           ]
         },
         "x": {
@@ -336,10 +337,18 @@
           "$ref": "#/$defs/stringList"
         },
         "yMin": {
-          "type": "string"
+          "$ref": "#/$defs/boundEncoding"
         },
         "yMax": {
-          "type": "string"
+          "$ref": "#/$defs/boundEncoding"
+        },
+        "refLines": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/refLine" }
+        },
+        "refBands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/refBand" }
         },
         "open": {
           "type": "string"
@@ -519,6 +528,38 @@
       "items": {
         "type": "string"
       }
+    },
+    "boundEncoding": {
+      "description": "A CI bound column: a single column name, or a per-series map {series column: bound column} for multi-line charts.",
+      "oneOf": [
+        { "type": "string" },
+        { "type": "object", "additionalProperties": { "type": "string" } }
+      ]
+    },
+    "refLine": {
+      "type": "object",
+      "required": ["axis", "value"],
+      "properties": {
+        "axis": { "enum": ["x", "y"] },
+        "value": { "type": "number" },
+        "label": { "type": "string" },
+        "color": { "type": "string" }
+      },
+      "patternProperties": { "^x-": true },
+      "additionalProperties": false
+    },
+    "refBand": {
+      "type": "object",
+      "required": ["axis", "from", "to"],
+      "properties": {
+        "axis": { "enum": ["x", "y"] },
+        "from": { "type": "number" },
+        "to": { "type": "number" },
+        "label": { "type": "string" },
+        "color": { "type": "string" }
+      },
+      "patternProperties": { "^x-": true },
+      "additionalProperties": false
     },
     "axisEncoding": {
       "type": "object",


### PR DESCRIPTION
Adds CI bands, bar error-bar caps, a forest chart type, and reference lines/bands to dashboards. yMin/yMax accept a scalar column or a per-series {series: column} map.

Covers the schema, Go model + validator, TSX loader, TS types and the Recharts renderer, plus an example dashboard and the widget docs.