### PR TITLE
Add Vega-Lite chart support

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -406,7 +406,7 @@ The SQL must return at least one row. The value from `value.field` in the first 
 
 ### Chart Widget
 
-Visualizations using Recharts. **17 chart types** available. Two modes: **dimensional** (using top-level dimensions + metrics) or **query-based** (using SQL with x/y columns).
+Visualizations use 22 built-in chart types rendered with Recharts, plus `vega-lite` for advanced composition. Built-in charts have two modes: **dimensional** (using top-level dimensions + metrics) or **query-based** (using SQL with x/y columns).
 
 #### Dimensional Charts (no SQL needed)
 
@@ -765,6 +765,31 @@ Multi-axis comparison across a small number of entities.
 ```
 
 OHLC chart for financial/pricing data. Green when close ≥ open, red otherwise.
+
+#### Vega-Lite (advanced composition)
+
+Use `chart: vega-lite` with a `spec` object for layered, faceted, concatenated, or transformed visualizations. DAC owns the widget data and injects query results as the named `dac` dataset:
+
+```yaml
+- name: Revenue with confidence interval
+  type: chart
+  chart: vega-lite
+  sql: SELECT month, revenue, lower_ci, upper_ci FROM monthly_revenue ORDER BY month
+  spec:
+    data: { name: dac }
+    encoding:
+      x: { field: month, type: temporal }
+    layer:
+      - mark: { type: area, opacity: 0.14 }
+        encoding:
+          y: { field: lower_ci, type: quantitative }
+          y2: { field: upper_ci }
+      - mark: { type: line, strokeWidth: 2 }
+        encoding:
+          y: { field: revenue, type: quantitative }
+```
+
+`spec.data` is optional and defaults to `{ name: dac }`. If provided, it must use that name. `data.url` and `datasets.dac` are invalid: load primary data through DAC `sql`, `query`, semantic fields, or illustrative inline `data`. DAC supplies theme and responsive sizing defaults; explicit Vega-Lite `config`, `width`, `height`, and `autosize` values override them.
 
 ### Table Widget
 
@@ -1567,7 +1592,7 @@ rows:
 | Type | Required Fields | Query Source | Description |
 |------|----------------|--------------|-------------|
 | `metric` | `metric:` ref OR `value` + query | Declarative or SQL | Single KPI number card |
-| `chart` | `dimension` + `metrics` OR `chart` + x/y + query | Declarative or SQL | Visualization (21 chart types) |
+| `chart` | `dimension` + `metrics`, built-in `chart` + encodings, OR `chart: vega-lite` + `spec` | Declarative, SQL, or inline | Visualization (22 built-in types plus Vega-Lite) |
 | `table` | — | SQL | Data table with optional column config |
 | `text` | `content` | None | Markdown/text content |
 | `divider` | — | None | Horizontal separator line |
@@ -1598,6 +1623,7 @@ rows:
 | `treemap` | `label`, `value` | | Rectangular part-to-whole hierarchy |
 | `radar` | `x`, `y` | | Polar/spider chart for multi-metric comparison |
 | `candlestick` | `x`, `open`, `high`, `low`, `close` | | OHLC chart |
+| `vega-lite` | `spec` | | Advanced layered/composed chart; DAC data is the named `dac` dataset |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The repository includes four self-contained example projects under [`examples/`]
 
 | Example | What it shows |
 | --- | --- |
-| [`examples/basic-yaml`](examples/basic-yaml) | A standard YAML dashboard with filters, SQL queries, and query files. |
+| [`examples/basic-yaml`](examples/basic-yaml) | Standard YAML dashboards with filters, SQL queries, and a self-contained Vega-Lite layered-chart demo. |
 | [`examples/basic-tsx`](examples/basic-tsx) | A TSX dashboard that uses load-time queries to generate layout from the database. |
 | [`examples/semantic-yaml`](examples/semantic-yaml) | A YAML dashboard that reads semantic models from `semantic/` and compiles widgets in the backend. |
 | [`examples/semantic-tsx`](examples/semantic-tsx) | A TSX dashboard using external semantic models and backend semantic query compilation. |

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -228,6 +228,31 @@ The `funnel` chart shows conversion through ordered stages: one bar per stage wi
 
 Confidence intervals use `yMin`/`yMax` (the lower/upper bound columns): on `line`/`area` they shade a CI **band** behind the estimate line; on `bar` they become **error-bar caps**; the `forest` chart draws a point estimate + horizontal CI per category (grey when the interval spans 0, `horizontal: false` for a vertical dot-and-whisker). `y` is the estimate only. `yMin`/`yMax` are a single column, or a per-series map `{seriesColumn: boundColumn}` for multi-line bands. Compute the bounds in SQL (e.g. `effect ± 1.96*stderr`). Reference guides: `refLines: [{ axis: x|y, value, label? }]` (dashed line, e.g. a 0 "no-effect" mark) and `refBands: [{ axis: x|y, from, to, label? }]` (a shaded range, e.g. a ±MDE band).
 
+### Vega-Lite charts
+
+Use `chart: vega-lite` with a `spec` object for advanced layered, faceted, concatenated, or transformed visualizations. DAC still owns the query and injects its result as the named `dac` dataset:
+
+```yaml
+- name: Revenue with confidence interval
+  type: chart
+  chart: vega-lite
+  sql: SELECT month, revenue, lower_ci, upper_ci FROM monthly_revenue ORDER BY month
+  spec:
+    data: { name: dac }
+    encoding:
+      x: { field: month, type: temporal }
+    layer:
+      - mark: { type: area, opacity: 0.14 }
+        encoding:
+          y: { field: lower_ci, type: quantitative }
+          y2: { field: upper_ci }
+      - mark: { type: line, strokeWidth: 2 }
+        encoding:
+          y: { field: revenue, type: quantitative }
+```
+
+`spec.data` is optional and defaults to `{ name: dac }`. If provided, it must use that name. Do not use `data.url` or define `datasets.dac`; load primary data through `sql`, `query`, semantic fields, or the widget's illustrative inline `data`. DAC supplies theme and responsive-size defaults, while explicit Vega-Lite `config`, `width`, `height`, and `autosize` values override them.
+
 Every query is an inline `sql:` block or a named `query:` reference — YAML widgets do not take file paths. In TSX, `include("queries/revenue.sql")` reads a `.sql` file into an inline query at load time.
 
 ## Inline (Static) Data

--- a/docs/dashboards/tsx.md
+++ b/docs/dashboards/tsx.md
@@ -182,11 +182,20 @@ All widget components accept the same props as their YAML equivalents.
 ```tsx
 <Metric name="Revenue" col={4} sql="..." value={{ field: "value", type: "number", format: "$,.2f" }} />
 <Chart name="Trend" chart="area" col={8} sql="..." x={{ field: "month" }} y={{ field: ["revenue"] }} />
