### PR TITLE
Add pivot tables to dashboards

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -873,6 +873,23 @@ rows:
               - { backgroundColor: [red, white, green] }                # base, last (always matches)
 ```
 
+**Pivot tables.** A `pivot_table` widget reshapes its flat result set into a spreadsheet-style pivot table, computed client-side (the query is unchanged). `rows` are the group-by, `columns` spread distinct values across the grid, `values` are the aggregated measures, and `heatmap: true` colours the value cells by a gradient (cohort tables). `pivot` is only valid on `pivot_table` widgets (which require a pivot); every other sub-key is optional, but `values` must be non-empty, and a field can't be in both `rows` and `columns` (that yields a near-empty diagonal). Row filtering is the dashboard's job — use the dashboard's `filters`.
+
+- `rows` / `columns`: nested group-by levels (outer→inner). Each item takes `field` (a result column), `order` (`asc`/`desc`, default `asc`), and `showTotals` — on an **outer** level it adds a subtotal per group; on the **innermost** level it adds the overall Grand Total row/column.
+- `values`: aggregated measures. Each item takes `field`, `summarize` (default `sum`), and `label`. `summarize` is one of exactly these 13: `sum`, `counta`, `count`, `countunique`, `average`, `max`, `min`, `median`, `product`, `stdev`, `stdevp`, `var`, `varp`.
+- `heatmap`: `true` colours the leaf value cells by a red→amber→green gradient over their range — ideal for cohort/retention tables.
+
+```yaml
+- name: Retention cohort
+  type: pivot_table
+  sql: SELECT cohort, month_since, active_users FROM retention
+  pivot:
+    rows: [{ field: cohort }]
+    columns: [{ field: month_since }]     # months since signup spread across
+    values: [{ field: active_users, summarize: sum }]
+    heatmap: true                         # colour the cells so decay is visible
+```
+
 ### Text Widget
 
 Static content with markdown formatting. No query needed.

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -101,7 +101,7 @@ rows:
         col: 3
 ```
 
-Widget types are `metric`, `chart`, `table`, `text`, `divider`, and `image`.
+Widget types are `metric`, `chart`, `table`, `pivot_table`, `text`, `divider`, and `image`.
 
 A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `align` (`left`/`center`/`right` — overrides the type-inferred alignment of the header and body cells, e.g. to right-align a text value like `£177K`), `like`, `hidden`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
 
@@ -159,6 +159,19 @@ rows:
             format:                                                     # a condition wins over the gradient base below
               - { if: is_equal_to, value: 0, backgroundColor: red, bold: true }
               - { backgroundColor: [red, white, green] }                # base, last (always matches)
