### PR TITLE
fix(deps): bump dompurify to 3.4.13 (Dependabot #66)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2654,9 +2654,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {


### PR DESCRIPTION
Resolves Dependabot alert [#66](https://github.com/bruin-data/dac/security/dependabot/66).

- **Package:** dompurify (transitive optional dep, via canvg)
- **Change:** 3.4.12 → 3.4.13 (lockfile-only; within existing semver range)
- **Manifest:** `frontend/package-lock.json`
- **Severity:** medium
- **Advisory:** [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7) — IN_PLACE hook removal leaves a detached subtree executable, causing XSS

**Origin:** the vulnerable 3.4.12 pin was introduced by commit `5ff513b` ("fix(deps): bump vulnerable frontend npm packages"), authored by Tanay Bensu Yurtturk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)