+<Chart name="Layered" chart="vega-lite" col={12} sql="..." spec={{
+  data: { name: "dac" },
+  layer: [
+    { mark: "line", encoding: { x: { field: "month", type: "temporal" }, y: { field: "revenue", type: "quantitative" } } },
+    { mark: "point", encoding: { x: { field: "month", type: "temporal" }, y: { field: "revenue", type: "quantitative" } } },
+  ],
+}} />
 <Table name="Orders" col={12} sql="..." />
 <Text name="Note" col={6} content="**Important:** This data updates daily." />
 <Divider name="sep" col={12} />
 <Image name="logo" col={3} src="https://example.com/logo.png" alt="Logo" />
 ```
+
+For `chart="vega-lite"`, the `spec` prop is the Vega-Lite specification and DAC injects the widget result as the named `dac` dataset. The same data-source and remote-URL rules documented for YAML Vega-Lite charts apply.
 
 ## How It Works
 
@@ -197,4 +206,4 @@ DAC:
 3. extracts the default export
 4. converts it to the same dashboard model used by YAML
 
-TSX dashboards are fully compatible with filters, named queries, external semantic models, validation, static builds, and Slides export.
+TSX dashboards are fully compatible with filters, named queries, external semantic models, validation, and static builds. Google Slides export supports the same widget subset documented for YAML dashboards.

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -99,6 +99,7 @@ Charts visualize one or more series. The `chart` field selects the chart type an
 | `radar` | `x`, `y` | | Multi-axis polar comparison |
 | `candlestick` | `x`, `open`, `high`, `low`, `close` | | OHLC chart |
 | `forest` | `x`, `y` | `yMin`, `yMax`, `horizontal` | Point estimate + CI interval per category (grey when the interval spans 0). `horizontal: false` → vertical dot-and-whisker; multiple `y` = grouped |
+| `vega-lite` | `spec` | | Advanced Vega-Lite visualization using DAC query data. Supports layers, facets, concatenation, transforms, and selections |
 
 SQL-backed example:
 
@@ -230,6 +231,7 @@ Common chart fields:
 | `yMax` | string \| object | CI upper bound (see `yMin`) |
 | `refLines` | object[] | Reference guide lines: `[{ axis: x\|y, value, label?, color? }]` — dashed line (e.g. a 0 no-effect mark). line/area/bar/forest |
 | `refBands` | object[] | Shaded reference bands: `[{ axis: x\|y, from, to, label?, color? }]` — a translucent range (e.g. a ±MDE band). line/area/bar/forest |
+| `spec` | object | Vega-Lite specification for `chart: vega-lite`. DAC data is injected as the named `dac` dataset |
 | `dimension` | string | Semantic dimension name |
 | `granularity` | string | Semantic time grain for `dimension` |
 | `metrics` | string[] | Semantic metric names |
@@ -272,6 +274,43 @@ Colors accept the same names as table formatting (`red`, `green`, `blue`,
 `indigo`, `cyan`, `purple`, `pink`, `amber`, plus `white`/`black` and the
 `positive`/`negative`/`warning` aliases) or hex. Cell-value ink is derived from
 each cell's fill, so `showValues` stays readable on any ramp.
+
+### Vega-Lite charts
+
+Use `chart: vega-lite` when a visualization needs composition beyond DAC's built-in chart options, such as layered marks, independent scales, faceting, concatenation, or Vega-Lite transforms. Built-in charts remain the concise default for standard visualizations.
+
+DAC executes the widget's `sql`, named `query`, semantic query, or inline `data` exactly like any other chart. The result is converted to records and made available to the Vega-Lite specification as the named `dac` dataset:
+
+```yaml
+- name: Revenue with confidence interval
+  type: chart
+  chart: vega-lite
+  col: 12
+  sql: |
+    SELECT month, revenue, lower_ci, upper_ci
+    FROM monthly_revenue ORDER BY month
+  spec:
+    data: { name: dac }
+    encoding:
+      x: { field: month, type: temporal }
+    layer:
+      - mark: { type: area, opacity: 0.14 }
+        encoding:
+          y: { field: lower_ci, type: quantitative, title: Revenue }
+          y2: { field: upper_ci }
+      - mark: { type: line, strokeWidth: 2 }
+        encoding:
+          y: { field: revenue, type: quantitative }
+      - mark: { type: point, filled: true }
+        encoding:
+          y: { field: revenue, type: quantitative }
+```
+
+`spec.data` may be omitted; DAC inserts `{ name: dac }` automatically. If present, it must use that name. `data.url` and `datasets.dac` are rejected: load primary chart data through DAC so filters, validation, CSV export, and static builds continue to work consistently. Other inline named datasets may be included for small supporting values.
+
+For a single or layered view, DAC supplies responsive width, row-derived height, and fit autosizing when the spec does not set them. Explicit `width`, `height`, `autosize`, and `config` values win. DAC also supplies theme-aware axes, legends, tooltips, typography, and the `chart-1` through `chart-8` categorical palette; values in `spec.config` override those defaults.
+
+See `examples/basic-yaml/dashboards/vega-lite.yml` for layered confidence intervals, independent dual axes, a lollipop chart, and a SQL-backed revenue heatmap with centered, contrast-aware value labels.
 
 ## Table
 

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -312,7 +312,7 @@ For a single or layered view, DAC supplies responsive width, row-derived height,
 
 PNG and PDF exports wait for Vega-Lite's asynchronous render to finish before capturing the widget or dashboard.
 
-See `examples/basic-yaml/dashboards/vega-lite.yml` for layered confidence intervals, independent dual axes, a lollipop chart, and a SQL-backed revenue heatmap with centered, contrast-aware value labels.
+See `examples/basic-yaml/dashboards/vega-lite.yml` for a Sankey-style customer journey built from curved weighted ribbons, layered confidence intervals, independent dual axes, a lollipop chart, and a SQL-backed revenue heatmap with centered, contrast-aware value labels.
 
 ## Table
 

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -310,6 +310,8 @@ DAC executes the widget's `sql`, named `query`, semantic query, or inline `data`
 
 For a single or layered view, DAC supplies responsive width, row-derived height, and fit autosizing when the spec does not set them. Explicit `width`, `height`, `autosize`, and `config` values win. DAC also supplies theme-aware axes, legends, tooltips, typography, and the `chart-1` through `chart-8` categorical palette; values in `spec.config` override those defaults.
 
+PNG and PDF exports wait for Vega-Lite's asynchronous render to finish before capturing the widget or dashboard.
+
 See `examples/basic-yaml/dashboards/vega-lite.yml` for layered confidence intervals, independent dual axes, a lollipop chart, and a SQL-backed revenue heatmap with centered, contrast-aware value labels.
 
 ## Table

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,7 @@ DAC uses Bruin connections for query execution, so install both `dac` and `bruin
 
 ## Included Projects
 
-- `basic-yaml`: standard YAML dashboard with SQL queries, filters, and query files
+- `basic-yaml`: standard YAML dashboards with SQL queries, filters, query files, and a self-contained Vega-Lite layered-chart demo
 - `basic-tsx`: TSX dashboard with load-time queries that generate layout from the database
 - `semantic-yaml`: YAML dashboard backed by external semantic models in `semantic/`
 - `semantic-tsx`: TSX dashboard backed by external semantic models in `semantic/`