+```
+
+**Pivot tables.** A `pivot_table` widget reshapes its flat result set into a spreadsheet-style pivot, computed client-side. `rows`/`columns` are nested group-by levels (each item: `field`, `order` `asc`/`desc`, `showTotals` — outer levels add per-group subtotals, the innermost level adds the Grand Total row/column), `values` are the aggregated measures (each item: `field`, `summarize` default `sum`, `label`), and `heatmap: true` colours the value cells by a gradient (cohort tables). `summarize` is one of: `sum`, `counta`, `count`, `countunique`, `average`, `max`, `min`, `median`, `product`, `stdev`, `stdevp`, `var`, `varp`. `pivot` is only valid on `pivot_table` widgets (which require a pivot), `values` must be non-empty, and a field can't be in both `rows` and `columns`. Row filtering is the dashboard's job — use the dashboard's `filters`.
+
+```yaml
+- name: Sales by Region and Product
+  type: table
+  sql: SELECT region, product, sales FROM orders
+  pivot:
+    rows: [ { field: region, showTotals: true } ]
+    columns: [ { field: product } ]
+    values: [ { field: sales, summarize: sum, label: Total Sales } ]
+    filters: [ { field: region, values: [North, South] } ]
 ```
 
 ## Filters

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -7,7 +7,7 @@ Widgets are the visual building blocks of a dashboard. Each widget occupies a nu
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Display name |
-| `type` | string | Yes | `metric`, `chart`, `table`, `text`, `image`, or `divider` |
+| `type` | string | Yes | `metric`, `chart`, `table`, `pivot_table`, `text`, `image`, or `divider` |
 | `col` | integer | No | Column span from 1 to 12 |
 | `description` | string | No | Optional tooltip or subtitle |
 
@@ -371,6 +371,49 @@ Table column fields:
 | `align` | string | Text alignment override: `left`, `center`, or `right`. Applies to the column header and its body cells. Use it to right-align a text value like `£177K` that isn't detected as numeric. |
 | `hidden` | boolean | Keep the column in the result but don't render it, see [Hidden columns](#hidden-columns) |
 | `format` | string \| object | Value display and conditional coloring, see below |
+
+### Pivot tables
+
+A `pivot_table` widget reshapes its flat result set into a spreadsheet-style
+pivot table, computed and rendered client-side (the query is unchanged — the
+pivot runs on the returned rows). **rows** are the group-by, **columns** spread
+distinct values across the grid, **values** are the aggregated measures, and
+**heatmap** colours the value cells by a gradient (cohort tables). Row filtering
+is the dashboard's job — use the dashboard's `filters`, which feed the SQL.
+
+```yaml
+- name: Sales by Region and Product
+  type: pivot_table
+  sql: SELECT region, product, sales FROM orders
+  pivot:
+    rows:
+      - { field: region, order: asc, showTotals: true }   # group-by (outer→inner); outer showTotals → subtotals, innermost → Grand Total row
+    columns:
+      - { field: product }                                # distinct products become columns (+ a Grand Total column with showTotals)
+    values:
+      - { field: sales, summarize: sum, label: Total Sales }  # aggregated measure
+    heatmap: true                                         # colour the value cells by a gradient
+```
+
+`pivot` sub-keys (all optional individually, but `values` must be non-empty for
+the pivot to do anything):
+
+| Sub-key | Item fields | Description |
+|---------|-------------|-------------|
+| `rows` | `field`, `order`, `showTotals` | Nested group-by (outer→inner). An **outer** level's `showTotals` adds a subtotal row per group (e.g. `East Total`); the **innermost** level's `showTotals` adds the overall Grand Total row. |
+| `columns` | `field`, `order`, `showTotals` | Nested; each level's distinct values become columns. An **outer** level's `showTotals` adds subtotal columns; the **innermost** level's adds the Grand Total column. |
+| `values` | `field`, `summarize`, `label` | Aggregated measures. `summarize` defaults to `sum`; `label` overrides the header. |
+| `heatmap` | `true` | Colour the leaf value cells by a red→amber→green gradient over their range (cohort tables). |
+
+For `rows`/`columns` items: `order` is `asc` or `desc` (default `asc`).
+All `field` values reference columns in the query result set, the same namespace
+`columns` uses. `pivot` is only valid on `type: pivot_table` widgets, which require
+a pivot. A field can appear only once across `rows` and `columns` — not twice on an
+axis, and not on both (that produces a near-empty diagonal).
+
+`summarize` is one of exactly these 13 aggregations: `sum`, `counta`, `count`,
+`countunique`, `average`, `max`, `min`, `median`, `product`, `stdev`, `stdevp`,
+`var`, `varp`.
 
 ## Conditional formatting
 

--- a/examples/basic-yaml/dashboards/pivot-table.yml
+++ b/examples/basic-yaml/dashboards/pivot-table.yml
@@ -1,0 +1,52 @@
+name: Pivot Table
+description: >
+  Pivot tables from inline data — nested rows/columns, subtotals, grand totals,
+  and a heatmap-coloured cohort retention table.
+connection: local_duckdb
+
+rows:
+  # Region › Month × Product, summed, with subtotals + grand total.
+  - widgets:
+      - name: Sales by Region / Month × Product
+        type: pivot_table
+        col: 12
+        data:
+          columns: [region, product, month, sales]
+          rows:
+            - [East, Shoes, Jan, 100]
+            - [West, Shoes, Jan, 80]
+            - [East, Hats, Jan, 40]
+            - [East, Shoes, Feb, 120]
+            - [West, Hats, Feb, 60]
+        pivot:
+          rows:
+            - { field: region, showTotals: true }
+            - { field: month, showTotals: true }
+          columns:
+            - { field: product, showTotals: true }
+          values:
+            - { field: sales, summarize: sum }
+
+  # Cohort retention: rows = signup cohort, columns = months since signup,
+  # values = active users, heatmap coloured so retention decay is visible.
+  - widgets:
+      - name: Retention cohort
+        type: pivot_table
+        col: 12
+        data:
+          columns: [cohort, month_since, active_users]
+          rows:
+            - [Jan, 0, 100]
+            - [Jan, 1, 62]
+            - [Jan, 2, 45]
+            - [Jan, 3, 38]
+            - [Feb, 0, 120]
+            - [Feb, 1, 78]
+            - [Feb, 2, 60]
+            - [Mar, 0, 90]
+            - [Mar, 1, 50]
+        pivot:
+          rows: [{ field: cohort }]
+          columns: [{ field: month_since }]
+          values: [{ field: active_users, summarize: sum }]
+          heatmap: true

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -2,12 +2,16 @@ import { useMemo, useState, type CSSProperties } from "react";
 import { format as d3Format } from "d3-format";
 import type { FormatLayer, Widget, WidgetData } from "../../types/dashboard";
 import { useTokens } from "../../themes/TemplateProvider";
-import { cellStyle, isGradient, resolveScale, toNumber, type ResolvedScale } from "./conditionalFormat";
+import { cellColor, cellStyle, isGradient, resolveScale, toNumber, type ResolvedScale } from "./conditionalFormat";
+import { pivotData } from "./pivot";
 
 interface Props {
   widget: Widget;
   data?: WidgetData;
 }
+
+// Cohort heatmap gradient (light red → amber → green) over the value cells.
+const HEATMAP_COLORS = ["#FECACA", "#FEF08A", "#BBF7D0"];
 
 type SortDirection = "asc" | "desc";
 
@@ -40,30 +44,46 @@ export function TableWidget({ widget, data }: Props) {
   const [sort, setSort] = useState<SortState | null>(null);
   const tokens = useTokens();
 
-  const columns: TableColumn[] = useMemo(() => {
-    if (!data?.columns) return [];
+  // A pivot reshapes the result client-side; the rest of the table renders the
+  // reshaped `effData` exactly as it would a plain result set.
+  const pivot = useMemo(() => {
+    if (!widget.pivot || !data?.columns) return null;
+    return pivotData(data.columns.map((c) => c.name), data.rows ?? [], widget.pivot);
+  }, [widget.pivot, data]);
+  const effData: WidgetData | undefined = useMemo(
+    () => (pivot ? { columns: pivot.columns.map((name) => ({ name })), rows: pivot.rows } : data),
+    [pivot, data],
+  );
 
-    const raw = widget.columns?.length
-      ? widget.columns.map((col) => ({
-          name: col.name,
-          label: col.label || col.name,
-          number: col.number,
-          align: col.align,
-          like: col.like,
-          hidden: col.hidden ?? false,
-          format: col.format,
-          idx: data.columns.findIndex((c) => c.name === col.name),
-        }))
-      : data.columns.map((col, idx) => ({
-          name: col.name,
-          label: col.name,
-          number: undefined as string | undefined,
-          align: undefined as TableColumn["align"],
-          like: undefined as string | undefined,
-          hidden: false,
-          format: undefined as FormatLayer[] | undefined,
-          idx,
-        }));
+  const columns: TableColumn[] = useMemo(() => {
+    if (!effData?.columns) return [];
+
+    const meta = new Map((widget.columns ?? []).map((c) => [c.name, c]));
+    const raw =
+      pivot || !widget.columns?.length
+        ? effData.columns.map((col, idx) => {
+            const m = meta.get(col.name);
+            return {
+              name: col.name,
+              label: m?.label || col.name,
+              number: m?.number,
+              align: m?.align,
+              like: m?.like,
+              hidden: m?.hidden ?? false,
+              format: m?.format,
+              idx,
+            };
+          })
+        : widget.columns.map((col) => ({
+            name: col.name,
+            label: col.label || col.name,
+            number: col.number,
+            align: col.align,
+            like: col.like,
+            hidden: col.hidden ?? false,
+            format: col.format,
+            idx: effData.columns.findIndex((c) => c.name === col.name),
+          }));
 
     // `like`: adopt the source column's coloring driven by its per-row value,
     // keeping own `number`. Followed transitively (cycle-guarded) to the terminal source.
@@ -88,17 +108,17 @@ export function TableWidget({ widget, data }: Props) {
         return { ...c, colorIdx: c.idx };
       })
       .filter((c) => !c.hidden);
-  }, [widget.columns, data?.columns]);
+  }, [widget.columns, effData?.columns]);
 
-  const rows = data?.rows ?? [];
+  const rows = effData?.rows ?? [];
 
   // All data columns by name → index, so cross-column rules can reference any
   // column (even ones not shown).
   const dataIndex = useMemo(() => {
     const m = new Map<string, number>();
-    data?.columns.forEach((c, i) => m.set(c.name, i));
+    effData?.columns.forEach((c, i) => m.set(c.name, i));
     return m;
-  }, [data?.columns]);
+  }, [effData?.columns]);
 
   const sortedRows = useMemo(() => {
     if (!sort || rows.length === 0) return rows;
@@ -145,12 +165,39 @@ export function TableWidget({ widget, data }: Props) {
     return m;
   }, [columns]);
 
+  // Heatmap scale over the pivot's leaf value cells (totals/labels excluded).
+  const heatmapScale = useMemo(() => {
+    if (!pivot || !widget.pivot?.heatmap) return null;
+    const vals: number[] = [];
+    pivot.rows.forEach((row, r) => {
+      if (pivot.rowKinds[r] && pivot.rowKinds[r] !== "leaf") return;
+      row.forEach((v, c) => { if (pivot.columnKinds[c] === "leaf") { const n = toNumber(v); if (n !== null) vals.push(n); } });
+    });
+    return vals.length ? resolveScale({ backgroundColor: HEATMAP_COLORS } as FormatLayer, vals, tokens) : null;
+  }, [pivot, widget.pivot, tokens]);
+
   if (!rows.length) {
     return <div className="text-[var(--dac-text-muted)] text-xs py-4 text-center">No data</div>;
   }
 
   const handleHeaderClick = (columnName: string) => {
+    if (pivot) return; // pivots use their own order; sort would break rowKinds alignment
     setSort((current) => nextSortState(current, columnName));
+  };
+
+  // Structural total emphasis for pivots (never label-based, so data named
+  // "… Total" isn't mistaken for a total).
+  const colIsTotal = (idx: number) => pivot?.columnKinds[idx] === "grandtotal";
+  const rowKind = (i: number) => pivot?.rowKinds[i];
+
+  // Cohort-style heatmap: one red→amber→green gradient over the leaf value cells.
+  const heatmapStyle = (rIdx: number, dataIdx: number, value: unknown): CSSProperties | undefined => {
+    if (!heatmapScale) return undefined;
+    const rk = pivot?.rowKinds[rIdx];
+    if (pivot?.columnKinds[dataIdx] !== "leaf" || (rk && rk !== "leaf")) return undefined;
+    const n = toNumber(value);
+    const hit = n === null ? undefined : cellColor(heatmapScale, n);
+    return hit ? { backgroundColor: hit.background } : undefined;
   };
 
   return (
@@ -177,7 +224,7 @@ export function TableWidget({ widget, data }: Props) {
                   <button
                     type="button"
                     onClick={() => handleHeaderClick(col.name)}
-                    className={`group w-full flex items-center gap-1 py-2 px-4 text-[10px] font-semibold uppercase tracking-wider text-[var(--dac-text-muted)] hover:text-[var(--dac-text-primary)] transition-colors duration-75 cursor-pointer border-0 bg-transparent ${alignCls.justify} ${active ? "text-[var(--dac-text-primary)]" : ""}`}
+                    className={`group w-full flex items-center gap-1 py-2 px-4 text-[10px] font-semibold uppercase tracking-wider text-[var(--dac-text-muted)] hover:text-[var(--dac-text-primary)] transition-colors duration-75 border-0 bg-transparent ${alignCls.justify} ${active ? "text-[var(--dac-text-primary)]" : ""} ${pivot ? "cursor-default" : "cursor-pointer"} ${colIsTotal(col.idx) ? "!font-bold" : ""}`}
                   >
                     <span>{col.label}</span>
                     <SortIndicator direction={active ? sort!.direction : null} />
@@ -188,16 +235,22 @@ export function TableWidget({ widget, data }: Props) {
           </tr>
         </thead>
         <tbody>
-          {sortedRows.map((row, i) => (
+          {sortedRows.map((row, i) => {
+            const kind = rowKind(i);
+            const totalRow = kind === "grandtotal";
+            const subtotalRow = kind === "subtotal";
+            return (
             <tr
               key={i}
-              className="hover:bg-[var(--dac-surface)] transition-colors duration-75"
+              className={`transition-colors duration-75 ${totalRow ? "bg-[var(--dac-surface)]" : subtotalRow ? "bg-[var(--dac-surface)]/60" : "hover:bg-[var(--dac-surface)]"}`}
             >
               {columns.map((col) => {
                 const numeric = col.number != null;
                 const alignCls = alignClasses(col.align, numeric);
                 const raw = col.idx >= 0 ? row[col.idx] : null; // displayed value (own column)
                 const style: CSSProperties = numeric ? { fontFamily: '"Geist Mono", monospace' } : {};
+                const hm = heatmapStyle(i, col.idx, raw); // under any explicit CF below
+                if (hm) Object.assign(style, hm);
                 if (col.format) {
                   const lookup = (name: string) => {
                     const idx = dataIndex.get(name);
@@ -212,7 +265,7 @@ export function TableWidget({ widget, data }: Props) {
                     key={col.name}
                     className={`py-1.5 px-4 whitespace-nowrap align-middle rounded-none ${alignCls.text} ${
                       numeric ? "tabular-nums text-[12px]" : ""
-                    }`}
+                    } ${totalRow || colIsTotal(col.idx) ? "font-bold" : ""}`}
                     style={Object.keys(style).length ? style : undefined}
                   >
                     {formatCell(raw, col.number, numberFormatters.get(col.name))}
