### PR TITLE
Let heatmaps set their own color scale

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -619,6 +619,10 @@ Client-side quartile computation from raw data rows.
   y: { field: [day_of_week] }              # REQUIRED: Y axis column (array with 1 element)
   value: { field: event_count }            # REQUIRED: intensity column
   showValues: true                         # optional: print each cell's value in the cell
+  colorScale:                              # optional: replaces the default blue buckets
+    backgroundColor: [red, white, green]   #   2+ colors, low -> high
+    range: [-500, 0, 500]                  #   one anchor per color; omit for auto min/max
+    unit: absolute                         #   absolute (default) | percent | percentile
   col: 8
 ```
 
@@ -1012,7 +1016,7 @@ Every YAML widget type has a corresponding JSX tag. Props map directly to YAML f
 | `<Query>` | (named query) | `name`, `sql`, `file`, `connection` |
 | `<Semantic>` | (semantic layer) | `source`, `metrics`, `dimensions` |
 | `<Metric>` | `metric` | `name`, `col`, `sql`, `query`, `value`, `metric` |
-| `<Chart>` | `chart` | `name`, `col`, `chart`, `sql`, `x`, `y`, `label`, `value`, `color`, `stacked`, `normalized`, `horizontal`, `showValues`, `dimension`, `metrics`, `limit`, etc. |
+| `<Chart>` | `chart` | `name`, `col`, `chart`, `sql`, `x`, `y`, `label`, `value`, `color`, `stacked`, `normalized`, `horizontal`, `showValues`, `colorScale`, `dimension`, `metrics`, `limit`, etc. |
 | `<Table>` | `table` | `name`, `col`, `sql`, `query`, `columns` |
 | `<Text>` | `text` | `name`, `col`, `content` |
 | `<Divider>` | `divider` | `name`, `col` |
@@ -1584,7 +1588,7 @@ rows:
 | `boxplot` | `x`, `y` | | Box-and-whisker plot (client-side quartiles) |
 | `funnel` | `label`, `value` | | Funnel chart |
 | `sankey` | `source`, `target`, `value` | | Sankey/flow diagram |
-| `heatmap` | `x`, `y`, `value` | `showValues` | Grid heatmap. `showValues: true` prints each cell's value inside the cell |
+| `heatmap` | `x`, `y`, `value` | `showValues`, `colorScale` | Grid heatmap. `showValues: true` prints each cell's value inside the cell; `colorScale` sets a custom ramp |
 | `calendar` | `x`, `value` | | Calendar heatmap (GitHub-style) |
 | `sparkline` | `x`, `y` | | Compact inline line (60px) |
 | `waterfall` | `x`, `y` | | Waterfall chart |

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -88,7 +88,7 @@ Charts visualize one or more series. The `chart` field selects the chart type an
 | `boxplot` | `x`, `y` | | Box-and-whisker plot (client-side quartiles) |
 | `funnel` | `label`, `value` | `horizontal` | Conversion funnel: one bar per stage with each stage's share of the top and step-to-step conversion. Rows render in query order — put the top of the funnel first. `horizontal: true` lays stages left-to-right |
 | `sankey` | `source`, `target`, `value` | | Sankey/flow diagram |
-| `heatmap` | `x`, `y`, `value` | `showValues` | Grid heatmap. `showValues: true` prints each cell's value inside the cell |
+| `heatmap` | `x`, `y`, `value` | `showValues`, `colorScale` | Grid heatmap. `showValues: true` prints each cell's value inside the cell; `colorScale` replaces the default blue buckets |
 | `calendar` | `x`, `value` | | GitHub-style calendar heatmap |
 | `sparkline` | `x`, `y` | | Compact inline line (60px), no axes |
 | `waterfall` | `x`, `y` | | Waterfall chart |
@@ -221,6 +221,7 @@ Common chart fields:
 | `normalized` | boolean | Render stacked bars as percentages of the row total (requires `stacked`) |
 | `horizontal` | boolean | Horizontal layout: bar charts put categories on the vertical axis; funnel charts lay stages left-to-right; forest charts are horizontal by default (`false` = vertical) |
 | `size` | string | Bubble size column for bubble charts |
+| `colorScale` | object | Heatmap color ramp: `backgroundColor` (2+ colors, low→high) plus optional `range` anchors and `unit` — the same keys a table gradient uses, resolved by the same code. Scaled across every cell in the grid, unlike a table gradient which is scaled per column. Omit for the default blue buckets |
 | `showValues` | boolean | Print each cell's value inside the cell (heatmap charts only). A number too wide for its cell is omitted — the shade still carries the magnitude and the tooltip has the exact value |
 | `lines` | string[] | Which `y` series render as lines (rest as bars) for combo charts |
 | `series` | object | Per-series line style overrides keyed by y-column: `{ revenue: { color, curve, dash } }` — line/area/combo. Each key falls back to the chart-wide `y.curve`/`y.dash`/palette |
@@ -238,6 +239,39 @@ Common chart fields:
 | `limit` | integer | Row limit |
 
 Charts using `dimension`, `metrics`, `segments`, or semantic `filters` are compiled through the backend semantic layer instead of requiring hand-written SQL.
+
+### Heatmap color scale
+
+By default a heatmap paints four blue buckets (Low → Very High) scaled across the
+whole grid. `colorScale` replaces them with a continuous ramp described in the
+same vocabulary as a table gradient:
+
+```yaml
+- name: Revenue vs Channel Average
+  type: chart
+  chart: heatmap
+  x: { field: channel, type: category }
+  y: { field: [region] }
+  value: { field: delta, format: "$,.0f" }
+  showValues: true
+  colorScale:
+    backgroundColor: [red, white, green]   # low → high, 2 or more colors
+    range: [-500, 0, 500]                  # one anchor per color; omit for auto min/max
+    unit: absolute                         # absolute (default) | percent | percentile
+```
+
+Pinning `range` does two things worth knowing: it puts the neutral color exactly
+on zero (so the sign is readable at a glance), and it keeps the colors stable as
+filters change — without it the ramp rescales to whatever the current result set
+contains, so two filtered views are not comparable.
+
+The default buckets round near-equal values to the same shade; a `colorScale`
+interpolates, so small differences stay visible.
+
+Colors accept the same names as table formatting (`red`, `green`, `blue`,
+`indigo`, `cyan`, `purple`, `pink`, `amber`, plus `white`/`black` and the
+`positive`/`negative`/`warning` aliases) or hex. Cell-value ink is derived from
+each cell's fill, so `showValues` stays readable on any ramp.
 
 ## Table
 

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -10,9 +10,10 @@ import {
   ReferenceLine, ReferenceArea, ErrorBar,
 } from "recharts";
 import type { TreemapNode } from "recharts";
-import type { Widget, WidgetData } from "../../types/dashboard";
+import type { ColorScale, Widget, WidgetData } from "../../types/dashboard";
 import { axisField, axisFields, buildAxisFormatter, valueField } from "../../lib/format";
 import { useTokens } from "../../themes/TemplateProvider";
+import { cellColor, resolveScale } from "./conditionalFormat";
 import { RowHeightContext } from "../../themes/RowContext";
 
 const DEFAULT_CHART_HEIGHT = 240;
@@ -497,6 +498,8 @@ function HeatmapChart({
   axisColor,
   showValues,
   valueFmt,
+  colorScale,
+  tokens,
 }: {
   data: Record<string, unknown>[];
   xKey: string;
@@ -506,6 +509,8 @@ function HeatmapChart({
   axisColor: string;
   showValues?: boolean;
   valueFmt: (val: unknown) => string;
+  colorScale?: ColorScale;
+  tokens: Record<string, string>;
 }) {
   const [hover, setHover] = useState<{ x: number; y: number; xLabel: string; yLabel: string; value: number } | null>(null);
 
@@ -529,6 +534,28 @@ function HeatmapChart({
   // Discrete 4-bucket scale (equal-width min→max); a continuous opacity ramp made near-equal values indistinguishable.
   const span = maxVal > minVal ? maxVal - minVal : 1;
   const bucketOf = (v: number) => Math.min(3, Math.max(0, Math.floor(((v - minVal) / span) * 4)));
+
+  // A `colorScale` replaces the buckets with the table gradient's continuous ramp,
+  // resolved by the same code — the difference is the domain: every cell in the
+  // grid, not one column. Scaled once per data/scale change.
+  const scale = useMemo(() => {
+    if (!colorScale?.backgroundColor?.length) return null;
+    return resolveScale(
+      { backgroundColor: colorScale.backgroundColor, range: colorScale.range, unit: colorScale.unit },
+      [...cells.values()],
+      tokens,
+    );
+  }, [colorScale, cells, tokens]);
+
+  // Fill + readable ink for one cell, from whichever scale is in play.
+  const paint = (v: number): { fill: string; ink: string } => {
+    if (scale) {
+      const c = cellColor(scale, v);
+      if (c) return { fill: c.background, ink: c.text };
+    }
+    const shade = HEATMAP_SHADES[bucketOf(v)].color;
+    return { fill: shade, ink: heatmapCellInk(shade) };
+  };
 
   // Measure width to draw 1:1; a small viewBox scaled to 100% magnified fonts/cells.
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -575,6 +602,22 @@ function HeatmapChart({
 
   return (
     <div ref={wrapRef} style={{ width: "100%" }}>
+      {scale ? (
+        <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 8, marginBottom: 8 }}>
+          <span style={{ fontSize: 12, color: axisColor, fontFamily: '"Geist", system-ui' }}>{valueFmt(scale.stops[0].value)}</span>
+          <span
+            style={{
+              width: 160,
+              height: 10,
+              borderRadius: 2,
+              background: `linear-gradient(to right, ${scale.stops.map((st) => `rgb(${st.rgb.join(",")})`).join(", ")})`,
+            }}
+          />
+          <span style={{ fontSize: 12, color: axisColor, fontFamily: '"Geist", system-ui' }}>
+            {valueFmt(scale.stops[scale.stops.length - 1].value)}
+          </span>
+        </div>
+      ) : (
       <div style={{ display: "flex", justifyContent: "center", gap: 16, marginBottom: 8, flexWrap: "wrap" }}>
         {HEATMAP_SHADES.map((s) => (
           <div key={s.name} style={{ display: "flex", alignItems: "center", gap: 5 }}>
@@ -583,6 +626,7 @@ function HeatmapChart({
           </div>
         ))}
       </div>
+      )}
       <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`}
         onMouseLeave={() => setHover(null)}>
         {yLabels.map((y, j) => (
@@ -595,7 +639,7 @@ function HeatmapChart({
             const raw = cells.get(`${x}_${y}`);
             const present = raw !== undefined;
             const val = raw ?? 0;
-            const fill = present ? HEATMAP_SHADES[bucketOf(val)].color : "#E5E7EB";
+            const fill = present ? paint(val).fill : "#E5E7EB";
             const rx = leftPad + i * cellW + 2;
             const ry = topPad + j * cellH + 2;
             return (
@@ -626,7 +670,7 @@ function HeatmapChart({
                     key={`${i}-${j}`}
                     x={leftPad + i * cellW + 2 + rectW / 2}
                     y={topPad + j * cellH + 2 + rectH / 2 + 4}
-                    fill={heatmapCellInk(HEATMAP_SHADES[bucketOf(val)].color)}
+                    fill={paint(val).ink}
                   >
                     {label}
                   </text>
@@ -1623,6 +1667,8 @@ function ChartBody({ widget, data, titleOffset = 0 }: Props & { titleOffset?: nu
           axisColor={axisColor}
           showValues={widget.showValues}
           valueFmt={buildAxisFormatter(widget.value, formatTooltipValue)}
+          colorScale={widget.colorScale}
+          tokens={tokens}
         />
       );
 

--- a/frontend/src/components/widgets/conditionalFormat.ts
+++ b/frontend/src/components/widgets/conditionalFormat.ts
@@ -121,7 +121,7 @@ function percentileValue(sorted: number[], p: number): number {
 }
 
 /** Interpolate the background/text colors for a single cell value. */
-function cellColor(scale: ResolvedScale, value: number | null): { background: string; text: string } | undefined {
+export function cellColor(scale: ResolvedScale, value: number | null): { background: string; text: string } | undefined {
   if (value === null) return undefined;
 
   const { stops } = scale;

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -92,6 +92,7 @@ export interface Widget {
   target?: string;     // sankey: target column / gauge: target (max) column
   bins?: number;       // histogram: number of bins
   showValues?: boolean; // heatmap: print each cell's value inside the cell
+  colorScale?: ColorScale; // heatmap: color ramp, same keys as a table gradient
   lines?: string[];    // combo: which y series are lines
   series?: Record<string, SeriesStyle>; // per-series line style overrides, keyed by y-column
   // xmr control limit column; line/bar/forest CI bound — a column name, or a
@@ -185,6 +186,17 @@ export type RuleValue = number | string | ColumnRef | Array<number | string | Co
  * `range` + `unit` (`absolute` | `percent` | `percentile`) pin a gradient's
  * anchors; omit `range` for an auto min/max gradient.
  */
+/**
+ * A heatmap's color ramp. Borrows the table gradient's keys so both resolve
+ * through the same code (see conditionalFormat.resolveScale); the difference is
+ * that this scale spans the whole grid, not one column.
+ */
+export interface ColorScale {
+  backgroundColor: string[]; // at least 2 colors, low → high
+  range?: number[];          // one anchor per color; omit for auto min/max
+  unit?: "absolute" | "percent" | "percentile";
+}
+
 export interface FormatLayer {
   if?: FormatOperator;
   value?: RuleValue;

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -538,6 +538,7 @@ func vnodeToWidget(n *vnode) Widget {
 		Target:     asString(n.Props["target"]),
 		Bins:       asInt(n.Props["bins"]),
 		ShowValues: asBool(n.Props["showValues"]),
+		ColorScale: asColorScale(n.Props["colorScale"]),
 		Lines:      asStringSlice(n.Props["lines"]),
 		Series:     asSeriesStyles(n.Props["series"]),
 		YMin:       asBoundEncoding(n.Props["yMin"]),
@@ -810,6 +811,22 @@ func asSeriesStyles(v interface{}) map[string]SeriesStyle {
 		return nil
 	}
 	return out
+}
+
+func asColorScale(v interface{}) *ColorScale {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	colors := asStringSlice(m["backgroundColor"])
+	if len(colors) == 0 {
+		return nil
+	}
+	return &ColorScale{
+		BackgroundColor: colors,
+		Range:           asFloatSlice(m["range"]),
+		Unit:            asString(m["unit"]),
+	}
 }
 
 func asValueEncoding(v interface{}) *ValueEncoding {

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -428,6 +428,34 @@ export default (
 	}
 }
 
+func TestEvalTSX_HeatmapColorScale(t *testing.T) {
+	source := `
+export default (
+  <Dashboard name="Heat" connection="db">
+    <Row>
+      <Chart name="Orders" chart="heatmap" col={12}
+        colorScale={{ backgroundColor: ["red", "white", "green"], range: [-500, 0, 500], unit: "absolute" }}
+        sql="SELECT day, region, delta FROM orders"
+        x="day" y="region" value="delta" />
+    </Row>
+  </Dashboard>
+)
+`
+	d, err := evalTSX(source, "test.tsx", &tsxConfig{})
+	assertNoErr(t, err)
+
+	cs := d.Rows[0].Widgets[0].ColorScale
+	if cs == nil {
+		t.Fatal("expected colorScale to be mapped")
+	}
+	if len(cs.BackgroundColor) != 3 || cs.BackgroundColor[1] != "white" {
+		t.Errorf("unexpected colors: %v", cs.BackgroundColor)
+	}
+	if len(cs.Range) != 3 || cs.Range[2] != 500 || cs.Unit != "absolute" {
+		t.Errorf("unexpected range/unit: %v %q", cs.Range, cs.Unit)
+	}
+}
+
 func TestEvalTSX_ErrorNoDefaultExport(t *testing.T) {
 	source := `const x = 1`
 	_, err := evalTSX(source, "test.tsx", &tsxConfig{})

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -131,6 +131,7 @@ type Widget struct {
 	Target     string         `yaml:"target,omitempty" json:"target,omitempty"`         // sankey: target column, gauge: target (max) column
 	Bins       int            `yaml:"bins,omitempty" json:"bins,omitempty"`             // histogram: number of bins
 	ShowValues bool           `yaml:"showValues,omitempty" json:"showValues,omitempty"` // heatmap: print each cell's value inside the cell
+	ColorScale *ColorScale    `yaml:"colorScale,omitempty" json:"colorScale,omitempty"` // heatmap: custom color ramp, same keys as a table gradient
 	Lines      []string       `yaml:"lines,omitempty" json:"lines,omitempty"`           // combo: which y series render as lines
 	// Series holds per-series line style overrides keyed by y-column: {column: {color, curve, dash}}.
 	Series   map[string]SeriesStyle `yaml:"series,omitempty" json:"series,omitempty"`
@@ -300,6 +301,17 @@ type FormatLayer struct {
 	Italic          bool      `yaml:"italic,omitempty" json:"italic,omitempty"`
 	Underline       bool      `yaml:"underline,omitempty" json:"underline,omitempty"`
 	Strikethrough   bool      `yaml:"strikethrough,omitempty" json:"strikethrough,omitempty"`
+}
+
+// ColorScale is a heatmap's color ramp. It deliberately borrows the table
+// gradient's keys (backgroundColor + range + unit) so an author who has written
+// conditional formatting already knows this, and the frontend resolves both
+// through the same code. Unlike a table gradient, which is scaled per column,
+// this one is scaled across every cell in the grid.
+type ColorScale struct {
+	BackgroundColor []string  `yaml:"backgroundColor" json:"backgroundColor"` // at least 2 colors, low → high
+	Range           []float64 `yaml:"range,omitempty" json:"range,omitempty"` // one anchor per color; omit for auto min/max
+	Unit            string    `yaml:"unit,omitempty" json:"unit,omitempty"`   // absolute (default) | percent | percentile
 }
 
 // WidgetData holds inline result data for a widget so it can render without a

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -552,6 +552,20 @@ func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
 	if w.ShowValues && w.Chart != "heatmap" {
 		errs = append(errs, fmt.Sprintf("%s: showValues is only valid on heatmap charts", prefix))
 	}
+	if cs := w.ColorScale; cs != nil {
+		if w.Chart != "heatmap" {
+			errs = append(errs, fmt.Sprintf("%s: colorScale is only valid on heatmap charts", prefix))
+		}
+		if len(cs.BackgroundColor) < 2 {
+			errs = append(errs, fmt.Sprintf("%s: colorScale.backgroundColor needs at least 2 colors", prefix))
+		}
+		if len(cs.Range) > 0 && len(cs.Range) != len(cs.BackgroundColor) {
+			errs = append(errs, fmt.Sprintf("%s: colorScale.range needs one anchor per color (%d colors, %d anchors)", prefix, len(cs.BackgroundColor), len(cs.Range)))
+		}
+		if cs.Unit != "" && cs.Unit != "absolute" && cs.Unit != "percent" && cs.Unit != "percentile" {
+			errs = append(errs, fmt.Sprintf("%s: colorScale.unit must be absolute, percent or percentile", prefix))
+		}
+	}
 
 	return errs
 }

--- a/pkg/dashboard/validator_test.go
+++ b/pkg/dashboard/validator_test.go
@@ -189,6 +189,48 @@ func TestValidate_ShowValuesOnHeatmap(t *testing.T) {
 	assertNoErr(t, Validate(d))
 }
 
+func TestValidate_ColorScale(t *testing.T) {
+	heatmap := func(cs *ColorScale, chart string) *Dashboard {
+		return &Dashboard{
+			Name: "test",
+			Rows: []Row{
+				{Widgets: []Widget{{
+					Name: "w", Type: WidgetTypeChart, Chart: chart, SQL: "SELECT 1",
+					X: &AxisEncoding{Field: "day"}, Y: &AxisEncoding{Field: "region"},
+					Value: &ValueEncoding{Field: "orders"}, ColorScale: cs,
+				}}},
+			},
+		}
+	}
+
+	cases := []struct {
+		name  string
+		chart string
+		scale *ColorScale
+		want  string // "" means valid
+	}{
+		{"auto min/max", "heatmap", &ColorScale{BackgroundColor: []string{"red", "white", "green"}}, ""},
+		{"pinned anchors", "heatmap", &ColorScale{BackgroundColor: []string{"red", "white", "green"}, Range: []float64{-500, 0, 500}, Unit: "absolute"}, ""},
+		{"percentile", "heatmap", &ColorScale{BackgroundColor: []string{"white", "indigo"}, Range: []float64{10, 90}, Unit: "percentile"}, ""},
+		{"one color", "heatmap", &ColorScale{BackgroundColor: []string{"red"}}, "at least 2 colors"},
+		{"anchor count mismatch", "heatmap", &ColorScale{BackgroundColor: []string{"red", "green"}, Range: []float64{0, 1, 2}}, "one anchor per color"},
+		{"bad unit", "heatmap", &ColorScale{BackgroundColor: []string{"red", "green"}, Unit: "quantile"}, "must be absolute, percent or percentile"},
+		{"wrong chart", "bar", &ColorScale{BackgroundColor: []string{"red", "green"}}, "only valid on heatmap charts"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(heatmap(tc.scale, tc.chart))
+			if tc.want == "" {
+				assertNoErr(t, err)
+				return
+			}
+			assertErr(t, err)
+			assertValidationContains(t, err, tc.want)
+		})
+	}
+}
+
 func TestValidate_DualAxisValid(t *testing.T) {
 	d := &Dashboard{
 		Name: "test",

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -341,6 +341,9 @@
           "type": "boolean",
           "description": "Heatmap charts: print each cell's value inside the cell."
         },
+        "colorScale": {
+          "$ref": "#/$defs/colorScale"
+        },
         "lines": {
           "$ref": "#/$defs/stringList"
         },
@@ -531,6 +534,33 @@
         "italic": { "type": "boolean" },
         "underline": { "type": "boolean" },
         "strikethrough": { "type": "boolean" }
+      },
+      "patternProperties": {
+        "^x-": true
+      },
+      "additionalProperties": false
+    },
+    "colorScale": {
+      "type": "object",
+      "description": "Heatmap charts: the color ramp, scaled across every cell in the grid. Same keys as a table gradient.",
+      "required": ["backgroundColor"],
+      "properties": {
+        "backgroundColor": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 2
+        },
+        "range": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "unit": {
+          "enum": ["absolute", "percent", "percentile"]
+        }
       },
       "patternProperties": {
         "^x-": true


### PR DESCRIPTION
## Why

A heatmap could only paint the four fixed blue buckets. Two consequences:

- **Signed data is unreadable.** A `-35k` cell and a `+35k` cell are both "some shade of blue"; nothing in the color says which side of zero you are on.
- **The ramp moves under you.** It rescales to whatever the current result set contains, so the same cell can be pale in one filter and dark in another, and two filtered views cannot be compared.

Plus the buckets round: three values inside one bucket paint identically even when they differ.

## What

```yaml
- name: Revenue vs Channel Average
  type: chart
  chart: heatmap
  x: { field: channel, type: category }
  y: { field: [region] }
  value: { field: delta, format: "$,.0f" }
  showValues: true
  colorScale:
    backgroundColor: [red, white, green]   # low → high, 2 or more colors
    range: [-500, 0, 500]                  # one anchor per color; omit for auto min/max
    unit: absolute                         # absolute (default) | percent | percentile
```

Omitting `colorScale` keeps today's buckets and legend exactly as they are.

## Design note: no new vocabulary

This deliberately does **not** add a `palette: blue|green|diverging|…` enum. It borrows the table gradient's keys — `backgroundColor` + `range` + `unit` — and is resolved by the same code (`conditionalFormat`'s `resolveScale` / `cellColor`, the latter newly exported). So named colors (`red`, `indigo`, `positive`, …), hex, and the three units behave identically in a heatmap and in a table column, and an author who has written conditional formatting already knows this feature.

The one difference is the **domain**, and it is the interesting one: a heatmap scale spans every cell in the grid, while a table gradient is scaled per column. Same numbers, different question — "who is high overall" vs "who is high within this column".

Two properties fall out for free rather than needing their own options:

- `range: [-500, 0, 500]` puts the neutral color exactly on zero, so the sign reads at a glance, and freezes the domain so filtered views stay comparable.
- The ramp interpolates, so values the buckets rounded together stay distinguishable.

Cell-value ink is derived from each cell's resolved fill, so `showValues` stays readable on any ramp (verified visually on a diverging ramp and a light single-hue ramp).

## Wiring

Same set of layers as bruin-data/dac#65: `Widget.ColorScale` in the Go model, validator rules (heatmap-only; ≥2 colors; one anchor per color; unit enum), the JSON schema (`$defs/colorScale`), the TS widget type, the TSX loader (`asColorScale`), the docs, and the `create-dashboard` skill reference.

## Testing

- `make test` green, including `TestValidate_ColorScale` (7 cases: auto / pinned / percentile / one-color / anchor-count mismatch / bad unit / wrong chart) and `TestEvalTSX_HeatmapColorScale`
- `make format`, frontend `tsc --noEmit`, `eslint` — clean
- `dac validate --dir examples/basic-yaml` — 6 dashboards OK
- Rendered in a browser: default buckets unchanged; a diverging ramp pinned at zero (legend shows the anchors, near-zero cells read neutral); a single-hue ramp with percentile anchors (legend shows the resolved data values). Cell values stayed legible on all three.