--- a/examples/basic-yaml/dashboards/vega-lite.yml
+++ b/examples/basic-yaml/dashboards/vega-lite.yml
@@ -1,0 +1,254 @@
+name: Vega-Lite Layered Charts
+description: Advanced composed charts using DAC data and Vega-Lite specifications
+connection: local_duckdb
+
+rows:
+  - widgets:
+      - name: Vega-Lite in DAC
+        type: text
+        col: 12
+        content: |
+          Vega-Lite is the advanced chart escape hatch. DAC still owns the data,
+          filters, layout, theme, and exports; the `spec` controls the visualization.
+          The first examples use illustrative inline data. The final heatmap executes
+          a live DuckDB query and renders the result as layered rectangles and labels.
+
+  - height: 420
+    widgets:
+      - name: Revenue forecast and confidence interval
+        description: Area, line, point, and rule marks share one temporal scale
+        type: chart
+        chart: vega-lite
+        col: 12
+        data:
+          columns: [month, actual, forecast, lower, upper, plan]
+          rows:
+            - ["2026-01-01", 92, null, null, null, 145]
+            - ["2026-02-01", 101, null, null, null, 145]
+            - ["2026-03-01", 98, null, null, null, 145]
+            - ["2026-04-01", 112, null, null, null, 145]
+            - ["2026-05-01", 119, null, null, null, 145]
+            - ["2026-06-01", 126, null, null, null, 145]
+            - ["2026-07-01", 132, 130, 121, 139, 145]
+            - ["2026-08-01", 138, 137, 126, 148, 145]
+            - ["2026-09-01", null, 143, 130, 156, 145]
+            - ["2026-10-01", null, 151, 136, 166, 145]
+            - ["2026-11-01", null, 157, 140, 174, 145]
+            - ["2026-12-01", null, 166, 147, 185, 145]
+        spec:
+          $schema: https://vega.github.io/schema/vega-lite/v6.json
+          data: { name: dac }
+          layer:
+            - mark: { type: area, opacity: 0.14 }
+              encoding:
+                x: { field: month, type: temporal, axis: { title: null, format: "%b", tickCount: 12 } }
+                y:
+                  field: lower
+                  type: quantitative
+                  title: Revenue ($k)
+                  scale: { zero: false }
+                y2: { field: upper }
+                color: { datum: Forecast, type: nominal }
+                tooltip:
+                  - { field: month, type: temporal, title: Month, format: "%B %Y" }
+                  - { field: lower, type: quantitative, title: Low, format: "$,.0f" }
+                  - { field: upper, type: quantitative, title: High, format: "$,.0f" }
+            - transform:
+                - aggregate:
+                    - { op: max, field: plan, as: plan }
+              mark: { type: rule, strokeDash: [5, 4], strokeWidth: 1.25 }
+              encoding:
+                y: { field: plan, type: quantitative }
+                color: { datum: Plan, type: nominal }
+                tooltip:
+                  - { field: plan, type: quantitative, title: Plan, format: "$,.0f" }
+            - mark: { type: line, strokeWidth: 2.25 }
+              encoding:
+                x: { field: month, type: temporal, axis: { title: null, format: "%b", tickCount: 12 } }
+                y: { field: actual, type: quantitative }
+                color: { datum: Actual, type: nominal }
+                tooltip:
+                  - { field: month, type: temporal, title: Month, format: "%B %Y" }
+                  - { field: actual, type: quantitative, title: Actual, format: "$,.0f" }
+            - mark: { type: point, filled: true, size: 42 }
+              encoding:
+                x: { field: month, type: temporal, axis: { title: null, format: "%b", tickCount: 12 } }
+                y: { field: actual, type: quantitative }
+                color: { datum: Actual, type: nominal }
+                tooltip:
+                  - { field: month, type: temporal, title: Month, format: "%B %Y" }
+                  - { field: actual, type: quantitative, title: Actual, format: "$,.0f" }
+            - mark: { type: line, strokeDash: [7, 4], strokeWidth: 2 }
+              encoding:
+                x: { field: month, type: temporal, axis: { title: null, format: "%b", tickCount: 12 } }
+                y: { field: forecast, type: quantitative }
+                color: { datum: Forecast, type: nominal }
+                tooltip:
+                  - { field: month, type: temporal, title: Month, format: "%B %Y" }
+                  - { field: forecast, type: quantitative, title: Forecast, format: "$,.0f" }
+
+  - height: 350
+    widgets:
+      - name: Revenue and margin
+        description: Independent left and right scales in one layered view
+        type: chart
+        chart: vega-lite
+        col: 6
+        data:
+          columns: [quarter, revenue, margin]
+          rows:
+            - [Q1, 220, 0.18]
+            - [Q2, 268, 0.21]
+            - [Q3, 251, 0.19]
+            - [Q4, 314, 0.24]
+        spec:
+          data: { name: dac }
+          encoding:
+            x: { field: quarter, type: ordinal, axis: { title: null } }
+          layer:
+            - mark: { type: bar, cornerRadiusTopLeft: 2, cornerRadiusTopRight: 2, opacity: 0.8 }
+              encoding:
+                y:
+                  field: revenue
+                  type: quantitative
+                  title: Revenue ($k)
+                  axis: { format: "$,.0f" }
+                color: { datum: Revenue, type: nominal }
+                tooltip:
+                  - { field: quarter, type: ordinal, title: Quarter }
+                  - { field: revenue, type: quantitative, title: Revenue, format: "$,.0f" }
+            - mark: { type: line, strokeWidth: 2.25, point: { filled: true, size: 48 } }
+              encoding:
+                y:
+                  field: margin
+                  type: quantitative
+                  title: Margin
+                  axis: { orient: right, format: ".0%" }
+                  scale: { zero: false }
+                color: { datum: Margin, type: nominal }
+                tooltip:
+                  - { field: quarter, type: ordinal, title: Quarter }
+                  - { field: margin, type: quantitative, title: Margin, format: ".1%" }
+          resolve:
+            scale: { y: independent }
+
+      - name: Variance by segment
+        description: Rules, points, text, and a zero reference share one scale
+        type: chart
+        chart: vega-lite
+        col: 6
+        data:
+          columns: [segment, variance, direction]
+          rows:
+            - [Enterprise, 0.084, Above plan]
+            - [Mid-market, 0.031, Above plan]
+            - [SMB, -0.046, Below plan]
+            - [Self-serve, 0.057, Above plan]
+            - [Partners, -0.021, Below plan]
+        spec:
+          data: { name: dac }
+          layer:
+            - mark: { type: rule, color: "#868C98", strokeDash: [3, 3] }
+              encoding:
+                x:
+                  datum: 0
+                  type: quantitative
+                  axis: { title: Variance to plan, format: "+.0%" }
+                  scale: { domain: [-0.07, 0.1] }
+            - mark: { type: rule, strokeWidth: 2.5 }
+              encoding:
+                y:
+                  field: segment
+                  type: nominal
+                  sort: { field: variance, order: descending }
+                  axis: { title: null }
+                x: { datum: 0, type: quantitative }
+                x2: { field: variance, type: quantitative }
+                color: { field: direction, type: nominal, title: null }
+            - mark: { type: point, filled: true, size: 72 }
+              encoding:
+                y:
+                  field: segment
+                  type: nominal
+                  sort: { field: variance, order: descending }
+                  axis: { title: null }
+                x: { field: variance, type: quantitative }
+                color: { field: direction, type: nominal, title: null }
+                tooltip:
+                  - { field: segment, type: nominal, title: Segment }
+                  - { field: variance, type: quantitative, title: Variance, format: "+.1%" }
+            - mark:
+                type: text
+                align: { expr: "datum.variance < 0 ? 'right' : 'left'" }
+                baseline: middle
+                dx: { expr: "datum.variance < 0 ? -8 : 8" }
+                fontSize: 10
+              encoding:
+                y:
+                  field: segment
+                  type: nominal
+                  sort: { field: variance, order: descending }
+                  axis: { title: null }
+                x: { field: variance, type: quantitative }
+                text: { field: variance, type: quantitative, format: "+.1%" }
+                color: { field: direction, type: nominal, title: null }
+
+  - height: 380
+    widgets:
+      - name: Monthly revenue by region
+        description: Live DuckDB results; color encodes revenue while labels show every value
+        type: chart
+        chart: vega-lite
+        col: 12
+        sql: |
+          WITH monthly_revenue AS (
+            SELECT
+              region,
+              STRFTIME(created_at, '%b') AS month,
+              MONTH(created_at) AS month_number,
+              ROUND(SUM(amount), 0) AS revenue
+            FROM sales
+            WHERE YEAR(created_at) = (SELECT MAX(YEAR(created_at)) FROM sales)
+            GROUP BY 1, 2, 3
+          ), ranked AS (
+            SELECT
+              *,
+              PERCENT_RANK() OVER (ORDER BY revenue) AS intensity
+            FROM monthly_revenue
+          )
+          SELECT region, month, revenue, intensity
+          FROM ranked
+          ORDER BY month_number, region
+        spec:
+          data: { name: dac }
+          encoding:
+            x:
+              field: month
+              type: ordinal
+              sort: [Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec]
+              axis: { title: null, labelAngle: 0 }
+              scale: { paddingInner: 0.04, paddingOuter: 0.02 }
+            y:
+              field: region
+              type: ordinal
+              sort: [North America, Europe, Asia Pacific, Latin America, Middle East]
+              axis: { title: null }
+              scale: { paddingInner: 0.06, paddingOuter: 0.03 }
+            tooltip:
+              - { field: region, type: nominal, title: Region }
+              - { field: month, type: ordinal, title: Month }
+              - { field: revenue, type: quantitative, title: Revenue, format: "$,.0f" }
+          layer:
+            - mark: { type: rect, cornerRadius: 2 }
+              encoding:
+                color:
+                  field: revenue
+                  type: quantitative
+                  title: Revenue
+                  scale: { scheme: blues }
+            - mark: { type: text, fontSize: 11, fontWeight: 600 }
+              encoding:
+                text: { field: revenue, type: quantitative, format: "$.3s" }
+                color:
+                  condition: { test: "datum.intensity >= 0.55", value: white }
+                  value: "#172033"

--- a/examples/basic-yaml/dashboards/vega-lite.yml
+++ b/examples/basic-yaml/dashboards/vega-lite.yml
@@ -10,8 +10,124 @@ rows:
         content: |
           Vega-Lite is the advanced chart escape hatch. DAC still owns the data,
           filters, layout, theme, and exports; the `spec` controls the visualization.
-          The first examples use illustrative inline data. The final heatmap executes
-          a live DuckDB query and renders the result as layered rectangles and labels.
+          The first examples use illustrative inline data, including a Sankey-style
+          flow composed from curved ribbons, nodes, and labels. The final heatmap
+          executes a live DuckDB query and renders layered rectangles and labels.
+
+  - height: 460
+    widgets:
+      - name: Customer journey Sankey
+        description: Curved weighted ribbons connect acquisition channels to evaluation paths and outcomes
+        type: chart
+        chart: vega-lite
+        col: 12
+        data:
+          columns: [flow, source_x, source_y, target_x, target_y, value, source, target, group]
+          rows:
+            - [organic-tour, 0, 14.6, 1, 20.8, 2100, Organic, Product tour, Organic]
+            - [organic-docs, 0, 24.6, 1, 57.6, 1100, Organic, Docs & demos, Organic]
+            - [paid-tour, 0, 46.6, 1, 32.5, 1500, Paid, Product tour, Paid]
+            - [paid-docs, 0, 54.6, 1, 64.7, 1100, Paid, Docs & demos, Paid]
+            - [partner-tour, 0, 73.5, 1, 38.7, 400, Partner, Product tour, Partner]
+            - [partner-docs, 0, 79.5, 1, 72.1, 1200, Partner, Docs & demos, Partner]
+            - [tour-activated, 1, 23.1, 2, 22.1, 2800, Product tour, Activated, Product tour]
+            - [tour-nurture, 1, 34.8, 2, 58.5, 800, Product tour, Needs nurture, Product tour]
+            - [tour-dropped, 1, 38.7, 2, 79.3, 400, Product tour, Dropped, Product tour]
+            - [docs-activated, 1, 58.9, 2, 36.1, 1500, Docs & demos, Activated, Docs & demos]
+            - [docs-nurture, 1, 67.3, 2, 64.5, 1100, Docs & demos, Needs nurture, Docs & demos]
+            - [docs-dropped, 1, 73.4, 2, 83.3, 800, Docs & demos, Dropped, Docs & demos]
+        spec:
+          data: { name: dac }
+          datasets:
+            nodes:
+              - { stage: 0, x: 0, x0: -0.035, x1: 0.035, y: 18, y0: 8, y1: 28, node: Organic, label: "Organic · 3.2k", value: 3200, group: Organic }
+              - { stage: 0, x: 0, x0: -0.035, x1: 0.035, y: 50, y0: 42, y1: 58, node: Paid, label: "Paid · 2.6k", value: 2600, group: Paid }
+              - { stage: 0, x: 0, x0: -0.035, x1: 0.035, y: 78, y0: 72, y1: 84, node: Partner, label: "Partner · 1.6k", value: 1600, group: Partner }
+              - { stage: 1, x: 1, x0: 0.965, x1: 1.035, y: 27, y0: 14, y1: 40, node: Product tour, label: "Product tour · 4.0k", value: 4000, group: Product tour }
+              - { stage: 1, x: 1, x0: 0.965, x1: 1.035, y: 65, y0: 54, y1: 76, node: Docs & demos, label: "Docs & demos · 3.4k", value: 3400, group: Docs & demos }
+              - { stage: 2, x: 2, x0: 1.965, x1: 2.035, y: 27, y0: 13, y1: 41, node: Activated, label: "Activated · 4.3k", value: 4300, group: Activated }
+              - { stage: 2, x: 2, x0: 1.965, x1: 2.035, y: 62, y0: 56, y1: 68, node: Needs nurture, label: "Needs nurture · 1.9k", value: 1900, group: Needs nurture }
+              - { stage: 2, x: 2, x0: 1.965, x1: 2.035, y: 82, y0: 78, y1: 86, node: Dropped, label: "Dropped · 1.2k", value: 1200, group: Dropped }
+            stages:
+              - { x: 0, label: ACQUISITION }
+              - { x: 1, label: EVALUATION }
+              - { x: 2, label: OUTCOME }
+          layer:
+            - transform:
+                - calculate: "[datum.source_x, datum.source_x + 0.34, datum.target_x - 0.34, datum.target_x]"
+                  as: x_path
+                - calculate: "[datum.source_y, datum.source_y, datum.target_y, datum.target_y]"
+                  as: y_path
+                - flatten: [x_path, y_path]
+                  as: [x, y]
+                - calculate: "datum.y - datum.value * 0.003125"
+                  as: y_top
+                - calculate: "datum.y + datum.value * 0.003125"
+                  as: y_bottom
+              params:
+                - name: flow_hover
+                  select: { type: point, fields: [flow], on: pointerover, clear: pointerout }
+              mark: { type: area, interpolate: basis }
+              encoding:
+                x:
+                  field: x
+                  type: quantitative
+                  scale: { domain: [-0.25, 2.32] }
+                  axis: null
+                y:
+                  field: y_top
+                  type: quantitative
+                  scale: { domain: [0, 94], reverse: true }
+                  axis: null
+                y2: { field: y_bottom }
+                detail: { field: flow, type: nominal }
+                color: { field: group, type: nominal, legend: null }
+                opacity:
+                  condition: { param: flow_hover, empty: false, value: 0.78 }
+                  value: 0.34
+                tooltip:
+                  - { field: source, type: nominal, title: From }
+                  - { field: target, type: nominal, title: To }
+                  - { field: value, type: quantitative, title: People, format: ",.0f" }
+            - data: { name: nodes }
+              mark: { type: rect, cornerRadius: 2, opacity: 0.96 }
+              encoding:
+                x: { field: x0, type: quantitative, scale: { domain: [-0.25, 2.32] }, axis: null }
+                x2: { field: x1 }
+                y: { field: y0, type: quantitative, scale: { domain: [0, 94], reverse: true }, axis: null }
+                y2: { field: y1 }
+                color: { field: group, type: nominal, legend: null }
+                tooltip:
+                  - { field: node, type: nominal, title: Stage }
+                  - { field: value, type: quantitative, title: People, format: ",.0f" }
+            - data: { name: nodes }
+              mark:
+                type: text
+                align: { expr: "datum.stage === 0 ? 'right' : 'left'" }
+                dx: { expr: "datum.stage === 0 ? -10 : 10" }
+                baseline: middle
+                fontSize: 11
+                fontWeight: 600
+                color: "#868C98"
+              encoding:
+                x: { field: x, type: quantitative, scale: { domain: [-0.25, 2.32] }, axis: null }
+                y: { field: y, type: quantitative, scale: { domain: [0, 94], reverse: true }, axis: null }
+                text: { field: label, type: nominal }
+                tooltip:
+                  - { field: node, type: nominal, title: Stage }
+                  - { field: value, type: quantitative, title: People, format: ",.0f" }
+            - data: { name: stages }
+              mark:
+                type: text
+                align: center
+                baseline: top
+                fontSize: 10
+                fontWeight: 600
+                color: "#868C98"
+              encoding:
+                x: { field: x, type: quantitative, scale: { domain: [-0.25, 2.32] }, axis: null }
+                y: { datum: 0, type: quantitative, scale: { domain: [0, 94], reverse: true }, axis: null }
+                text: { field: label, type: nominal }
 
   - height: 420
     widgets:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,10 @@
         "react-router-dom": "^7.18.2",
         "react-select": "^5.10.2",
         "recharts": "^3.8.0",