@@ -220,7 +273,8 @@ export function TableWidget({ widget, data }: Props) {
                 );
               })}
             </tr>
-          ))}
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/frontend/src/components/widgets/conditionalFormat.ts
+++ b/frontend/src/components/widgets/conditionalFormat.ts
@@ -192,6 +192,16 @@ function matchLayer(layer: FormatLayer, raw: unknown, lookup: (column: string) =
   return CONDITIONS[layer.if]?.(raw, value) ?? false;
 }
 
+// Shared operator predicate for CF and pivot filter-by-condition. `operand` is a
+// scalar, or [lo, hi] for between ops; unused for arity-0 ops.
+export function matchesCondition(op: string | undefined, cell: unknown, operand: unknown): boolean {
+  if (!op) return true;
+  if (op === "is_empty") return isEmpty(cell);
+  if (op === "is_not_empty") return !isEmpty(cell);
+  if (isEmpty(cell)) return false;
+  return CONDITIONS[op]?.(cell, operand) ?? false;
+}
+
 function applyTextStyles(style: CSSProperties, s: FormatLayer): void {
   if (s.bold) style.fontWeight = 600;
   if (s.italic) style.fontStyle = "italic";

--- a/frontend/src/components/widgets/pivot.ts
+++ b/frontend/src/components/widgets/pivot.ts
@@ -1,0 +1,232 @@
+// Pivot-table logic on a flat `{ columns, rows }` result set (ported from the
+// Bruin Cloud renderer so the two stay identical):
+//   pivot = {
+//     rows:    [ { field, order?: 'asc'|'desc', showTotals? } ],  // nested group-by
+//     columns: [ { field, order?, showTotals? } ],  // nested; spread into columns
+//     values:  [ { field, summarize?, label? } ],  // measure; summarize defaults to 'sum'
+//     heatmap?: boolean,  // gradient over the value cells (cohort-style)
+//   }
+// Row filtering is the dashboard's job (its filter bar feeds the SQL); the pivot
+// only reshapes. Multi-level axes: a level with showTotals adds per-group
+// subtotals; the axis gets a Grand Total.
+
+export interface PivotField {
+  field: string;
+  order?: "asc" | "desc";
+  showTotals?: boolean;
+}
+export interface PivotValue {
+  field: string;
+  summarize?: string;
+  label?: string;
+}
+export interface PivotConfig {
+  rows?: PivotField[];
+  columns?: PivotField[];
+  values?: PivotValue[];
+  heatmap?: boolean;
+}
+export interface PivotResult {
+  columns: string[];
+  rows: unknown[][];
+  columnKinds: string[];
+  rowKinds: string[];
+}
+
+const LABEL_SEP = " / ";
+
+// ── Aggregations ──
+// Numeric aggregations ignore non-numeric values; COUNTA/COUNTUNIQUE use raw.
+const nonEmpty = (vals: unknown[]): unknown[] => vals.filter((v) => v !== null && v !== undefined && v !== "");
+// Filter empties first since Number('') coerces to 0.
+const nums = (vals: unknown[]): number[] => nonEmpty(vals).map(Number).filter((n) => Number.isFinite(n));
+const sum = (a: number[]): number => a.reduce((s, v) => s + v, 0);
+
+function variance(a: number[], population: boolean): number | null {
+  if (a.length < (population ? 1 : 2)) return null;
+  const mean = sum(a) / a.length;
+  const ss = sum(a.map((v) => (v - mean) ** 2));
+  return ss / (a.length - (population ? 0 : 1));
+}
+
+type Agg = (vals: unknown[]) => number | null;
+export const AGGREGATIONS: Record<string, Agg> = {
+  sum: (vals) => { const a = nums(vals); return a.length ? sum(a) : null; },
+  counta: (vals) => nonEmpty(vals).length,
+  count: (vals) => nums(vals).length,
+  countunique: (vals) => new Set(nonEmpty(vals).map(String)).size,
+  average: (vals) => { const a = nums(vals); return a.length ? sum(a) / a.length : null; },
+  max: (vals) => { const a = nums(vals); return a.length ? Math.max(...a) : null; },
+  min: (vals) => { const a = nums(vals); return a.length ? Math.min(...a) : null; },
+  median: (vals) => {
+    const a = nums(vals).sort((x, y) => x - y);
+    if (!a.length) return null;
+    const m = Math.floor(a.length / 2);
+    return a.length % 2 ? a[m] : (a[m - 1] + a[m]) / 2;
+  },
+  product: (vals) => { const a = nums(vals); return a.length ? a.reduce((p, v) => p * v, 1) : null; },
+  stdev: (vals) => { const v = variance(nums(vals), false); return v === null ? null : Math.sqrt(v); },
+  stdevp: (vals) => { const v = variance(nums(vals), true); return v === null ? null : Math.sqrt(v); },
+  var: (vals) => variance(nums(vals), false),
+  varp: (vals) => variance(nums(vals), true),
+};
+
+function aggregate(fn: string | undefined, vals: unknown[]): number | null {
+  return (AGGREGATIONS[fn ?? "sum"] ?? AGGREGATIONS.sum)(vals);
+}
+
+type FieldDef<T> = T & { idx: number };
+function fieldIndexes<T extends { field: string }>(fields: T[], colIndex: Record<string, number>): FieldDef<T>[] {
+  return fields
+    .map((f) => ({ ...f, idx: colIndex[f.field] }))
+    .filter((f) => f.idx !== undefined);
+}
+
+// Sort distinct group keys by their raw values, honouring each level's asc/desc.
+function orderKeys(keys: string[], defs: FieldDef<PivotField>[], keyValues: Record<string, unknown[]>): string[] {
+  const cmp = (a: string, b: string): number => {
+    const av = keyValues[a], bv = keyValues[b];
+    for (let i = 0; i < av.length; i++) {
+      const an = Number(av[i]), bn = Number(bv[i]);
+      let d = Number.isFinite(an) && Number.isFinite(bn) ? an - bn : String(av[i]).localeCompare(String(bv[i]));
+      if (defs[i]?.order === "desc") d = -d;
+      if (d) return d;
+    }
+    return 0;
+  };
+  return [...keys].sort(cmp);
+}
+
+function valueLabel(v: PivotValue): string {
+  return v.label || `${(v.summarize || "sum").toUpperCase()} of ${v.field}`;
+}
+
+interface Segment { path: unknown[]; keys: string[]; kind: "leaf" | "subtotal" | "grandtotal"; level: number; }
+
+// Walk a nested axis into ordered segments: a 'leaf' per full path, plus a
+// 'subtotal' after each group of a showTotals level.
+function axisSegments(orderedKeys: string[], keyVals: Record<string, unknown[]>, defs: FieldDef<PivotField>[]): Segment[] {
+  if (!defs.length) return [{ path: [], keys: orderedKeys, kind: "leaf", level: 0 }];
+  const build = (level: number, keys: string[]): Segment[] => {
+    const out: Segment[] = [];
+    const groups: { v: unknown; keys: string[] }[] = [];
+    const seen = new Map<string, number>();
+    for (const k of keys) {
+      const label = String(keyVals[k][level] ?? "");
+      if (!seen.has(label)) { seen.set(label, groups.length); groups.push({ v: keyVals[k][level], keys: [] }); }
+      groups[seen.get(label)!].keys.push(k);
+    }
+    for (const g of groups) {
+      if (level === defs.length - 1) {
+        out.push({ path: [g.v], keys: g.keys, kind: "leaf", level });
+      } else {
+        const child = build(level + 1, g.keys);
+        for (const seg of child) seg.path = [g.v, ...seg.path];
+        out.push(...child);
+        if (defs[level].showTotals) out.push({ path: [g.v], keys: g.keys, kind: "subtotal", level });
+      }
+    }
+    return out;
+  };
+  return build(0, orderedKeys);
+}
+
+// Returns a pivoted `{ columns, rows, columnKinds, rowKinds }`, or null when the
+// pivot has no usable Values field (caller renders the raw result).
+export function pivotData(columns: string[], rows: unknown[][], pivot: PivotConfig | undefined): PivotResult | null {
+  if (!pivot) return null;
+  const colIndex: Record<string, number> = {};
+  columns.forEach((name, i) => { colIndex[name] = i; });
+
+  // A field belongs to at most one axis, once (mirrors the editor + dac validation).
+  const axisSeen = new Set<string>();
+  const onceAcrossAxes = (defs: FieldDef<PivotField>[]) => defs.filter((d) => (axisSeen.has(d.field) ? false : (axisSeen.add(d.field), true)));
+  const rowDefs = onceAcrossAxes(fieldIndexes(pivot.rows ?? [], colIndex));
+  const colDefs = onceAcrossAxes(fieldIndexes(pivot.columns ?? [], colIndex));
+  const valDefs = fieldIndexes(pivot.values ?? [], colIndex);
+  if (!valDefs.length) return null;
+  const kept = rows;
+
+  // Bucket raw value cells by (rowKey, colKey, valueField).
+  const rowKeys: string[] = [], colKeys: string[] = [];
+  const rowKeyVals: Record<string, unknown[]> = {}, colKeyVals: Record<string, unknown[]> = {};
+  const rowSeen = new Set<string>(), colSeen = new Set<string>();
+  const buckets: Record<string, Record<string, unknown[][]>> = Object.create(null);
+
+  const keyOf = (row: unknown[], defs: FieldDef<PivotField>[], keys: string[], keyVals: Record<string, unknown[]>, seen: Set<string>): string => {
+    const vals = defs.map((d) => row[d.idx]);
+    // JSON-encode the tuple so distinct values can't collide (e.g. ["a b","c"]
+    // vs ["a","b c"]) and null is kept distinct from the empty string.
+    const key = defs.length ? JSON.stringify(vals) : "";
+    if (!seen.has(key)) { seen.add(key); keys.push(key); keyVals[key] = vals; }
+    return key;
+  };
+
+  for (const row of kept) {
+    const rk = keyOf(row, rowDefs, rowKeys, rowKeyVals, rowSeen);
+    const ck = keyOf(row, colDefs, colKeys, colKeyVals, colSeen);
+    const byCol = buckets[rk] || (buckets[rk] = Object.create(null));
+    const cells = byCol[ck] || (byCol[ck] = valDefs.map(() => [] as unknown[]));
+    valDefs.forEach((v, i) => cells[i].push(row[v.idx]));
+  }
+
+  const orderedRowKeys = orderKeys(rowKeys, rowDefs, rowKeyVals);
+  const orderedColKeys = orderKeys(colKeys, colDefs, colKeyVals);
+
+  // Outer levels' showTotals drive subtotals; the innermost drives the Grand Total.
+  const showRowTotals = rowDefs.length ? !!rowDefs[rowDefs.length - 1].showTotals : false;
+  const showColTotals = colDefs.length ? !!colDefs[colDefs.length - 1].showTotals : false;
+
+  // One cell = aggregate over the cross product of a row-key set and col-key set.
+  const cellAgg = (rks: string[], cks: string[], i: number): number | null =>
+    aggregate(valDefs[i].summarize, rks.flatMap((rk) => cks.flatMap((ck) => buckets[rk]?.[ck]?.[i] || [])));
+
+  // Column units (one per rendered measure column).
+  const colHeader = (seg: Segment, v: PivotValue): string => {
+    if (!colDefs.length) return valueLabel(v);
+    const base = seg.kind === "subtotal" ? `${seg.path[seg.path.length - 1]} Total` : seg.path.join(LABEL_SEP);
+    return valDefs.length > 1 ? `${base} — ${valueLabel(v)}` : base;
+  };
+  const colUnits: { cks: string[]; i: number; header: string; kind: string }[] = [];
+  for (const seg of axisSegments(orderedColKeys, colKeyVals, colDefs)) {
+    valDefs.forEach((v, i) => colUnits.push({ cks: seg.keys, i, header: colHeader(seg, v), kind: seg.kind }));
+  }
+  if (showColTotals) {
+    valDefs.forEach((v, i) => colUnits.push({ cks: orderedColKeys, i, header: valDefs.length > 1 ? `Grand Total — ${valueLabel(v)}` : "Grand Total", kind: "grandtotal" }));
+  }
+
+  // Uniquify headers so duplicate value labels / total-named data don't collide.
+  const nameSeen = new Map<string, number>();
+  const uniq = (name: string) => {
+    const n = (nameSeen.get(name) || 0) + 1;
+    nameSeen.set(name, n);
+    return n > 1 ? `${name} (${n})` : name;
+  };
+  const outColumns = [...rowDefs.map((d) => d.field), ...colUnits.map((u) => u.header)].map(uniq);
+  const columnKinds = [...rowDefs.map(() => "label"), ...colUnits.map((u) => u.kind || "leaf")];
+
+  // Row segments → output rows.
+  const rowSegs = axisSegments(orderedRowKeys, rowKeyVals, rowDefs);
+  if (rowDefs.length && showRowTotals) rowSegs.push({ path: [], keys: orderedRowKeys, kind: "grandtotal", level: 0 });
+
+  // Row-label cells: a leaf blanks a level that repeats the previous leaf;
+  // subtotal/grand-total rows carry their own label.
+  let prev: unknown[] | null = null;
+  const outRows = rowSegs.map((seg) => {
+    const labels: unknown[] = rowDefs.map(() => "");
+    if (seg.kind === "grandtotal") {
+      labels[0] = "Grand Total";
+    } else if (seg.kind === "subtotal") {
+      labels[seg.level] = `${seg.path[seg.path.length - 1]} Total`;
+    } else {
+      let c = 0;
+      while (prev && c < seg.path.length && String(prev[c]) === String(seg.path[c])) c++;
+      for (let l = 0; l < seg.path.length; l++) labels[l] = l >= c ? seg.path[l] : "";
+      prev = seg.path;
+    }
+    return [...labels, ...colUnits.map((u) => cellAgg(seg.keys, u.cks, u.i))];
+  });
+  const rowKinds = rowSegs.map((seg) => seg.kind || "leaf");
+
+  return { columns: outColumns, rows: outRows, columnKinds, rowKinds };
+}

--- a/frontend/src/themes/bruin/WidgetFrame.tsx
+++ b/frontend/src/themes/bruin/WidgetFrame.tsx
@@ -46,12 +46,12 @@ export function BruinWidgetFrame({ widget, data, isLoading }: WidgetFrameProps) 
     );
   }
 
