### PR TITLE
fix(deps): resolve Dependabot alerts (nanoid, js-yaml, dompurify)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2012,9 +2012,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2654,9 +2654,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -3468,9 +3468,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4536,9 +4536,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves the 3 open Dependabot alerts. All are transitive dependencies whose patched versions satisfy the existing semver ranges, so these are lockfile-only bumps (no `package.json` changes).

| Alert | Package | Change | Manifest | Severity | Advisory |
|---|---|---|---|---|---|
| [#70](https://github.com/bruin-data/dac/security/dependabot/70) | nanoid | 3.3.16 → 3.3.18 | docs + frontend* | high | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — infinite loop when size is zero |
| [#67](https://github.com/bruin-data/dac/security/dependabot/67) | js-yaml | 4.3.0 → 4.3.1 | frontend | high | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU in `!!omap` resolution |
| [#66](https://github.com/bruin-data/dac/security/dependabot/66) | dompurify | 3.4.12 → 3.4.13 | frontend | medium | [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7) — detached-subtree XSS |

\* nanoid was also present at the vulnerable 3.3.16 in `frontend/package-lock.json` (surfaced by `npm audit`, not separately alerted); bumped there too.

`npm audit` now reports 0 vulnerabilities in both `frontend` and `docs`. Frontend builds cleanly (`make frontend`).

**Origin of the vulnerable pins:** all three were introduced by earlier dependency-bump commits — `f04d6c4` (nanoid, "fix(deps): bump vite and postcss in docs") and `5ff513b` (js-yaml + dompurify, "fix(deps): bump vulnerable frontend npm packages"), both authored by Tanay Bensu Yurtturk. They were the latest-patched versions available at the time; these advisories were published afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)