-        "shiki": "^4.0.1"
+        "shiki": "^4.0.1",
+        "vega": "^6.2.0",
+        "vega-embed": "^7.1.0",
+        "vega-lite": "^6.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -881,9 +884,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -901,9 +901,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -921,9 +918,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -941,9 +935,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -961,9 +952,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -981,9 +969,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1587,9 +1572,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -1600,6 +1585,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2066,6 +2057,18 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2306,6 +2309,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2343,6 +2360,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/concat-map": {
@@ -2452,6 +2478,52 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -2461,10 +2533,66 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-projection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg.js",
+        "geograticule": "bin/geograticule.js",
+        "geoproject": "bin/geoproject.js",
+        "geoquantize": "bin/geoquantize.js",
+        "geostitch": "bin/geostitch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2491,6 +2619,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -2502,6 +2639,19 @@
         "d3-interpolate": "1.2.0 - 3",
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -2611,6 +2761,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2670,6 +2829,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
@@ -2716,7 +2881,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2947,6 +3111,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3085,6 +3255,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob-parent": {
@@ -3275,6 +3466,18 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3527,6 +3730,12 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -5194,6 +5403,12 @@
         "node": ">= 0.8.15"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -5233,6 +5448,18 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -5338,6 +5565,23 @@
         "node": ">=0.1.14"
       }
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -5350,6 +5594,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5478,6 +5737,26 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -5515,9 +5794,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5729,6 +6006,496 @@
       "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/vega": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-6.3.1.tgz",