-  const isTable = widget.type === "table";
-  const isExportable = widget.type === "chart" || widget.type === "table";
+  const isTable = widget.type === "table" || widget.type === "pivot_table";
+  const isExportable = widget.type === "chart" || isTable;
   const canExport = isExportable && !isLoading;
 
   return (
-    <div data-dac-widget-frame className={`group ${containerClass[widget.type] ?? containerClass.text}`}>
+    <div data-dac-widget-frame className={`group ${containerClass[widget.type] ?? (isTable ? containerClass.table : containerClass.text)}`}>
       {widget.type !== "text" && (
         <div className={`flex items-center text-[11px] font-medium uppercase tracking-wider text-[var(--dac-text-muted)] ${widget.description ? "mb-0.5" : "mb-1.5"} ${isTable ? "px-4" : ""}`}>
           <span>{widget.name}</span>
@@ -79,7 +79,7 @@ export function BruinWidgetFrame({ widget, data, isLoading }: WidgetFrameProps) 
         <>
           {widget.type === "metric" && <div className="mt-auto"><MetricWidget widget={widget} data={data} /></div>}
           {widget.type === "chart" && <ChartWidget widget={widget} data={data} />}
-          {widget.type === "table" && <TableWidget widget={widget} data={data} />}
+          {isTable && <TableWidget widget={widget} data={data} />}
         </>
       )}
       {widget.type === "text" && <TextWidget widget={widget} />}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -53,7 +53,7 @@ export interface Row {
 export interface Widget {
   name: string;
   description?: string;
-  type: "metric" | "chart" | "table" | "text" | "divider" | "image";
+  type: "metric" | "chart" | "table" | "pivot_table" | "text" | "divider" | "image";
   col?: number;
 
   // Query source
@@ -111,6 +111,7 @@ export interface Widget {
 
   // Table
   columns?: TableColumn[];
+  pivot?: import("../components/widgets/pivot").PivotConfig;
 
   // Text
   content?: string;

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -14,12 +14,13 @@ import (
 
 // Widget type constants.
 const (
-	WidgetTypeMetric  = "metric"
-	WidgetTypeChart   = "chart"
-	WidgetTypeTable   = "table"
-	WidgetTypeText    = "text"
-	WidgetTypeDivider = "divider"
-	WidgetTypeImage   = "image"
+	WidgetTypeMetric     = "metric"
+	WidgetTypeChart      = "chart"
+	WidgetTypeTable      = "table"
+	WidgetTypePivotTable = "pivot_table"
+	WidgetTypeText       = "text"
+	WidgetTypeDivider    = "divider"
+	WidgetTypeImage      = "image"
 )
 
 // Dashboard represents a complete dashboard definition loaded from YAML.
@@ -149,6 +150,9 @@ type Widget struct {
 
 	// Table fields
 	Columns []TableColumn `yaml:"columns,omitempty" json:"columns,omitempty"`
+	// Pivot turns a table's flat result set into a spreadsheet-style pivot,
+	// computed and rendered client-side. Table widgets only — see PivotConfig.
+	Pivot *PivotConfig `yaml:"pivot,omitempty" json:"pivot,omitempty"`
 
 	// Text fields
 	Content string `yaml:"content,omitempty" json:"content,omitempty"`
@@ -224,6 +228,29 @@ type TableColumn struct {
 	Hidden bool          `yaml:"hidden,omitempty" json:"hidden,omitempty"` // keep the column in the result (for cross-column rules / like) but don't render it
 	Align  string        `yaml:"align,omitempty" json:"align,omitempty"`   // text alignment override: left | center | right (applies to the header and body cells)
 	Format []FormatLayer `yaml:"format,omitempty" json:"format,omitempty"` // ordered conditional-format style layers; first match wins
+}
+
+// PivotConfig reshapes a pivot_table widget's flat result into a pivot table.
+// Heatmap, when set, colours the value cells by a gradient (cohort tables).
+type PivotConfig struct {
+	Rows    []PivotField `yaml:"rows,omitempty" json:"rows,omitempty"`
+	Columns []PivotField `yaml:"columns,omitempty" json:"columns,omitempty"`
+	Values  []PivotValue `yaml:"values,omitempty" json:"values,omitempty"`
+	Heatmap bool         `yaml:"heatmap,omitempty" json:"heatmap,omitempty"`
+}
+
+// PivotField is one nested group-by level (rows or columns axis).
+type PivotField struct {
+	Field      string `yaml:"field" json:"field"`
+	Order      string `yaml:"order,omitempty" json:"order,omitempty"` // asc | desc (default asc)
+	ShowTotals bool   `yaml:"showTotals,omitempty" json:"showTotals,omitempty"`
+}
+
+// PivotValue is an aggregated measure.
+type PivotValue struct {
+	Field     string `yaml:"field" json:"field"`
+	Summarize string `yaml:"summarize,omitempty" json:"summarize,omitempty"` // default sum; see validPivotAggregations
+	Label     string `yaml:"label,omitempty" json:"label,omitempty"`
 }
 
 // UnmarshalYAML makes a column's `format` polymorphic for backward compatibility.

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -74,6 +74,12 @@ func Validate(d *Dashboard) error {
 				// Table widgets just need a query source.
 				errs = append(errs, validateQuerySource(prefix, &w, d)...)
 				validateTableColumns(prefix, &w, &errs)
+			case WidgetTypePivotTable:
+				errs = append(errs, validateQuerySource(prefix, &w, d)...)
+				validateTableColumns(prefix, &w, &errs)
+				if w.Pivot == nil {
+					errs = append(errs, fmt.Sprintf("%s: pivot_table widgets need a pivot", prefix))
+				}
 			case WidgetTypeText:
 				if w.Content == "" {
 					errs = append(errs, fmt.Sprintf("%s: content is required for text widgets", prefix))
@@ -87,7 +93,7 @@ func Validate(d *Dashboard) error {
 			case "":
 				// Already reported above.
 			default:
-				errs = append(errs, fmt.Sprintf("%s: unknown widget type %q (expected metric, chart, table, text, divider, or image)", prefix, w.Type))
+				errs = append(errs, fmt.Sprintf("%s: unknown widget type %q (expected metric, chart, table, pivot_table, text, divider, or image)", prefix, w.Type))
 			}
 
 			if len(w.Spec) > 0 && (w.Type != WidgetTypeChart || w.Chart != "vega-lite") {
@@ -95,6 +101,8 @@ func Validate(d *Dashboard) error {
 			}
 
 			errs = append(errs, validateInlineData(prefix, &w)...)
+
+			validatePivot(prefix, &w, &errs)
 
 			if w.Col < 0 || w.Col > 12 {
 				errs = append(errs, fmt.Sprintf("%s: col must be between 1 and 12, got %d", prefix, w.Col))
@@ -187,9 +195,9 @@ func validateInlineData(prefix string, w *Widget) []string {
 	var errs []string
 
 	switch w.Type {
-	case WidgetTypeMetric, WidgetTypeChart, WidgetTypeTable:
+	case WidgetTypeMetric, WidgetTypeChart, WidgetTypeTable, WidgetTypePivotTable:
 	default:
-		return append(errs, fmt.Sprintf("%s: data is only valid on metric, chart, or table widgets", prefix))
+		return append(errs, fmt.Sprintf("%s: data is only valid on metric, chart, table, or pivot_table widgets", prefix))
 	}
 
 	if w.SQL != "" || w.QueryRef != "" || w.IsSemantic() {
@@ -681,6 +689,65 @@ var validFormatOps = map[string]bool{
 	CondGreaterThan: true, CondGreaterThanOrEqual: true, CondLessThan: true,
 	CondLessThanOrEqual: true, CondIsEqualTo: true, CondIsNotEqualTo: true,
 	CondIsBetween: true, CondIsNotBetween: true,
+}
+
+// validPivotAggregations are the allowed pivot summarize functions.
+var validPivotAggregations = map[string]bool{
+	"sum": true, "counta": true, "count": true, "countunique": true,
+	"average": true, "max": true, "min": true, "median": true,
+	"product": true, "stdev": true, "stdevp": true, "var": true, "varp": true,
+}
+
+// validatePivot checks a pivot_table widget's pivot config.
+func validatePivot(prefix string, w *Widget, errs *[]string) {
+	p := w.Pivot
+	if p == nil {
+		return
+	}
+	if w.Type != WidgetTypePivotTable {
+		*errs = append(*errs, fmt.Sprintf("%s: pivot is only valid on pivot_table widgets", prefix))
+		return
+	}
+	validatePivotAxis(prefix, "rows", p.Rows, errs)
+	validatePivotAxis(prefix, "columns", p.Columns, errs)
+	// A field can't be on both axes (near-empty diagonal).
+	rowFields := map[string]bool{}
+	for _, f := range p.Rows {
+		rowFields[f.Field] = true
+	}
+	for _, f := range p.Columns {
+		if f.Field != "" && rowFields[f.Field] {
+			*errs = append(*errs, fmt.Sprintf("%s: pivot field %q can't be in both rows and columns", prefix, f.Field))
+		}
+	}
+	if len(p.Values) == 0 {
+		*errs = append(*errs, fmt.Sprintf("%s: pivot.values must list at least one value", prefix))
+	}
+	for i, v := range p.Values {
+		if v.Field == "" {
+			*errs = append(*errs, fmt.Sprintf("%s: pivot.values[%d].field is required", prefix, i))
+		}
+		if v.Summarize != "" && !validPivotAggregations[v.Summarize] {
+			*errs = append(*errs, fmt.Sprintf("%s: pivot.values[%d].summarize %q is invalid (expected one of sum, counta, count, countunique, average, max, min, median, product, stdev, stdevp, var, varp)", prefix, i, v.Summarize))
+		}
+	}
+}
+
+// validatePivotAxis checks one nested axis (rows or columns) of a pivot config.
+func validatePivotAxis(prefix, axis string, fields []PivotField, errs *[]string) {
+	seen := map[string]bool{}
+	for i, f := range fields {
+		if f.Field == "" {
+			*errs = append(*errs, fmt.Sprintf("%s: pivot.%s[%d].field is required", prefix, axis, i))
+		} else if seen[f.Field] {
+			*errs = append(*errs, fmt.Sprintf("%s: pivot.%s field %q is listed more than once", prefix, axis, f.Field))
+		} else {
+			seen[f.Field] = true
+		}
+		if f.Order != "" && f.Order != "asc" && f.Order != "desc" {
+			*errs = append(*errs, fmt.Sprintf("%s: pivot.%s[%d].order must be asc or desc", prefix, axis, i))
+		}
+	}
 }
 
 func validateTableColumns(prefix string, w *Widget, errs *[]string) {

--- a/pkg/dashboard/validator_test.go
+++ b/pkg/dashboard/validator_test.go
@@ -411,6 +411,152 @@ func TestValidate_DualAxisRejectsColor(t *testing.T) {
 	assertValidationContains(t, err, "y2 cannot be combined with color")
 }
 
+func TestValidate_PivotValid(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "w", Type: WidgetTypePivotTable, SQL: "SELECT region, product, sales FROM orders",
+				Pivot: &PivotConfig{
+					Rows:    []PivotField{{Field: "region", Order: "asc", ShowTotals: true}},
+					Columns: []PivotField{{Field: "product"}},
+					Values:  []PivotValue{{Field: "sales", Summarize: "sum", Label: "Total Sales"}},
+					Heatmap: true,
+				},
+			}}},
+		},
+	}
+	assertNoErr(t, Validate(d))
+}
+
+func TestValidate_PivotOnlyOnTables(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "w", Type: WidgetTypeChart, Chart: "line", SQL: "SELECT 1",
+				X:     &AxisEncoding{Field: "month"},
+				Y:     &AxisEncoding{Field: []string{"revenue"}},
+				Pivot: &PivotConfig{Values: []PivotValue{{Field: "revenue"}}},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "pivot is only valid on pivot_table widgets")
+}
+
+func TestValidate_PivotRequiresValues(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "w", Type: WidgetTypePivotTable, SQL: "SELECT region FROM orders",
+				Pivot: &PivotConfig{Rows: []PivotField{{Field: "region"}}},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "pivot.values must list at least one value")
+}
+
+func TestValidate_PivotFieldOnBothAxes(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "w", Type: WidgetTypePivotTable, SQL: "SELECT region, sales FROM orders",
+				Pivot: &PivotConfig{
+					Rows:    []PivotField{{Field: "region"}},
+					Columns: []PivotField{{Field: "region"}},
+					Values:  []PivotValue{{Field: "sales"}},
+				},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "can't be in both rows and columns")
+}
+
+func TestValidate_PivotDuplicateFieldInAxis(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "w", Type: WidgetTypePivotTable, SQL: "SELECT region, sales FROM orders",
+				Pivot: &PivotConfig{
+					Rows:   []PivotField{{Field: "region"}, {Field: "region"}},
+					Values: []PivotValue{{Field: "sales"}},
+				},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "is listed more than once")
+}
+
+func TestValidate_PivotRequiresPivotType(t *testing.T) {
+	// A pivot config on a plain table is rejected — it must be a pivot_table.
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "w", Type: WidgetTypeTable, SQL: "SELECT region, sales FROM orders",
+			Pivot: &PivotConfig{Values: []PivotValue{{Field: "sales"}}},
+		}}}},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "pivot is only valid on pivot_table widgets")
+}
+
+func TestValidate_PivotTableNeedsPivot(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{{Widgets: []Widget{{
+			Name: "w", Type: WidgetTypePivotTable, SQL: "SELECT region FROM orders",
+		}}}},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "pivot_table widgets need a pivot")
+}
+
+func TestValidate_PivotInvalidSummarize(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "w", Type: WidgetTypePivotTable, SQL: "SELECT sales FROM orders",
+				Pivot: &PivotConfig{Values: []PivotValue{{Field: "sales", Summarize: "total"}}},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "summarize \"total\" is invalid")
+}
+
+func TestValidate_PivotInvalidOrder(t *testing.T) {
+	d := &Dashboard{
+		Name: "test",
+		Rows: []Row{
+			{Widgets: []Widget{{
+				Name: "w", Type: WidgetTypePivotTable, SQL: "SELECT region, sales FROM orders",
+				Pivot: &PivotConfig{
+					Rows:   []PivotField{{Field: "region", Order: "ascending"}},
+					Values: []PivotValue{{Field: "sales"}},
+				},
+			}}},
+		},
+	}
+	err := Validate(d)
+	assertErr(t, err)
+	assertValidationContains(t, err, "pivot.rows[0].order must be asc or desc")
+}
+
 func TestValidate_FilterTypes(t *testing.T) {
 	d := &Dashboard{
 		Name: "test",
@@ -595,7 +741,7 @@ func TestValidate_InlineDataInvalidOnText(t *testing.T) {
 	}
 	err := Validate(d)
 	assertErr(t, err)
-	assertValidationContains(t, err, "data is only valid on metric, chart, or table widgets")
+	assertValidationContains(t, err, "data is only valid on metric, chart, table, or pivot_table widgets")
 }
 
 func TestValidate_InlineDataEmptyColumns(t *testing.T) {

--- a/pkg/slides/export.go
+++ b/pkg/slides/export.go
@@ -215,7 +215,7 @@ func widgetRequests(ctx context.Context, driveSvc *driveapi.Service, slideID str
 				}
 			}
 
-		case dashboard.WidgetTypeTable:
+		case dashboard.WidgetTypeTable, dashboard.WidgetTypePivotTable:
 			reqs = append(reqs, tableReqs(prefix, slideID, &w, data, x, padY, wWidth)...)
 
 		case dashboard.WidgetTypeText:

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -198,7 +198,7 @@
           "type": "string"
         },
         "type": {
-          "enum": ["metric", "chart", "table", "text", "divider", "image"]
+          "enum": ["metric", "chart", "table", "pivot_table", "text", "divider", "image"]
         },
         "col": {
           "type": "integer",
@@ -390,6 +390,10 @@
             "$ref": "#/$defs/tableColumn"
           }
         },
