### PR TITLE
Add showValues option to heatmap charts

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -618,10 +618,13 @@ Client-side quartile computation from raw data rows.
   x: { field: hour }                       # REQUIRED: X axis column
   y: { field: [day_of_week] }              # REQUIRED: Y axis column (array with 1 element)
   value: { field: event_count }            # REQUIRED: intensity column
+  showValues: true                         # optional: print each cell's value in the cell
   col: 8
 ```
 
-Custom SVG rendering with hover tooltips.
+Custom SVG rendering with hover tooltips. `showValues` prints the value inside
+each cell (formatted with `value.format`); numbers too wide for their cell are
+omitted.
 
 #### Calendar
 
@@ -1009,7 +1012,7 @@ Every YAML widget type has a corresponding JSX tag. Props map directly to YAML f
 | `<Query>` | (named query) | `name`, `sql`, `file`, `connection` |
 | `<Semantic>` | (semantic layer) | `source`, `metrics`, `dimensions` |
 | `<Metric>` | `metric` | `name`, `col`, `sql`, `query`, `value`, `metric` |
-| `<Chart>` | `chart` | `name`, `col`, `chart`, `sql`, `x`, `y`, `label`, `value`, `color`, `stacked`, `normalized`, `horizontal`, `dimension`, `metrics`, `limit`, etc. |
+| `<Chart>` | `chart` | `name`, `col`, `chart`, `sql`, `x`, `y`, `label`, `value`, `color`, `stacked`, `normalized`, `horizontal`, `showValues`, `dimension`, `metrics`, `limit`, etc. |
 | `<Table>` | `table` | `name`, `col`, `sql`, `query`, `columns` |
 | `<Text>` | `text` | `name`, `col`, `content` |
 | `<Divider>` | `divider` | `name`, `col` |
@@ -1581,7 +1584,7 @@ rows:
 | `boxplot` | `x`, `y` | | Box-and-whisker plot (client-side quartiles) |
 | `funnel` | `label`, `value` | | Funnel chart |
 | `sankey` | `source`, `target`, `value` | | Sankey/flow diagram |
-| `heatmap` | `x`, `y`, `value` | | Grid heatmap |
+| `heatmap` | `x`, `y`, `value` | `showValues` | Grid heatmap. `showValues: true` prints each cell's value inside the cell |
 | `calendar` | `x`, `value` | | Calendar heatmap (GitHub-style) |
 | `sparkline` | `x`, `y` | | Compact inline line (60px) |
 | `waterfall` | `x`, `y` | | Waterfall chart |

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -88,7 +88,7 @@ Charts visualize one or more series. The `chart` field selects the chart type an
 | `boxplot` | `x`, `y` | | Box-and-whisker plot (client-side quartiles) |
 | `funnel` | `label`, `value` | `horizontal` | Conversion funnel: one bar per stage with each stage's share of the top and step-to-step conversion. Rows render in query order — put the top of the funnel first. `horizontal: true` lays stages left-to-right |
 | `sankey` | `source`, `target`, `value` | | Sankey/flow diagram |
-| `heatmap` | `x`, `y`, `value` | | Grid heatmap |
+| `heatmap` | `x`, `y`, `value` | `showValues` | Grid heatmap. `showValues: true` prints each cell's value inside the cell |
 | `calendar` | `x`, `value` | | GitHub-style calendar heatmap |
 | `sparkline` | `x`, `y` | | Compact inline line (60px), no axes |
 | `waterfall` | `x`, `y` | | Waterfall chart |
@@ -221,6 +221,7 @@ Common chart fields:
 | `normalized` | boolean | Render stacked bars as percentages of the row total (requires `stacked`) |
 | `horizontal` | boolean | Horizontal layout: bar charts put categories on the vertical axis; funnel charts lay stages left-to-right; forest charts are horizontal by default (`false` = vertical) |
 | `size` | string | Bubble size column for bubble charts |
+| `showValues` | boolean | Print each cell's value inside the cell (heatmap charts only). A number too wide for its cell is omitted — the shade still carries the magnitude and the tooltip has the exact value |
 | `lines` | string[] | Which `y` series render as lines (rest as bars) for combo charts |
 | `series` | object | Per-series line style overrides keyed by y-column: `{ revenue: { color, curve, dash } }` — line/area/combo. Each key falls back to the chart-wide `y.curve`/`y.dash`/palette |
 | `bins` | integer | Number of bins for histogram charts (default 10) |

--- a/examples/basic-yaml/dashboards/experiment-charts.yml
+++ b/examples/basic-yaml/dashboards/experiment-charts.yml
@@ -247,6 +247,7 @@ rows:
         type: chart
         chart: heatmap
         col: 6
+        showValues: true
         x:
           field: nf_arm
           type: category

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -482,6 +482,12 @@ const HEATMAP_SHADES = [
   { color: "#1E3A8A", name: "Very High" },
 ];
 
+// Ink for a value printed on a shaded cell. getTreemapTextColor's 0.32 threshold
+// would put white on #3B82F6 (3.7:1) — at 11px the darker ink wins there (5.3:1).
+function heatmapCellInk(fill: string): string {
+  return (getHexLuminance(fill) ?? 1) > 0.18 ? "#111827" : "#F9FAFB";
+}
+
 function HeatmapChart({
   data,
   xKey,
@@ -489,6 +495,8 @@ function HeatmapChart({
   valueKey,
   xTitle,
   axisColor,
+  showValues,
+  valueFmt,
 }: {
   data: Record<string, unknown>[];
   xKey: string;
@@ -496,6 +504,8 @@ function HeatmapChart({
   valueKey: string;
   xTitle?: string;
   axisColor: string;
+  showValues?: boolean;
+  valueFmt: (val: unknown) => string;
 }) {
   const [hover, setHover] = useState<{ x: number; y: number; xLabel: string; yLabel: string; value: number } | null>(null);
 
@@ -546,6 +556,22 @@ function HeatmapChart({
   const width = Math.max(240, boxW);
   const gridW = Math.max(48, width - leftPad - rightPad);
   const cellW = gridW / xLabels.length;
+  const rectW = Math.max(1, cellW - 4);
+  const rectH = Math.max(1, cellH - 4);
+
+  // Cell values, formatted and width-checked once per data/size change — hovering
+  // re-renders the whole grid, so this keeps the formatter off that path. A label
+  // that would not fit its cell is dropped: the shade carries the magnitude and
+  // the tooltip has the exact number.
+  const cellLabels = useMemo(() => {
+    if (!showValues) return null;
+    const fitted = new Map<string, string>();
+    for (const [key, val] of cells) {
+      const label = valueFmt(val);
+      if (truncateTreemapLabel(label, rectW, 11) === label) fitted.set(key, label);
+    }
+    return fitted;
+  }, [cells, showValues, valueFmt, rectW]);
 
   return (
     <div ref={wrapRef} style={{ width: "100%" }}>
@@ -577,8 +603,8 @@ function HeatmapChart({
                 key={`${i}-${j}`}
                 x={rx}
                 y={ry}
-                width={Math.max(1, cellW - 4)}
-                height={Math.max(1, cellH - 4)}
+                width={rectW}
+                height={rectH}
                 rx={3}
                 fill={fill}
                 opacity={present ? 1 : 0.4}
@@ -587,6 +613,27 @@ function HeatmapChart({
               />
             );
           }),
+        )}
+        {cellLabels && cellLabels.size > 0 && (
+          <g {...AXIS_STYLE} textAnchor="middle" pointerEvents="none">
+            {xLabels.map((x, i) =>
+              yLabels.map((y, j) => {
+                const label = cellLabels.get(`${x}_${y}`);
+                if (!label) return null;
+                const val = cells.get(`${x}_${y}`) ?? 0;
+                return (
+                  <text
+                    key={`${i}-${j}`}
+                    x={leftPad + i * cellW + 2 + rectW / 2}
+                    y={topPad + j * cellH + 2 + rectH / 2 + 4}
+                    fill={heatmapCellInk(HEATMAP_SHADES[bucketOf(val)].color)}
+                  >
+                    {label}
+                  </text>
+                );
+              }),
+            )}
+          </g>
         )}
         {xLabels.map((x, i) => (
           <text key={`xt-${i}`} x={leftPad + i * cellW + cellW / 2} y={tickY} fill={axisColor} fontSize={12} fontFamily='"Geist", system-ui' textAnchor="middle">
@@ -600,7 +647,7 @@ function HeatmapChart({
         )}
         {hover && (
           <SvgTooltip x={hover.x} y={hover.y}
-            lines={[`${formatAxisTick(hover.xLabel)}, ${hover.yLabel}`, formatTooltipValue(hover.value)]} />
+            lines={[`${formatAxisTick(hover.xLabel)}, ${hover.yLabel}`, valueFmt(hover.value)]} />
         )}
       </svg>
     </div>
@@ -1574,6 +1621,8 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
           valueKey={valueField(widget.value) || "value"}
           xTitle={widget.x?.title}
           axisColor={axisColor}
+          showValues={widget.showValues}
+          valueFmt={buildAxisFormatter(widget.value, formatTooltipValue)}
         />
       );
 

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -91,6 +91,7 @@ export interface Widget {
   source?: string;     // sankey: source column
   target?: string;     // sankey: target column / gauge: target (max) column
   bins?: number;       // histogram: number of bins
+  showValues?: boolean; // heatmap: print each cell's value inside the cell
   lines?: string[];    // combo: which y series are lines
   series?: Record<string, SeriesStyle>; // per-series line style overrides, keyed by y-column
   // xmr control limit column; line/bar/forest CI bound — a column name, or a

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -537,6 +537,7 @@ func vnodeToWidget(n *vnode) Widget {
 		Source:     asString(n.Props["source"]),
 		Target:     asString(n.Props["target"]),
 		Bins:       asInt(n.Props["bins"]),
+		ShowValues: asBool(n.Props["showValues"]),
 		Lines:      asStringSlice(n.Props["lines"]),
 		Series:     asSeriesStyles(n.Props["series"]),
 		YMin:       asBoundEncoding(n.Props["yMin"]),

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -408,6 +408,26 @@ export default (
 	}
 }
 
+func TestEvalTSX_HeatmapShowValues(t *testing.T) {
+	source := `
+export default (
+  <Dashboard name="Heat" connection="db">
+    <Row>
+      <Chart name="Orders" chart="heatmap" showValues={true} col={12}
+        sql="SELECT day, region, orders FROM orders"
+        x="day" y="region" value="orders" />
+    </Row>
+  </Dashboard>
+)
+`
+	d, err := evalTSX(source, "test.tsx", &tsxConfig{})
+	assertNoErr(t, err)
+
+	if !d.Rows[0].Widgets[0].ShowValues {
+		t.Error("expected showValues=true")
+	}
+}
+
 func TestEvalTSX_ErrorNoDefaultExport(t *testing.T) {
 	source := `const x = 1`
 	_, err := evalTSX(source, "test.tsx", &tsxConfig{})

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -127,10 +127,11 @@ type Widget struct {
 	Normalized bool           `yaml:"normalized,omitempty" json:"normalized,omitempty"`
 	Horizontal *bool          `yaml:"horizontal,omitempty" json:"horizontal,omitempty"` // bar/funnel: horizontal layout; forest: defaults horizontal, set false for a vertical dot-and-whisker. Pointer so an explicit false survives JSON marshaling.
 	Size       string         `yaml:"size,omitempty" json:"size,omitempty"`
-	Source     string         `yaml:"source,omitempty" json:"source,omitempty"` // sankey: source column
-	Target     string         `yaml:"target,omitempty" json:"target,omitempty"` // sankey: target column, gauge: target (max) column
-	Bins       int            `yaml:"bins,omitempty" json:"bins,omitempty"`     // histogram: number of bins
-	Lines      []string       `yaml:"lines,omitempty" json:"lines,omitempty"`   // combo: which y series render as lines
+	Source     string         `yaml:"source,omitempty" json:"source,omitempty"`         // sankey: source column
+	Target     string         `yaml:"target,omitempty" json:"target,omitempty"`         // sankey: target column, gauge: target (max) column
+	Bins       int            `yaml:"bins,omitempty" json:"bins,omitempty"`             // histogram: number of bins
+	ShowValues bool           `yaml:"showValues,omitempty" json:"showValues,omitempty"` // heatmap: print each cell's value inside the cell
+	Lines      []string       `yaml:"lines,omitempty" json:"lines,omitempty"`           // combo: which y series render as lines
 	// Series holds per-series line style overrides keyed by y-column: {column: {color, curve, dash}}.
 	Series   map[string]SeriesStyle `yaml:"series,omitempty" json:"series,omitempty"`
 	YMin     *BoundEncoding         `yaml:"yMin,omitempty" json:"yMin,omitempty"`         // xmr: min control limit column; line/bar/forest: CI lower bound (column or per-series map)

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -549,6 +549,9 @@ func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
 	if w.Horizontal != nil && *w.Horizontal && w.Chart != "bar" && w.Chart != "funnel" && w.Chart != "forest" {
 		errs = append(errs, fmt.Sprintf("%s: horizontal is only valid on bar, funnel and forest charts", prefix))
 	}
+	if w.ShowValues && w.Chart != "heatmap" {
+		errs = append(errs, fmt.Sprintf("%s: showValues is only valid on heatmap charts", prefix))
+	}
 
 	return errs
 }

--- a/pkg/dashboard/validator_test.go
+++ b/pkg/dashboard/validator_test.go
@@ -159,6 +159,36 @@ func TestValidate_StackedBarWithColor(t *testing.T) {
 	assertNoErr(t, Validate(d))
 }
 
+func TestValidate_ShowValuesOnlyOnHeatmap(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "w", Type: WidgetTypeChart, Chart: "bar", SQL: "SELECT 1",
+				X: &AxisEncoding{Field: "month"}, Y: &AxisEncoding{Field: "revenue"},
+				ShowValues: true,
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "showValues is only valid on heatmap charts")
+}
+
+func TestValidate_ShowValuesOnHeatmap(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "w", Type: WidgetTypeChart, Chart: "heatmap", SQL: "SELECT 1",
+				X: &AxisEncoding{Field: "day"}, Y: &AxisEncoding{Field: "region"},
+				Value: &ValueEncoding{Field: "orders"}, ShowValues: true,
+			}}},
+		},
+	}
+	assertNoErr(t, Validate(d))
+}
+
 func TestValidate_DualAxisValid(t *testing.T) {
 	d := &Dashboard{
 		Name: "test",

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -337,6 +337,10 @@
           "type": "integer",
           "minimum": 1
         },
+        "showValues": {
+          "type": "boolean",
+          "description": "Heatmap charts: print each cell's value inside the cell."
+        },
         "lines": {
           "$ref": "#/$defs/stringList"
         },


### PR DESCRIPTION
## What

Heatmap charts get a `showValues` option that prints each cell's value inside the cell:

```yaml
- name: Orders by Day and Slot
  type: chart
  chart: heatmap
  showValues: true
  x: { field: day, type: category }
  y: { field: [slot] }
  value: { field: orders, format: ",.0f" }
