### PR TITLE
BRU-6471: preserve list shape for multi-select semantic filters

### DIFF
--- a/pkg/server/semantic.go
+++ b/pkg/server/semantic.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	sem "github.com/bruin-data/bruin/semantic-engine"
@@ -159,18 +160,24 @@ func renderSemanticQuery(query sem.Query, filters map[string]any) (sem.Query, er
 		return rendered, nil
 	}
 
-	rendered.Filters = make([]sem.Filter, len(query.Filters))
-	for i, filter := range query.Filters {
-		rendered.Filters[i] = filter
+	rendered.Filters = make([]sem.Filter, 0, len(query.Filters))
+	for _, filter := range query.Filters {
+		rf := filter
 		var err error
-		rendered.Filters[i].Expression, err = renderTemplateString(filter.Expression, filters)
+		rf.Expression, err = renderTemplateString(filter.Expression, filters)
 		if err != nil {
 			return sem.Query{}, fmt.Errorf("rendering filter expression: %w", err)
 		}
-		rendered.Filters[i].Value, err = renderTemplateValue(filter.Value, filters)
+		rf.Value, err = renderTemplateValue(filter.Value, filters)
 		if err != nil {
 			return sem.Query{}, fmt.Errorf("rendering filter value: %w", err)
 		}
+		// An empty multi-select applies no constraint (show all) rather than
+		// emitting `IN ()`, which is a SQL error / silently matches zero rows.
+		if rf.Expression == "" && isEmptyList(rf.Value) {
+			continue
+		}
+		rendered.Filters = append(rendered.Filters, rf)
 	}
 
 	return rendered, nil
@@ -185,9 +192,23 @@ func renderTemplateString(value string, filters map[string]any) (string, error) 
 	return tmpl.Render(value, filters)
 }
 