+      "integrity": "sha512-mX5tvY3ISCSiPPmunuZyQfccq0XlUvJd2t5oyc6SNS0N0TwnPNoklx0mVod5n+qbzuUoiuxl7Ve/SvoRqH4RzA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-crossfilter": "~5.1.2",
+        "vega-dataflow": "~6.1.2",
+        "vega-encode": "~5.2.1",
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.2.1",
+        "vega-force": "~5.1.2",
+        "vega-format": "~2.1.2",
+        "vega-functions": "~6.1.3",
+        "vega-geo": "~5.1.2",
+        "vega-hierarchy": "~5.1.2",
+        "vega-label": "~2.1.2",
+        "vega-loader": "~5.1.2",
+        "vega-parser": "~7.1.2",
+        "vega-projection": "~2.1.2",
+        "vega-regression": "~2.1.2",
+        "vega-runtime": "~7.1.2",
+        "vega-scale": "~8.1.2",
+        "vega-scenegraph": "~5.2.1",
+        "vega-statistics": "~2.0.0",
+        "vega-time": "~3.2.1",
+        "vega-transforms": "~5.2.1",
+        "vega-typings": "~2.2.0",
+        "vega-util": "~2.1.0",
+        "vega-view": "~6.1.2",
+        "vega-view-transforms": "~5.2.1",
+        "vega-voronoi": "~5.1.2",
+        "vega-wordcloud": "~5.1.2"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      }
+    },
+    "node_modules/vega-canvas": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-2.0.0.tgz",
+      "integrity": "sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-crossfilter": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-5.1.2.tgz",
+      "integrity": "sha512-K14PtfBxQzb7UJq5rL1IuwDdPov6lucoHVzRaraGiBBnfc963jkWHQNfRFAuEj/nIt5BIixXBiqIrGKgfScjSA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-dataflow": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.1.2.tgz",
+      "integrity": "sha512-0/HBBlzPERh0wV5kUOh/N4aAAmb3rB18Kfpej+nWvDIjPk3dixTapNkVVkoA9CsB5dY5bY+HNqiM/Pp4XPduGQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-format": "^2.1.2",
+        "vega-loader": "^5.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-embed": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-7.1.0.tgz",
+      "integrity": "sha512-ZmEIn5XJrQt7fSh2lwtSdXG/9uf3yIqZnvXFEwBJRppiBgrEWZcZbj6VK3xn8sNTFQ+sQDXW5sl/6kmbAW3s5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fast-json-patch": "^3.1.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "semver": "^7.7.2",
+        "tslib": "^2.8.1",
+        "vega-interpreter": "^2.0.0",
+        "vega-schema-url-parser": "^3.0.2",
+        "vega-themes": "3.0.0",
+        "vega-tooltip": "1.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
+      "peerDependencies": {
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-embed/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vega-encode": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-5.2.1.tgz",
+      "integrity": "sha512-YuvJ66z6FQRtu0n0IYxsJp7BpliXVgaxNsur0Fqic10/a5TLMQmDYURPUcrtWViAMpqKgdNMyxnmr0ZQ4bjwCA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-interpolate": "^3.0.1",
+        "vega-dataflow": "^6.1.2",
+        "vega-scale": "^8.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-event-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
+      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-expression": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.2.1.tgz",
+      "integrity": "sha512-AK4EYh9ErCC7KU8vGigsetwG66S1wLLfPFnfjkOdydRaN4kNJp129qp4jos0wA/r7F/lIlhM3uIzw+KSA2cZEg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-force": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.1.2.tgz",
+      "integrity": "sha512-693paaBvACvAtUO8vp4m/KUJ0F3tKaoXixzw+ExpP4qKkqJ/Me2MGWsVrEJh/f6KuU9bp7xv+g7OPNhqnVrpoQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-force": "^3.0.0",
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-format": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-2.1.2.tgz",
+      "integrity": "sha512-cJ2oqGEGYJ2NbkIIUDic03ZZX1meE+sq330gq4HFf3CvzSupTwHLWQj3/H5zug5DrqEQhLCLkiRwvmMe4pEqfg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-format": "^3.1.2",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^3.2.1",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-functions": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-6.1.3.tgz",
+      "integrity": "sha512-WOgWVxGg1T1tuICyylIppxXWXWEtl7P81Xnj0vQtoIn11VvQ0mrsBZr1aia4g8Sw0fEH1mUO7Dtj7v3o8BgBmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.1",
+        "vega-dataflow": "^6.1.2",
+        "vega-expression": "^6.2.1",
+        "vega-scale": "^8.1.2",
+        "vega-scenegraph": "^5.2.1",
+        "vega-selections": "^6.1.4",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.2.1",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-geo": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.1.2.tgz",
+      "integrity": "sha512-tls2+IVuKaIOxEqdshuSk2Til8qcF7SUNaWkATKu5hwWqQEY3cp7tfdXosuTMaDTkLp+Nw84iWfe5BzfoxDYMA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.1",
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.2",
+        "vega-projection": "^2.1.2",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-hierarchy": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.1.2.tgz",
+      "integrity": "sha512-7a72/lA6j50HU6PQe5ChbomftHi29V1oCcibaQpDozZncHuAnsQummqfiPyTMPpNMrSRtyZy18do0IEoOvrbMg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-interpreter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-2.3.1.tgz",
+      "integrity": "sha512-IYleUp+lXVIGjJUQg+5WJ/xUdteMxEGEnSyWtRhagVuUDiXD0JnERKWffIrQSCUypA86UOuyjzVDtb7oNOsaxw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-label": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-2.1.2.tgz",
+      "integrity": "sha512-MFsOKOCG6a5QwP5atoFFi+R58IP/Q7//65UvgrSeankX2QrDcWjBtzIqS6JlYBOAdyjoiAAghx7pnIAj5nAO6A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.2",
+        "vega-scenegraph": "^5.2.1",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-lite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.4.3.tgz",
+      "integrity": "sha512-d/7hPjfz560UERaQuTmGgIVfXAe3g2hJWeC+igDeaGohUdEoNrHLXgR/yTOBT8vV/lIuuKnw+0/xWWblkDwkMQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "json-stringify-pretty-compact": "~4.0.0",
+        "tslib": "~2.8.1",
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.1.0",
+        "vega-util": "~2.1.0",
+        "yargs": "~18.0.0"
+      },
+      "bin": {
+        "vl2pdf": "bin/vl2pdf",
+        "vl2png": "bin/vl2png",
+        "vl2svg": "bin/vl2svg",
+        "vl2vg": "bin/vl2vg"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
+      "peerDependencies": {
+        "vega": "^6.0.0"
+      }
+    },
+    "node_modules/vega-lite/node_modules/vega-expression": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.1.0.tgz",
+      "integrity": "sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-loader": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.1.2.tgz",
+      "integrity": "sha512-O29bKHsSJBi391H88OZXH8vgUdopWMorC5ZJ/8XjTq8TIXVdeUrNnI8dMkUyv7yQg3ywMTji+5fHhov1TOkkyA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dsv": "^3.0.1",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^2.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.1.2.tgz",
+      "integrity": "sha512-88HNkVrEwWbMmbbhPCmFHPrl/ClTcvThRv2UMZqMJJ5IqgjWLUolCA1fhAvnAbvRPe+Z1j+GbV/WWjYWAjEuyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-dataflow": "^6.1.2",
+        "vega-event-selector": "^4.0.0",
+        "vega-functions": "^6.1.3",
+        "vega-scale": "^8.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-projection": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-2.1.2.tgz",
+      "integrity": "sha512-HL+FS9AgYSOa1UOIJfhOD39RMT4tDODkMcN6MCRsdlRNnukVm1+JhrixDnciBjqiZLxDhUjESJwgLQtXx8cUyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-geo": "^3.1.1",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^8.1.2"
+      }
+    },
+    "node_modules/vega-regression": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-2.1.2.tgz",
+      "integrity": "sha512-2dyb2sT6cxdTK5K87uNDYpW7LbTP90lplxW62imjfLAwKUq1wL74X8y03a0W5tpRfV8+f3ai+cYTv+HXB3XmDQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.2",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-runtime": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.1.2.tgz",
+      "integrity": "sha512-MMfm7FeWLX2XqaY26i99GrlToexO/EWYqT7MRqEkpw+0nYgKh4zpQ47j04LB3ishnSZAj2AL0HNl9uPZLxgFhg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-scale": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-8.1.2.tgz",
+      "integrity": "sha512-ADCGgdSmhcZyHxtHbrVcDrG76er2s2eXowO3qDg0vx2eclHdXL4YNaEjTHrosNG/1TAI5LAe7aQ2BGssJFfAXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
+        "vega-time": "^3.2.1",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-scenegraph": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.2.1.tgz",
+      "integrity": "sha512-tWolI3s/cjU5g8evEjpxJqgqKQ2IJv1FoPXqvNuviLNdylP1I/h5iF5RY08Cz4jkuP9zircSskFEBsHylD1dgQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^2.0.0",
+        "vega-loader": "^5.1.2",
+        "vega-scale": "^8.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-schema-url-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-3.0.2.tgz",
+      "integrity": "sha512-xAnR7KAvNPYewI3O0l5QGdT8Tv0+GCZQjqfP39cW/hbe/b3aYMAQ39vm8O2wfXUHzm04xTe7nolcsx8WQNVLRQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-selections": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-6.1.4.tgz",
+      "integrity": "sha512-qR5feBL8xq5BjoG3rf7e2WKle/cn5Fa9pBFMBnzoOYp4nTA0GYDoKuOjZkftibsQcmdST0HzPjSrS14jH3TCQw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "3.2.4",
+        "vega-expression": "^6.2.1",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-statistics": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-2.0.0.tgz",
+      "integrity": "sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4"
+      }
+    },
+    "node_modules/vega-themes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-3.0.0.tgz",
+      "integrity": "sha512-1iFiI3BNmW9FrsLnDLx0ZKEddsCitRY3XmUAwp6qmp+p+IXyJYc9pfjlVj9E6KXBPfm4cQyU++s0smKNiWzO4g==",
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
+      "peerDependencies": {
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-time": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-3.2.1.tgz",
+      "integrity": "sha512-SXo1klLYPsmBdSj9itYSuFMmCpwnnIvQS8jWFxsCTnyWcPaBQKz0kf2M7DqTysi34KTk+6ws4kqZg11XMWnIYA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-time": "^3.1.0",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-tooltip": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-1.0.0.tgz",
+      "integrity": "sha512-P1R0JP29v0qnTuwzCQ0SPJlkjAzr6qeyj+H4VgUFSykHmHc1OBxda//XBaFDl/bZgIscEMvjKSjZpXd84x3aZQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-util": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      }
+    },
+    "node_modules/vega-transforms": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-5.2.1.tgz",
+      "integrity": "sha512-csKiYXJFa0YY5lubP1wc8b99SJ8nHLG/sOWvKFpW3CfDfjp8LoB0exrxgtIoClCsngAguKiuZVDwQZxBhPJZwA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.2",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.2.1",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-typings": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.2.0.tgz",
+      "integrity": "sha512-pX7LsqgMpzMPOyydg/drYbIjh+mmvLfKtuKr75OpCu/ZYKJ2i8UjSmNlpARYeYGLaXfuNUAM3hMN8NPZPDYiBQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/geojson": "7946.0.16",
+        "vega-event-selector": "^4.0.0",
+        "vega-expression": "^6.2.0",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-util": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.2.tgz",
+      "integrity": "sha512-Mdvv33BUlx4no5gz2VHdue4bJ6ejWmInuieID3JGnAXwewHKrPWE/Xr2vVWA+xS9Om1eHvj/0wVsiBGJ61v2uQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-view": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-6.1.2.tgz",
+      "integrity": "sha512-BG/Kqd1csdK4uKdJ4hv72msgQX3Ry5SzCV1ngbytkn6QwuQPpFWzya/f0OSWyMQP9S79avdHXqdLCxjSeiDQRw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-timer": "^3.0.1",
+        "vega-dataflow": "^6.1.2",
+        "vega-format": "^2.1.2",
+        "vega-functions": "^6.1.3",
+        "vega-runtime": "^7.1.2",
+        "vega-scenegraph": "^5.2.1",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-view-transforms": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-5.2.1.tgz",
+      "integrity": "sha512-TiguoCJ6BB7TEV+s3nNMoCoH4+q5A6XQsDMEzbVuRaSWmfIJxvWUlbZQqn4CUt65VMDr63Fy21Xpb0ntlaU5LQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-dataflow": "^6.1.2",
+        "vega-scenegraph": "^5.2.1",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-voronoi": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.1.2.tgz",
+      "integrity": "sha512-8BgKb6aF/42L/PrFi3Idqag7FtbzNqDVhvPD4SfswSzGYlRDcxcn1eQQsa//q72qIZk4i5rsHeAiH2QbIjPSBg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-delaunay": "^6.0.4",
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
+      }
+    },
+    "node_modules/vega-wordcloud": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-5.1.2.tgz",
+      "integrity": "sha512-ZSw6fupf4qx4hBzL9q/oVUKPVbVePjJ/FSgfxxgRcKvE1VoYq3HWfx9qg+CQMvgDS+oGDsn2WoQJuNLYx9T3AQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.2",
+        "vega-scale": "^8.1.2",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vfile": {
@@ -6146,6 +6913,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -6160,6 +6965,32 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,10 @@
     "react-router-dom": "^7.18.2",
     "react-select": "^5.10.2",
     "recharts": "^3.8.0",
-    "shiki": "^4.0.1"
+    "shiki": "^4.0.1",
+    "vega": "^6.2.0",
+    "vega-embed": "^7.1.0",
+    "vega-lite": "^6.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/components/widgets/ChartWidget.tsx
+++ b/frontend/src/components/widgets/ChartWidget.tsx
@@ -15,6 +15,7 @@ import { axisField, axisFields, buildAxisFormatter, valueField } from "../../lib
 import { useTokens } from "../../themes/TemplateProvider";
 import { cellColor, resolveScale } from "./conditionalFormat";
 import { RowHeightContext } from "../../themes/RowContext";
