### PR TITLE
fix(deps): bump nanoid to 3.3.18 (Dependabot #70)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2012,9 +2012,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4536,9 +4536,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves Dependabot alert [#70](https://github.com/bruin-data/dac/security/dependabot/70).

- **Package:** nanoid (transitive, via postcss)
- **Change:** 3.3.16 → 3.3.18 (lockfile-only; within existing semver range)
- **Manifests:** `docs/package-lock.json` + `frontend/package-lock.json` (frontend also carried the vulnerable 3.3.16, surfaced by `npm audit`)
- **Severity:** high
- **Advisory:** [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators can loop indefinitely when size is zero

`npm audit` reports 0 vulnerabilities after the bump.

**Origin:** the vulnerable 3.3.16 pin was introduced by commit `f04d6c4` ("fix(deps): bump vite and postcss in docs"), authored by Tanay Bensu Yurtturk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)