+// bareFilterRef matches a value that is exactly a single `{{ filters.<key> }}`
+// reference — no surrounding text and no filter pipe (e.g. `| join`). Such a
+// reference must keep the native shape of the value it points at.
+var bareFilterRef = regexp.MustCompile(`^\{\{\s*filters\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}$`)
+
 func renderTemplateValue(value any, filters map[string]any) (any, error) {
 	switch typed := value.(type) {
 	case string:
+		// A lone `{{ filters.x }}` reference to a multi-select value must keep its
+		// list shape: gonja would render it to `['a', 'b']`, which the engine then
+		// treats as one scalar and quotes into broken SQL. Resolve the reference
+		// directly so a list reaches formatList as a list.
+		if m := bareFilterRef.FindStringSubmatch(strings.TrimSpace(typed)); m != nil {
+			if v, ok := filters[m[1]]; ok && isList(v) {
+				return v, nil
+			}
+		}
 		return renderTemplateString(typed, filters)
 	case []string:
 		out := make([]string, len(typed))
@@ -222,4 +243,22 @@ func renderTemplateValue(value any, filters map[string]any) (any, error) {
 	default:
 		return value, nil
 	}
+}
+
+func isList(v any) bool {
+	switch v.(type) {
+	case []string, []interface{}:
+		return true
+	}
+	return false
+}
+
+func isEmptyList(v any) bool {
+	switch typed := v.(type) {
+	case []string:
+		return len(typed) == 0
+	case []interface{}:
+		return len(typed) == 0
+	}
+	return false
 }

--- a/pkg/server/semantic.go
+++ b/pkg/server/semantic.go
@@ -162,6 +162,10 @@ func renderSemanticQuery(query sem.Query, filters map[string]any) (sem.Query, er
 
 	rendered.Filters = make([]sem.Filter, 0, len(query.Filters))
 	for _, filter := range query.Filters {
+		// Empty multi-select: apply no constraint instead of IN () / IN ('').
+		if filterSelectionEmpty(filter, filters) {
+			continue
+		}
 		rf := filter
 		var err error
 		rf.Expression, err = renderTemplateString(filter.Expression, filters)
@@ -171,11 +175,6 @@ func renderSemanticQuery(query sem.Query, filters map[string]any) (sem.Query, er
 		rf.Value, err = renderTemplateValue(filter.Value, filters)
 		if err != nil {
 			return sem.Query{}, fmt.Errorf("rendering filter value: %w", err)
-		}
-		// An empty multi-select applies no constraint (show all) rather than
-		// emitting `IN ()`, which is a SQL error / silently matches zero rows.
-		if rf.Expression == "" && isEmptyList(rf.Value) {
-			continue
 		}
 		rendered.Filters = append(rendered.Filters, rf)
 	}
@@ -193,17 +192,32 @@ func renderTemplateString(value string, filters map[string]any) (string, error) 
 }
 
 // bareFilterRef matches a value that is exactly a single `{{ filters.<key> }}`
-// reference — no surrounding text and no filter pipe (e.g. `| join`). Such a
-// reference must keep the native shape of the value it points at.
+// reference: no surrounding text, no pipe.
 var bareFilterRef = regexp.MustCompile(`^\{\{\s*filters\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}$`)
+
+// filterRef matches any `filters.<key>` reference within a string.
+var filterRef = regexp.MustCompile(`filters\.([A-Za-z_][A-Za-z0-9_]*)`)
+
+// filterSelectionEmpty reports whether the filter references a multi-select
+// selection that is currently empty, in either its Expression or Value.
+func filterSelectionEmpty(f sem.Filter, filters map[string]any) bool {
+	refs := f.Expression
+	if s, ok := f.Value.(string); ok {
+		refs += " " + s
+	}
+	for _, m := range filterRef.FindAllStringSubmatch(refs, -1) {
+		if v, ok := filters[m[1]]; ok && isEmptyList(v) {
+			return true
+		}
+	}
+	return false
+}
 
 func renderTemplateValue(value any, filters map[string]any) (any, error) {
 	switch typed := value.(type) {
 	case string:
-		// A lone `{{ filters.x }}` reference to a multi-select value must keep its
-		// list shape: gonja would render it to `['a', 'b']`, which the engine then
-		// treats as one scalar and quotes into broken SQL. Resolve the reference
-		// directly so a list reaches formatList as a list.
+		// Keep a lone list reference as a list; gonja would stringify it to
+		// `['a', 'b']`, which the engine then quotes into broken SQL.
 		if m := bareFilterRef.FindStringSubmatch(strings.TrimSpace(typed)); m != nil {
 			if v, ok := filters[m[1]]; ok && isList(v) {
 				return v, nil

--- a/pkg/server/semantic_filter_test.go
+++ b/pkg/server/semantic_filter_test.go
@@ -6,10 +6,9 @@ import (
 	sem "github.com/bruin-data/bruin/semantic-engine"
 )
 
-// TestRenderSemanticQuery_MultiSelectFilter verifies that a multi-select
-// dashboard filter (a list value referenced via `{{ filters.x }}`) keeps its
-// list shape through templating, so the engine renders `IN ('a', 'b')` instead
-// of quoting the stringified list into broken SQL.
+// TestRenderSemanticQuery_MultiSelectFilter covers multi-select filters: a
+// filled selection keeps its list shape, and an empty selection drops the
+// filter, on both the value and expression authoring paths.
 func TestRenderSemanticQuery_MultiSelectFilter(t *testing.T) {
 	query := sem.Query{
 		Filters: []sem.Filter{{
@@ -45,6 +44,21 @@ func TestRenderSemanticQuery_MultiSelectFilter(t *testing.T) {
 		}
 		if len(out.Filters) != 0 {
 			t.Fatalf("expected empty multi-select to drop the filter, got %d filters", len(out.Filters))
+		}
+	})
+
+	t.Run("empty selection drops an expression filter", func(t *testing.T) {
+		exprQuery := sem.Query{
+			Filters: []sem.Filter{{
+				Expression: "platform IN ('{{ filters.platform | join(\"','\") }}')",
+			}},
+		}
+		out, err := renderSemanticQuery(exprQuery, map[string]any{"platform": []interface{}{}})
+		if err != nil {
+			t.Fatalf("renderSemanticQuery: %v", err)
+		}
+		if len(out.Filters) != 0 {
+			t.Fatalf("expected empty selection to drop the expression filter, got %d", len(out.Filters))
 		}
 	})
 

--- a/pkg/server/semantic_filter_test.go
+++ b/pkg/server/semantic_filter_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"testing"
+
+	sem "github.com/bruin-data/bruin/semantic-engine"
+)
+
+// TestRenderSemanticQuery_MultiSelectFilter verifies that a multi-select
+// dashboard filter (a list value referenced via `{{ filters.x }}`) keeps its
+// list shape through templating, so the engine renders `IN ('a', 'b')` instead
+// of quoting the stringified list into broken SQL.
+func TestRenderSemanticQuery_MultiSelectFilter(t *testing.T) {
+	query := sem.Query{
+		Filters: []sem.Filter{{
+			Dimension: "platform",
+			Operator:  "in",
+			Value:     "{{ filters.platform }}",
+		}},
+	}
+
+	t.Run("filled list stays a list", func(t *testing.T) {
+		filters := map[string]any{"platform": []interface{}{"ios", "android"}}
+		out, err := renderSemanticQuery(query, filters)
+		if err != nil {
+			t.Fatalf("renderSemanticQuery: %v", err)
+		}
+		if len(out.Filters) != 1 {
+			t.Fatalf("expected 1 filter, got %d", len(out.Filters))
+		}
+		got, ok := out.Filters[0].Value.([]interface{})
+		if !ok {
+			t.Fatalf("expected []interface{} value, got %T (%v)", out.Filters[0].Value, out.Filters[0].Value)
+		}
+		if len(got) != 2 || got[0] != "ios" || got[1] != "android" {
+			t.Fatalf("unexpected value: %v", got)
+		}
+	})
+
+	t.Run("empty list drops the filter", func(t *testing.T) {
+		filters := map[string]any{"platform": []interface{}{}}
+		out, err := renderSemanticQuery(query, filters)
+		if err != nil {
+			t.Fatalf("renderSemanticQuery: %v", err)
+		}
+		if len(out.Filters) != 0 {
+			t.Fatalf("expected empty multi-select to drop the filter, got %d filters", len(out.Filters))
+		}
+	})
+
+	t.Run("scalar still renders to a string", func(t *testing.T) {
+		filters := map[string]any{"platform": "ios"}
+		out, err := renderSemanticQuery(query, filters)
+		if err != nil {
+			t.Fatalf("renderSemanticQuery: %v", err)
+		}
+		if len(out.Filters) != 1 {
+			t.Fatalf("expected 1 filter, got %d", len(out.Filters))
+		}
+		if out.Filters[0].Value != "ios" {
+			t.Fatalf("expected scalar \"ios\", got %T (%v)", out.Filters[0].Value, out.Filters[0].Value)
+		}
+	})
+}


### PR DESCRIPTION
Multi-select dashboard filters never worked on semantic widgets: filled → SQL syntax error, empty → silently zero rows. Single-select and date filters were unaffected.

Root cause: a filter authored `value: "{{ filters.x }}"` was rendered through gonja, which stringifies a list to `['a', 'b']`. The engine then treated that as one scalar and quoted it into `IN ('['a', 'b']')`, so the list shape was lost before the SQL was built.

- Resolve a lone `{{ filters.<key> }}` reference to its native list so it reaches the engine as a list → `IN ('a', 'b')`. Templates with surrounding text or a `| join` pipe still render to a string.
- Drop an empty multi-select so it applies no constraint (show all) instead of emitting `IN ()`.

Adds `semantic_filter_test.go` (filled / empty / scalar). `go vet` clean, full `pkg/server` suite passes.