+import { VegaLiteChart } from "./VegaLiteChart";
 
 const DEFAULT_CHART_HEIGHT = 240;
 // Approx pixels consumed by the widget frame's title/padding above the chart.
@@ -1172,6 +1173,9 @@ const Y_TITLE_OFFSET = 18;
 
 export function ChartWidget({ widget, data }: Props) {
   const tokens = useTokens();
+  if (widget.chart === "vega-lite") {
+    return <VegaLiteChart widget={widget} data={data} />;
+  }
   const yTitle = widget.y?.title;
   if (!yTitle) {
     return <ChartBody widget={widget} data={data} />;

--- a/frontend/src/components/widgets/VegaLiteChart.tsx
+++ b/frontend/src/components/widgets/VegaLiteChart.tsx
@@ -209,8 +209,8 @@ export function VegaLiteChart({ widget, data }: Props) {
         if (!disposed) container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
       })
       .catch((error: unknown) => {
-        container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
         if (!disposed) {
+          container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
           setRenderError(error instanceof Error ? error.message : String(error));
         }
       });

--- a/frontend/src/components/widgets/VegaLiteChart.tsx
+++ b/frontend/src/components/widgets/VegaLiteChart.tsx
@@ -1,0 +1,235 @@
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import type { View } from "vega";
+import type { VisualizationSpec } from "vega-embed";
+import type { Widget, WidgetData } from "../../types/dashboard";
+import { RowHeightContext } from "../../themes/RowContext";
+import { useTokens } from "../../themes/TemplateProvider";
+
+const DAC_DATASET_NAME = "dac";
+const VEGA_TOOLTIP_ID = "vg-tooltip-element";
+const DEFAULT_CHART_HEIGHT = 240;
+const FRAME_OVERHEAD = 60;
+
+interface Props {
+  widget: Widget;
+  data?: WidgetData;
+}
+
+type JSONObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JSONObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function toRecords(data: WidgetData): JSONObject[] {
+  return data.rows.map((row) => {
+    const record: JSONObject = {};
+    data.columns.forEach((column, index) => {
+      record[column.name] = row[index];
+    });
+    return record;
+  });
+}
+
+function hasExternalDataURL(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(hasExternalDataURL);
+  if (!isObject(value)) return false;
+
+  if (isObject(value.data) && "url" in value.data) return true;
+  return Object.values(value).some(hasExternalDataURL);
+}
+
+function mergeConfig(defaults: JSONObject, override: unknown): JSONObject {
+  if (!isObject(override)) return defaults;
+
+  const merged: JSONObject = { ...defaults, ...override };
+  for (const key of ["axis", "legend", "title", "view", "range"]) {
+    if (isObject(defaults[key]) && isObject(override[key])) {
+      merged[key] = { ...defaults[key], ...override[key] };
+    }
+  }
+  return merged;
+}
+
+// Vega Tooltip appends its element to document.body, outside TemplateProvider's
+// token scope. Create the shared element up front and copy the active DAC theme
+// variables onto it so its colors do not become invalid/transparent.
+function syncTooltipTheme(tokens: Record<string, string>): void {
+  let tooltip = document.getElementById(VEGA_TOOLTIP_ID);
+  if (!tooltip) {
+    tooltip = document.createElement("div");
+    tooltip.id = VEGA_TOOLTIP_ID;
+    tooltip.classList.add("vg-tooltip");
+    tooltip.setAttribute("role", "tooltip");
+    document.body.appendChild(tooltip);
+  }
+
+  for (const [key, value] of Object.entries(tokens)) {
+    tooltip.style.setProperty(`--dac-${key}`, value);
+  }
+}
+
+function themedSpec(
+  source: JSONObject,
+  records: JSONObject[],
+  tokens: Record<string, string>,
+  chartHeight: number,
+): JSONObject {
+  if (hasExternalDataURL(source)) {
+    throw new Error("Vega-Lite data.url is not allowed; load data through the widget query");
+  }
+
+  const category = Array.from({ length: 8 }, (_, index) => tokens[`chart-${index + 1}`] || "#888888");
+  const defaultConfig: JSONObject = {
+    axis: {
+      domain: false,
+      gridColor: tokens.border,
+      gridOpacity: 0.55,
+      labelColor: tokens["text-muted"],
+      labelFont: "Geist, system-ui, sans-serif",
+      labelFontSize: 11,
+      tickColor: tokens.border,
+      titleColor: tokens["text-muted"],
+      titleFont: "Geist, system-ui, sans-serif",
+      titleFontSize: 11,
+      titleFontWeight: 500,
+    },
+    legend: {
+      labelColor: tokens["text-secondary"],
+      labelFont: "Geist, system-ui, sans-serif",
+      labelFontSize: 11,
+      titleColor: tokens["text-primary"],
+      titleFont: "Geist, system-ui, sans-serif",
+      titleFontSize: 11,
+    },
+    title: {
+      color: tokens["text-primary"],
+      font: "Geist, system-ui, sans-serif",
+      fontSize: 12,
+      fontWeight: 500,
+    },
+    view: { stroke: null },
+    range: { category },
+  };
+
+  const sourceData = isObject(source.data) ? source.data : {};
+  const dataOptions = { ...sourceData };
+  delete dataOptions.url;
+  delete dataOptions.values;
+  const sourceDatasets = isObject(source.datasets) ? source.datasets : {};
+  const spec: JSONObject = {
+    ...source,
+    background: source.background ?? "transparent",
+    data: { ...dataOptions, name: DAC_DATASET_NAME },
+    datasets: { ...sourceDatasets, [DAC_DATASET_NAME]: records },
+    config: mergeConfig(defaultConfig, source.config),
+  };
+
+  const isSingleOrLayeredView = "mark" in source || "layer" in source;
+  if (isSingleOrLayeredView) {
+    spec.width ??= "container";
+    spec.height ??= chartHeight;
+    spec.autosize ??= { type: "fit", contains: "padding", resize: true };
+  }
+
+  return spec;
+}
+
+export function VegaLiteChart({ widget, data }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [renderError, setRenderError] = useState<string | null>(null);
+  const tokens = useTokens();
+  const rowHeight = useContext(RowHeightContext);
+  const chartHeight = rowHeight !== undefined
+    ? Math.max(80, rowHeight - FRAME_OVERHEAD)
+    : DEFAULT_CHART_HEIGHT;
+
+  const records = useMemo(() => data ? toRecords(data) : [], [data]);
+  const resolvedSpec = useMemo(() => {
+    try {
+      return themedSpec(widget.spec ?? {}, records, tokens, chartHeight);
+    } catch (error) {
+      return error instanceof Error ? error : new Error(String(error));
+    }
+  }, [widget.spec, records, tokens, chartHeight]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || records.length === 0) return;
+
+    if (resolvedSpec instanceof Error) {
+      setRenderError(resolvedSpec.message);
+      return;
+    }
+
+    let disposed = false;
+    let view: View | undefined;
+    let observer: ResizeObserver | undefined;
+    let animationFrame = 0;
+    let lastWidth = -1;
+    let lastHeight = -1;
+
+    setRenderError(null);
+    container.replaceChildren();
+    syncTooltipTheme(tokens);
+
+    void import("vega-embed")
+      .then(({ default: vegaEmbed }) => vegaEmbed(
+        container,
+        resolvedSpec as VisualizationSpec,
+        {
+          mode: "vega-lite",
+          renderer: "svg",
+          actions: false,
+          defaultStyle: false,
+        },
+      ))
+      .then((result) => {
+        if (disposed) {
+          result.view.finalize();
+          return;
+        }
+        view = result.view;
+        observer = new ResizeObserver(([entry]) => {
+          const width = Math.round(entry.contentRect.width);
+          const height = Math.round(entry.contentRect.height);
+          if (width === lastWidth && height === lastHeight) return;
+          lastWidth = width;
+          lastHeight = height;
+          cancelAnimationFrame(animationFrame);
+          animationFrame = requestAnimationFrame(() => {
+            void view?.resize().runAsync();
+          });
+        });
+        observer.observe(container);
+      })
+      .catch((error: unknown) => {
+        if (!disposed) {
+          setRenderError(error instanceof Error ? error.message : String(error));
+        }
+      });
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(animationFrame);
+      observer?.disconnect();
+      view?.finalize();
+      container.replaceChildren();
+    };
+  }, [records, resolvedSpec, tokens]);
+
+  if (!data?.rows?.length) {
+    return <div className="text-[var(--dac-text-muted)] text-xs py-6 text-center">No data</div>;
+  }
+
+  return (
+    <div className="relative" style={{ height: chartHeight }}>
+      <div ref={containerRef} className="dac-vega-lite h-full w-full" />
+      {renderError && (
+        <div className="absolute inset-0 flex items-center justify-center bg-[var(--dac-background)]/90 px-4 text-center font-mono text-xs text-[var(--dac-error)]">
+          {renderError}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/widgets/VegaLiteChart.tsx
+++ b/frontend/src/components/widgets/VegaLiteChart.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { View } from "vega";
 import type { VisualizationSpec } from "vega-embed";
 import type { Widget, WidgetData } from "../../types/dashboard";
+import { DAC_EXPORT_PENDING_ATTRIBUTE } from "../../lib/renderExport";
 import { RowHeightContext } from "../../themes/RowContext";
 import { useTokens } from "../../themes/TemplateProvider";
 
@@ -158,6 +159,7 @@ export function VegaLiteChart({ widget, data }: Props) {
     if (!container || records.length === 0) return;
 
     if (resolvedSpec instanceof Error) {
+      container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
       setRenderError(resolvedSpec.message);
       return;
     }
@@ -170,6 +172,7 @@ export function VegaLiteChart({ widget, data }: Props) {
     let lastHeight = -1;
 
     setRenderError(null);
+    container.setAttribute(DAC_EXPORT_PENDING_ATTRIBUTE, "true");
     container.replaceChildren();
     syncTooltipTheme(tokens);
 
@@ -184,7 +187,7 @@ export function VegaLiteChart({ widget, data }: Props) {
           defaultStyle: false,
         },
       ))
-      .then((result) => {
+      .then(async (result) => {
         if (disposed) {
           result.view.finalize();
           return;
@@ -202,8 +205,11 @@ export function VegaLiteChart({ widget, data }: Props) {
           });
         });
         observer.observe(container);
+        await result.view.resize().runAsync();
+        if (!disposed) container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
       })
       .catch((error: unknown) => {
+        container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
         if (!disposed) {
           setRenderError(error instanceof Error ? error.message : String(error));
         }
@@ -214,6 +220,7 @@ export function VegaLiteChart({ widget, data }: Props) {
       cancelAnimationFrame(animationFrame);
       observer?.disconnect();
       view?.finalize();
+      container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
       container.replaceChildren();
     };
   }, [records, resolvedSpec, tokens]);
@@ -224,7 +231,11 @@ export function VegaLiteChart({ widget, data }: Props) {
 
   return (
     <div className="relative" style={{ height: chartHeight }}>
-      <div ref={containerRef} className="dac-vega-lite h-full w-full" />
+      <div
+        ref={containerRef}
+        className="dac-vega-lite h-full w-full"
+        data-dac-export-pending="true"
+      />
       {renderError && (
         <div className="absolute inset-0 flex items-center justify-center bg-[var(--dac-background)]/90 px-4 text-center font-mono text-xs text-[var(--dac-error)]">
           {renderError}

--- a/frontend/src/components/widgets/VegaLiteChart.tsx
+++ b/frontend/src/components/widgets/VegaLiteChart.tsx
@@ -170,6 +170,7 @@ export function VegaLiteChart({ widget, data }: Props) {
     let animationFrame = 0;
     let lastWidth = -1;
     let lastHeight = -1;
+    let resizeGeneration = 0;
 
     setRenderError(null);
     container.setAttribute(DAC_EXPORT_PENDING_ATTRIBUTE, "true");
@@ -193,20 +194,36 @@ export function VegaLiteChart({ widget, data }: Props) {
           return;
         }
         view = result.view;
+        await result.view.resize().runAsync();
+        if (disposed) return;
+        container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
+
         observer = new ResizeObserver(([entry]) => {
           const width = Math.round(entry.contentRect.width);
           const height = Math.round(entry.contentRect.height);
           if (width === lastWidth && height === lastHeight) return;
           lastWidth = width;
           lastHeight = height;
+          const generation = ++resizeGeneration;
+          container.setAttribute(DAC_EXPORT_PENDING_ATTRIBUTE, "true");
           cancelAnimationFrame(animationFrame);
           animationFrame = requestAnimationFrame(() => {
-            void view?.resize().runAsync();
+            const activeView = view;
+            if (!activeView || disposed || generation !== resizeGeneration) return;
+            void activeView.resize().runAsync()
+              .catch((error: unknown) => {
+                if (!disposed && generation === resizeGeneration) {
+                  setRenderError(error instanceof Error ? error.message : String(error));
+                }
+              })
+              .finally(() => {
+                if (!disposed && generation === resizeGeneration) {
+                  container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
+                }
+              });
           });
         });
         observer.observe(container);
-        await result.view.resize().runAsync();
-        if (!disposed) container.removeAttribute(DAC_EXPORT_PENDING_ATTRIBUTE);
       })
       .catch((error: unknown) => {
         if (!disposed) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,52 @@
 @import "tailwindcss";
+
+.dac-vega-lite .vega-embed,
+.dac-vega-lite .vega-embed > div {
+  width: 100%;
+  height: 100%;
+}
+
+.dac-vega-lite svg {
+  display: block;
+  max-width: 100%;
+}
+
+#vg-tooltip-element.vg-tooltip {
+  color: var(--dac-text-primary, #18181b);
+  background: var(--dac-surface, #ffffff);
+  border: 1px solid var(--dac-border, #e4e4e7);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--dac-text-primary, #18181b) 12%, transparent);
+  font-family: "Geist", system-ui, sans-serif;
+  font-size: 11px;
+  line-height: 1.35;
+  padding: 6px 8px;
+  pointer-events: none;
+}
+
+#vg-tooltip-element.vg-tooltip table {
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+#vg-tooltip-element.vg-tooltip table tr td {
+  padding-block: 2px;
+  white-space: nowrap;
+}
+
+#vg-tooltip-element.vg-tooltip table tr td.key {
+  color: var(--dac-text-muted, #71717a);
+  padding-right: 12px;
+  text-align: left;
+}
+
+#vg-tooltip-element.vg-tooltip table tr td.value {
+  color: var(--dac-text-primary, #18181b);
+  display: table-cell;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  text-align: right;
+}
 @import "react-day-picker/style.css";
 
 @utility scrollbar-hide {

--- a/frontend/src/lib/renderExport.ts
+++ b/frontend/src/lib/renderExport.ts
@@ -1,4 +1,7 @@
 const EXPORT_CONTROL_SELECTOR = "[data-dac-export-control]";
+export const DAC_EXPORT_PENDING_ATTRIBUTE = "data-dac-export-pending";
+const EXPORT_PENDING_SELECTOR = `[${DAC_EXPORT_PENDING_ATTRIBUTE}]`;
+const EXPORT_READY_TIMEOUT_MS = 15_000;
 
 function exportFilter(node: HTMLElement): boolean {
   if (!(node instanceof Element)) return true;
@@ -33,8 +36,39 @@ async function waitForFonts(): Promise<void> {
   }
 }
 
+function hasPendingExportContent(element: HTMLElement): boolean {
+  return element.matches(EXPORT_PENDING_SELECTOR) || element.querySelector(EXPORT_PENDING_SELECTOR) !== null;
+}
+
+async function waitForExportContent(element: HTMLElement): Promise<void> {
+  if (!hasPendingExportContent(element)) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const observer = new MutationObserver(() => {
+      if (!hasPendingExportContent(element)) finish();
+    });
+    const timeout = window.setTimeout(() => {
+      finish(new Error("Timed out waiting for dashboard content to finish rendering"));
+    }, EXPORT_READY_TIMEOUT_MS);
+    const finish = (error?: Error) => {
+      window.clearTimeout(timeout);
+      observer.disconnect();
+      if (error) reject(error);
+      else resolve();
+    };
+
+    observer.observe(element, {
+      attributeFilter: [DAC_EXPORT_PENDING_ATTRIBUTE],
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+    if (!hasPendingExportContent(element)) finish();
+  });
+}
+
 async function elementToPNGDataURL(element: HTMLElement): Promise<string> {
-  await waitForFonts();
+  await Promise.all([waitForFonts(), waitForExportContent(element)]);
 
   const { toPng } = await import("html-to-image");
   const { width, height } = elementSize(element);

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -73,7 +73,9 @@ export interface Widget {
   sort?: SemanticSort[];
 
   // Chart
-  chart?: "line" | "bar" | "area" | "pie" | "scatter" | "bubble" | "combo" | "histogram" | "boxplot" | "funnel" | "sankey" | "heatmap" | "calendar" | "sparkline" | "waterfall" | "xmr" | "dumbbell" | "gauge" | "treemap" | "radar" | "candlestick" | "forest";
+  chart?: "line" | "bar" | "area" | "pie" | "scatter" | "bubble" | "combo" | "histogram" | "boxplot" | "funnel" | "sankey" | "heatmap" | "calendar" | "sparkline" | "waterfall" | "xmr" | "dumbbell" | "gauge" | "treemap" | "radar" | "candlestick" | "forest" | "vega-lite";
+  /** Vega-Lite spec. Widget query results are injected as the named `dac` dataset. */
+  spec?: Record<string, unknown>;
   x?: AxisEncoding;
   y?: AxisEncoding;
   // Optional second value axis on the right (line/area/bar/combo). A y-column

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -524,6 +524,7 @@ func vnodeToWidget(n *vnode) Widget {
 
 		// Chart fields
 		Chart:      asString(n.Props["chart"]),
+		Spec:       asMap(n.Props["spec"]),
 		X:          asAxisEncoding(n.Props["x"]),
 		Y:          asAxisEncoding(n.Props["y"]),
 		Y2:         asAxisEncoding(n.Props["y2"]),

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -456,6 +456,39 @@ export default (
 	}
 }
 
+func TestEvalTSX_VegaLiteSpec(t *testing.T) {
+	source := `
+export default (
+  <Dashboard name="Vega TSX" connection="db">
+    <Row>
+      <Chart name="Layered" chart="vega-lite" sql="SELECT 1 AS value" spec={{
+        data: { name: "dac" },
+        layer: [
+          { mark: "line", encoding: { y: { field: "value", type: "quantitative" } } },
+          { mark: "point", encoding: { y: { field: "value", type: "quantitative" } } },
+        ],
+      }} />
+    </Row>
+  </Dashboard>
+)
+`
+	d, err := evalTSX(source, "vega.dashboard.tsx", &tsxConfig{})
+	assertNoErr(t, err)
+
+	w := d.Rows[0].Widgets[0]
+	if w.Chart != "vega-lite" {
+		t.Fatalf("expected vega-lite chart, got %q", w.Chart)
+	}
+	data, ok := w.Spec["data"].(map[string]interface{})
+	if !ok || data["name"] != "dac" {
+		t.Fatalf("expected named dac data source, got %#v", w.Spec["data"])
+	}
+	layers, ok := w.Spec["layer"].([]interface{})
+	if !ok || len(layers) != 2 {
+		t.Fatalf("expected two Vega-Lite layers, got %#v", w.Spec["layer"])
+	}
+}
+
 func TestEvalTSX_ErrorNoDefaultExport(t *testing.T) {
 	source := `const x = 1`
 	_, err := evalTSX(source, "test.tsx", &tsxConfig{})

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -114,9 +114,10 @@ type Widget struct {
 	Limit       int                    `yaml:"limit,omitempty" json:"limit,omitempty"` // LIMIT for dimensional queries
 
 	// Chart fields
-	Chart string        `yaml:"chart,omitempty" json:"chart,omitempty"` // line, bar, area, pie, scatter, bubble, combo, histogram, boxplot, funnel, sankey, heatmap, calendar, sparkline, waterfall, xmr, dumbbell, gauge, treemap, radar, candlestick, forest
-	X     *AxisEncoding `yaml:"x,omitempty" json:"x,omitempty"`
-	Y     *AxisEncoding `yaml:"y,omitempty" json:"y,omitempty"`
+	Chart string         `yaml:"chart,omitempty" json:"chart,omitempty"` // built-in chart type, or vega-lite
+	Spec  map[string]any `yaml:"spec,omitempty" json:"spec,omitempty"`   // vega-lite: visualization spec; DAC query data is injected as the named "dac" dataset
+	X     *AxisEncoding  `yaml:"x,omitempty" json:"x,omitempty"`
+	Y     *AxisEncoding  `yaml:"y,omitempty" json:"y,omitempty"`
 	// Y2 is an optional second value axis on the right (line/area/bar/combo): a
 	// y-column plots against it when listed in y2.field, all others stay on y.
 	Y2         *AxisEncoding  `yaml:"y2,omitempty" json:"y2,omitempty"`

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -90,6 +90,10 @@ func Validate(d *Dashboard) error {
 				errs = append(errs, fmt.Sprintf("%s: unknown widget type %q (expected metric, chart, table, text, divider, or image)", prefix, w.Type))
 			}
 
+			if len(w.Spec) > 0 && (w.Type != WidgetTypeChart || w.Chart != "vega-lite") {
+				errs = append(errs, fmt.Sprintf("%s: spec is only valid on vega-lite charts", prefix))
+			}
+
 			errs = append(errs, validateInlineData(prefix, &w)...)
 
 			if w.Col < 0 || w.Col > 12 {
@@ -265,7 +269,71 @@ var validChartTypes = map[string]bool{
 	"boxplot": true, "funnel": true, "sankey": true, "heatmap": true,
 	"calendar": true, "sparkline": true, "waterfall": true, "xmr": true,
 	"dumbbell": true, "gauge": true, "treemap": true, "radar": true,
-	"candlestick": true, "forest": true,
+	"candlestick": true, "forest": true, "vega-lite": true,
+}
+
+func validateVegaLiteSpec(prefix string, w *Widget, d *Dashboard) []string {
+	var errs []string
+	if len(w.Spec) == 0 {
+		errs = append(errs, fmt.Sprintf("%s: spec is required for vega-lite charts", prefix))
+	} else {
+		if !hasVegaLiteView(w.Spec) {
+			errs = append(errs, fmt.Sprintf("%s: vega-lite spec must define mark, layer, facet, concat, hconcat, vconcat, or repeat", prefix))
+		}
+		if rawData, ok := w.Spec["data"]; ok {
+			data, ok := rawData.(map[string]any)
+			if !ok || data["name"] != "dac" {
+				errs = append(errs, fmt.Sprintf("%s: vega-lite spec.data must be { name: dac } when provided", prefix))
+			}
+			if _, ok := data["values"]; ok {
+				errs = append(errs, fmt.Sprintf("%s: vega-lite spec.data.values is not allowed; use the widget query or data field", prefix))
+			}
+		}
+		if datasets, ok := w.Spec["datasets"].(map[string]any); ok {
+			if _, reserved := datasets["dac"]; reserved {
+				errs = append(errs, fmt.Sprintf("%s: vega-lite spec.datasets.dac is reserved for widget query data", prefix))
+			}
+		}
+		if hasExternalVegaDataURL(w.Spec) {
+			errs = append(errs, fmt.Sprintf("%s: vega-lite data.url is not allowed; load data through DAC queries", prefix))
+		}
+	}
+	errs = append(errs, validateQuerySource(prefix, w, d)...)
+	return errs
+}
+
+func hasVegaLiteView(spec map[string]any) bool {
+	for _, key := range []string{"mark", "layer", "facet", "concat", "hconcat", "vconcat", "repeat"} {
+		if _, ok := spec[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExternalVegaDataURL(value any) bool {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			if key == "data" {
+				if data, ok := child.(map[string]any); ok {
+					if _, external := data["url"]; external {
+						return true
+					}
+				}
+			}
+			if hasExternalVegaDataURL(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if hasExternalVegaDataURL(child) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // dualAxisCharts are the cartesian composed charts that can render a second
@@ -342,6 +410,9 @@ func validateChartWidget(prefix string, w *Widget, d *Dashboard) []string {
 	if !validChartTypes[w.Chart] {
 		errs = append(errs, fmt.Sprintf("%s: unknown chart type %q", prefix, w.Chart))
 		return errs
+	}
+	if w.Chart == "vega-lite" {
+		return validateVegaLiteSpec(prefix, w, d)
 	}
 	errs = append(errs, validateRefAnnotations(prefix, w)...)
 

--- a/pkg/dashboard/validator_test.go
+++ b/pkg/dashboard/validator_test.go
@@ -113,6 +113,66 @@ func TestValidate_ChartWidgetMissingChartType(t *testing.T) {
 	assertValidationContains(t, err, "chart type is required")
 }
 
+func TestValidate_VegaLiteChart(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "Layered", Type: WidgetTypeChart, Chart: "vega-lite", SQL: "SELECT 1 AS value",
+			Spec: map[string]any{
+				"data": map[string]any{"name": "dac"},
+				"layer": []any{
+					map[string]any{"mark": "line"},
+					map[string]any{"mark": "point"},
+				},
+			},
+		}}}},
+	}
+	assertNoErr(t, Validate(d))
+}
+
+func TestValidate_VegaLiteChartRequiresSpec(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "Layered", Type: WidgetTypeChart, Chart: "vega-lite", SQL: "SELECT 1 AS value",
+		}}}},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "spec is required for vega-lite charts")
+}
+
+func TestValidate_VegaLiteChartRejectsRemoteData(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "Remote", Type: WidgetTypeChart, Chart: "vega-lite", SQL: "SELECT 1 AS value",
+			Spec: map[string]any{
+				"mark": "line",
+				"data": map[string]any{"url": "https://example.com/data.json"},
+			},
+		}}}},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "spec.data must be { name: dac }")
+	assertValidationContains(t, err, "data.url is not allowed")
+}
+
+func TestValidate_VegaLiteSpecOnlyOnVegaLiteCharts(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "Line", Type: WidgetTypeChart, Chart: "line", SQL: "SELECT 1 AS x, 2 AS y",
+			X: &AxisEncoding{Field: "x"}, Y: &AxisEncoding{Field: "y"},
+			Spec: map[string]any{"mark": "line"},
+		}}}},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "spec is only valid on vega-lite charts")
+}
+
 func TestValidate_StackedRequiresColor(t *testing.T) {
 	d := &Dashboard{
 		Name: "test",

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -292,8 +292,13 @@
             "treemap",
             "radar",
             "candlestick",
-            "forest"
+            "forest",
+            "vega-lite"
           ]
+        },
+        "spec": {
+          "type": "object",
+          "description": "Vega-Lite specification. Widget query data is available as the named dataset 'dac'."
         },
         "x": {
           "$ref": "#/$defs/axisEncoding"

--- a/schemas/schema_test.go
+++ b/schemas/schema_test.go
@@ -46,6 +46,25 @@ rows:
 `,
 		},
 		{
+			name:     "dashboard vega-lite chart",
+			schemaID: DashboardV1ID,
+			yaml: `name: Vega-Lite
+rows:
+  - widgets:
+      - name: Layered
+        type: chart
+        chart: vega-lite
+        data:
+          columns: [x, y]
+          rows: [[A, 1], [B, 2]]
+        spec:
+          data: { name: dac }
+          layer:
+            - mark: line
+            - mark: point
+`,
+		},
+		{
 			name:     "theme",
 			schemaID: ThemeV1ID,
 			yaml: `schema: https://getbruin.com/schemas/dac/theme/v1


### PR DESCRIPTION
## Summary

Adds Vega-Lite as an advanced chart type with DAC-managed data, validation, responsive theme-aware rendering, and layered demos.

## Testing

- [x] `make test`
- [x] `make build`
- [x] `make format`, example validation, and SQL-backed demo smoke test

## Checklist

- [x] scanned `docs/` and updated the relevant pages
- [x] examples updated for the new authoring model
- [ ] screenshots or recordings attached for UI changes
