### PR TITLE
fix(deps): bump js-yaml to 4.3.1 (Dependabot #67)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3468,9 +3468,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves Dependabot alert [#67](https://github.com/bruin-data/dac/security/dependabot/67).

- **Package:** js-yaml (transitive dev dep, via eslint)
- **Change:** 4.3.0 → 4.3.1 (lockfile-only; within existing semver range)
- **Manifest:** `frontend/package-lock.json`
- **Severity:** high
- **Advisory:** [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption in `!!omap` resolution

**Origin:** the vulnerable 4.3.0 pin was introduced by commit `5ff513b` ("fix(deps): bump vulnerable frontend npm packages"), authored by Tanay Bensu Yurtturk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)