+        "pivot": {
+          "$ref": "#/$defs/pivot",
+          "description": "pivot_table widgets: reshape the flat result set into a pivot table, computed client-side. rows/columns are nested group-by levels; columns' distinct values spread across the grid; values are the aggregated measures; heatmap colours the value cells by a gradient (cohort tables). Row filtering is the dashboard's job."
+        },
         "content": {
           "type": "string"
         },
@@ -403,7 +407,17 @@
       "patternProperties": {
         "^x-": true
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "required": ["type"],
+            "properties": { "type": { "const": "pivot_table" } }
+          },
+          "then": { "required": ["pivot"] },
+          "else": { "not": { "required": ["pivot"] } }
+        }
+      ]
     },
     "dimensionRef": {
       "type": "object",
@@ -495,6 +509,73 @@
             { "type": "array", "items": { "$ref": "#/$defs/formatLayer" } }
           ]
         }
+      },
+      "patternProperties": {
+        "^x-": true
+      },
+      "additionalProperties": false
+    },
+    "pivot": {
+      "type": "object",
+      "properties": {
+        "rows": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pivotField" }
+        },
+        "columns": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pivotField" }
+        },
+        "values": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pivotValue" }
+        },
+        "heatmap": {
+          "type": "boolean",
+          "description": "colour the value cells by a red→amber→green gradient over their range (cohort/retention tables)"
+        }
+      },
+      "patternProperties": {
+        "^x-": true
+      },
+      "additionalProperties": false
+    },
+    "pivotField": {
+      "type": "object",
+      "required": ["field"],
+      "properties": {
+        "field": { "type": "string", "minLength": 1 },
+        "order": { "enum": ["asc", "desc"] },
+        "showTotals": { "type": "boolean" }
+      },
+      "patternProperties": {
+        "^x-": true
+      },
+      "additionalProperties": false
+    },
+    "pivotValue": {
+      "type": "object",
+      "required": ["field"],
+      "properties": {
+        "field": { "type": "string", "minLength": 1 },
+        "summarize": {
+          "enum": [
+            "sum",
+            "counta",
+            "count",
+            "countunique",
+            "average",
+            "max",
+            "min",
+            "median",
+            "product",
+            "stdev",
+            "stdevp",
+            "var",
+            "varp"
+          ]
+        },
+        "label": { "type": "string" }
       },
       "patternProperties": {
         "^x-": true

--- a/schemas/schema_test.go
+++ b/schemas/schema_test.go
@@ -65,6 +65,25 @@ rows:
 `,
 		},
 		{
+			name:     "dashboard pivot table",
+			schemaID: DashboardV1ID,
+			yaml: `name: Pivot
+rows:
+  - widgets:
+      - name: Sales
+        type: pivot_table
+        sql: SELECT region, product, sales FROM orders
+        pivot:
+          rows:
+            - { field: region, order: asc, showTotals: true }
+          columns:
+            - { field: product }
+          values:
+            - { field: sales, summarize: sum, label: Total Sales }
+          heatmap: true
+`,
+		},
+		{
 			name:     "theme",
 			schemaID: ThemeV1ID,
 			yaml: `schema: https://getbruin.com/schemas/dac/theme/v1
@@ -143,6 +162,33 @@ rows:
 			schemaID: ThemeV1ID,
 			yaml: `schema: https://getbruin.com/schemas/dac/theme/v1
 name: corporate
+`,
+		},
+		{
+			name:     "pivot on non-pivot_table widget",
+			schemaID: DashboardV1ID,
+			yaml: `name: Pivot On Table
+rows:
+  - widgets:
+      - name: Sales
+        type: table
+        sql: SELECT region, sales FROM orders
+        pivot:
+          rows:
+            - { field: region }
+          values:
+            - { field: sales }
+`,
+		},
+		{
+			name:     "pivot_table widget without pivot",
+			schemaID: DashboardV1ID,
+			yaml: `name: Pivot Missing
+rows:
+  - widgets:
+      - name: Sales
+        type: pivot_table
+        sql: SELECT region, sales FROM orders
 `,
 		},
 	}


### PR DESCRIPTION
Adds pivot tables to table widgets: nested rows/columns, aggregated values (sum, count, average, …), per-group subtotals and grand totals, and keep-only / condition filters. Covers schema, validation, docs, the React renderer, and an example dashboard.