```

Off by default — without it heatmaps render exactly as before.

## How

- `Widget.ShowValues` (`showValues` in YAML/JSON), wired through every authoring path: YAML loader, TSX loader (`jsloader.go`), JSON schema, TS widget type, docs, and the `create-dashboard` skill reference.
- Validator rejects it on non-heatmap charts, matching the existing `stacked` / `normalized` / `horizontal` rules.
- Cell labels go through the widget's `value` encoding (`buildAxisFormatter`, the same prop `FunnelChart` already takes), so `value: { format: "$,.0f" }` now applies to the cell label **and** to the heatmap tooltip, which had the same gap.
- A number too wide for its cell is omitted instead of overflowing into its neighbours, reusing the treemap label-width math. Labels are formatted and measured once per data/size change rather than on every hover re-render (hover re-renders the whole grid).
- Cell ink comes from the shade's luminance. Note the shared `getTreemapTextColor` threshold (0.32) would put white on `#3B82F6` — 3.68:1, below AA at 11px — while the darker ink there is 5.28:1, so the heatmap keeps its own threshold rather than changing treemap's behaviour in this PR.

## Testing

- `make test` — green, including new `TestValidate_ShowValuesOnlyOnHeatmap`, `TestValidate_ShowValuesOnHeatmap`, `TestEvalTSX_HeatmapShowValues`
- `make format` (go vet), frontend `tsc --noEmit` and `eslint` — clean
- `dac validate --dir examples/basic-yaml` — 6 dashboards OK; the Experiment Readout heatmap example now sets `showValues: true`
- Verified end to end through the API: the widget payload carries `"showValues": true`

Not yet verified visually in a browser — the render path is exercised only by the example dashboard, so a reviewer eyeballing `dac serve --dir examples/basic-yaml` → Experiment Readout is worth it.