### PR TITLE
BRU-6471: fix multi-select filters on semantic widgets

### DIFF
--- a/pkg/server/semantic.go
+++ b/pkg/server/semantic.go
@@ -159,18 +159,23 @@ func renderSemanticQuery(query sem.Query, filters map[string]any) (sem.Query, er
 		return rendered, nil
 	}
 
-	rendered.Filters = make([]sem.Filter, len(query.Filters))
-	for i, filter := range query.Filters {
-		rendered.Filters[i] = filter
+	rendered.Filters = make([]sem.Filter, 0, len(query.Filters))
+	for _, filter := range query.Filters {
+		// Empty multi-select: apply no constraint instead of IN () / IN ('').
+		if filterSelectionEmpty(filter, filters) {
+			continue
+		}
+		rf := filter
 		var err error
-		rendered.Filters[i].Expression, err = renderTemplateString(filter.Expression, filters)
+		rf.Expression, err = renderTemplateString(filter.Expression, filters)
 		if err != nil {
 			return sem.Query{}, fmt.Errorf("rendering filter expression: %w", err)
 		}
-		rendered.Filters[i].Value, err = renderTemplateValue(filter.Value, filters)
+		rf.Value, err = renderTemplateValue(filter.Value, filters)
 		if err != nil {
 			return sem.Query{}, fmt.Errorf("rendering filter value: %w", err)
 		}
+		rendered.Filters = append(rendered.Filters, rf)
 	}
 
 	return rendered, nil
@@ -185,9 +190,42 @@ func renderTemplateString(value string, filters map[string]any) (string, error) 
 	return tmpl.Render(value, filters)
 }
 
+// filterSelectionEmpty reports whether the filter references an empty
+// multi-select, so it can be dropped instead of rendering an empty IN clause.
+func filterSelectionEmpty(f sem.Filter, filters map[string]any) bool {
+	text := f.Expression
+	if s, ok := f.Value.(string); ok {
+		text += " " + s
+	}
+	for name, v := range filters {
+		if isEmptyList(v) && strings.Contains(text, "filters."+name) {
+			return true
+		}
+	}
+	return false
+}
+
+// bareFilterRef returns the key of a lone `{{ filters.<key> }}` reference; the
+// caller confirms it via map lookup, so junk keys harmlessly miss.
+func bareFilterRef(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "{{") || !strings.HasSuffix(s, "}}") {
+		return "", false
+	}
+	inner := strings.TrimSpace(s[2 : len(s)-2])
+	return strings.TrimPrefix(inner, "filters."), strings.HasPrefix(inner, "filters.")
+}
+
 func renderTemplateValue(value any, filters map[string]any) (any, error) {
 	switch typed := value.(type) {
 	case string:
+		// Keep a lone list reference as a list; gonja would stringify it to
+		// `['a', 'b']`, which the engine then quotes into broken SQL.
+		if key, ok := bareFilterRef(typed); ok {
+			if v, ok := filters[key]; ok && isList(v) {
+				return v, nil
+			}
+		}
 		return renderTemplateString(typed, filters)
 	case []string:
 		out := make([]string, len(typed))
@@ -222,4 +260,22 @@ func renderTemplateValue(value any, filters map[string]any) (any, error) {
 	default:
 		return value, nil
 	}
+}
+
+func isList(v any) bool {
+	switch v.(type) {
+	case []string, []interface{}:
+		return true
+	}
+	return false
+}
+
+func isEmptyList(v any) bool {
+	switch typed := v.(type) {
+	case []string:
+		return len(typed) == 0
+	case []interface{}:
+		return len(typed) == 0
+	}
+	return false
 }

--- a/pkg/server/semantic.go
+++ b/pkg/server/semantic.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	sem "github.com/bruin-data/bruin/semantic-engine"
@@ -190,6 +191,10 @@ func renderTemplateString(value string, filters map[string]any) (string, error) 
 	return tmpl.Render(value, filters)
 }
 
+// filterRef matches a whole `filters.<name>` token (\b treats `_` as a word
+// char, so `filters.team` won't match inside `filters.team_id`).
+var filterRef = regexp.MustCompile(`\bfilters\.(\w+)\b`)
+
 // filterSelectionEmpty reports whether the filter references an empty
 // multi-select, so it can be dropped instead of rendering an empty IN clause.
 func filterSelectionEmpty(f sem.Filter, filters map[string]any) bool {
@@ -197,33 +202,12 @@ func filterSelectionEmpty(f sem.Filter, filters map[string]any) bool {
 	if s, ok := f.Value.(string); ok {
 		text += " " + s
 	}
-	for name, v := range filters {
-		if isEmptyList(v) && referencesFilter(text, name) {
+	for _, m := range filterRef.FindAllStringSubmatch(text, -1) {
+		if isEmptyList(filters[m[1]]) {
 			return true
 		}
 	}
 	return false
-}
-
-// referencesFilter reports whether text contains a `filters.<name>` reference as
-// a whole token, so an empty `team` doesn't match `filters.team_id`.
-func referencesFilter(text, name string) bool {
-	ref := "filters." + name
-	for i := 0; ; {
-		j := strings.Index(text[i:], ref)
-		if j < 0 {
-			return false
-		}
-		end := i + j + len(ref)
-		if end == len(text) || !isIdentByte(text[end]) {
-			return true
-		}
-		i = end
-	}
-}
-
-func isIdentByte(b byte) bool {
-	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
 // bareFilterRef returns the key of a lone `{{ filters.<key> }}` reference; the

--- a/pkg/server/semantic.go
+++ b/pkg/server/semantic.go
@@ -198,11 +198,32 @@ func filterSelectionEmpty(f sem.Filter, filters map[string]any) bool {
 		text += " " + s
 	}
 	for name, v := range filters {
-		if isEmptyList(v) && strings.Contains(text, "filters."+name) {
+		if isEmptyList(v) && referencesFilter(text, name) {
 			return true
 		}
 	}
 	return false
+}
+
+// referencesFilter reports whether text contains a `filters.<name>` reference as
+// a whole token, so an empty `team` doesn't match `filters.team_id`.
+func referencesFilter(text, name string) bool {
+	ref := "filters." + name
+	for i := 0; ; {
+		j := strings.Index(text[i:], ref)
+		if j < 0 {
+			return false
+		}
+		end := i + j + len(ref)
+		if end == len(text) || !isIdentByte(text[end]) {
+			return true
+		}
+		i = end
+	}
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
 // bareFilterRef returns the key of a lone `{{ filters.<key> }}` reference; the

--- a/pkg/server/semantic_filter_test.go
+++ b/pkg/server/semantic_filter_test.go
@@ -47,6 +47,25 @@ func TestRenderSemanticQuery_MultiSelectFilter(t *testing.T) {
 		}
 	})
 
+	t.Run("empty prefix name keeps a different filter's constraint", func(t *testing.T) {
+		q := sem.Query{Filters: []sem.Filter{{
+			Dimension: "team_id",
+			Operator:  "in",
+			Value:     "{{ filters.team_id }}",
+		}}}
+		// team is empty, team_id is not: team must not drop the team_id filter.
+		out, err := renderSemanticQuery(q, map[string]any{
+			"team":    []interface{}{},
+			"team_id": []interface{}{"7"},
+		})
+		if err != nil {
+			t.Fatalf("renderSemanticQuery: %v", err)
+		}
+		if len(out.Filters) != 1 {
+			t.Fatalf("expected team_id filter to survive, got %d filters", len(out.Filters))
+		}
+	})
+
 	t.Run("empty selection drops an expression filter", func(t *testing.T) {
 		exprQuery := sem.Query{
 			Filters: []sem.Filter{{

--- a/pkg/server/semantic_filter_test.go
+++ b/pkg/server/semantic_filter_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"testing"
+
+	sem "github.com/bruin-data/bruin/semantic-engine"
+)
+
+// TestRenderSemanticQuery_MultiSelectFilter covers multi-select filters: a
+// filled selection keeps its list shape, and an empty selection drops the
+// filter, on both the value and expression authoring paths.
+func TestRenderSemanticQuery_MultiSelectFilter(t *testing.T) {
+	query := sem.Query{
+		Filters: []sem.Filter{{
+			Dimension: "platform",
+			Operator:  "in",
+			Value:     "{{ filters.platform }}",
+		}},
+	}
+
+	t.Run("filled list stays a list", func(t *testing.T) {
+		filters := map[string]any{"platform": []interface{}{"ios", "android"}}
+		out, err := renderSemanticQuery(query, filters)
+		if err != nil {
+			t.Fatalf("renderSemanticQuery: %v", err)
+		}
+		if len(out.Filters) != 1 {
+			t.Fatalf("expected 1 filter, got %d", len(out.Filters))
+		}
+		got, ok := out.Filters[0].Value.([]interface{})
+		if !ok {
+			t.Fatalf("expected []interface{} value, got %T (%v)", out.Filters[0].Value, out.Filters[0].Value)
+		}
+		if len(got) != 2 || got[0] != "ios" || got[1] != "android" {
+			t.Fatalf("unexpected value: %v", got)
+		}
+	})
+
+	t.Run("empty list drops the filter", func(t *testing.T) {
+		filters := map[string]any{"platform": []interface{}{}}
+		out, err := renderSemanticQuery(query, filters)
+		if err != nil {
+			t.Fatalf("renderSemanticQuery: %v", err)
+		}
+		if len(out.Filters) != 0 {
+			t.Fatalf("expected empty multi-select to drop the filter, got %d filters", len(out.Filters))
+		}
+	})
+
+	t.Run("empty selection drops an expression filter", func(t *testing.T) {
+		exprQuery := sem.Query{
+			Filters: []sem.Filter{{
+				Expression: "platform IN ('{{ filters.platform | join(\"','\") }}')",
+			}},
+		}
+		out, err := renderSemanticQuery(exprQuery, map[string]any{"platform": []interface{}{}})
+		if err != nil {
+			t.Fatalf("renderSemanticQuery: %v", err)
+		}
+		if len(out.Filters) != 0 {
+			t.Fatalf("expected empty selection to drop the expression filter, got %d", len(out.Filters))
+		}
+	})
+
+	t.Run("scalar still renders to a string", func(t *testing.T) {
+		filters := map[string]any{"platform": "ios"}
+		out, err := renderSemanticQuery(query, filters)
+		if err != nil {
+			t.Fatalf("renderSemanticQuery: %v", err)
+		}
+		if len(out.Filters) != 1 {
+			t.Fatalf("expected 1 filter, got %d", len(out.Filters))
+		}
+		if out.Filters[0].Value != "ios" {
+			t.Fatalf("expected scalar \"ios\", got %T (%v)", out.Filters[0].Value, out.Filters[0].Value)
+		}
+	})
+}
+
+// TestRenderTemplateValue_ListRefOnlyWhenBare checks that only a lone
+// `{{ filters.x }}` keeps its list; anything with a pipe, dotted path, or extra
+// text renders to a string instead.
+func TestRenderTemplateValue_ListRefOnlyWhenBare(t *testing.T) {
+	filters := map[string]any{"channel": []interface{}{"online", "retail"}}
+
+	if got, _ := renderTemplateValue("{{ filters.channel }}", filters); !isList(got) {
+		t.Errorf("bare reference should stay a list, got %T (%v)", got, got)
+	}
+
+	for _, in := range []string{
+		"{{ filters.channel | join(\"','\") }}",
+		"prefix {{ filters.channel }}",
+	} {
+		got, err := renderTemplateValue(in, filters)
+		if err != nil {
+			t.Fatalf("renderTemplateValue(%q): %v", in, err)
+		}
+		if _, ok := got.(string); !ok {
+			t.Errorf("renderTemplateValue(%q) = %T, want rendered string", in, got)
+		}
+	}
+}


### PR DESCRIPTION
Multi-select dashboard filters never worked on semantic widgets: filled → SQL error, empty → silently zero rows. Single-select and date filters were unaffected.

A filter authored `value: "{{ filters.x }}"` was rendered through gonja, which stringifies a list to `['a', 'b']`. The engine then treated that as one scalar and quoted it into `IN ('['a', 'b']')`, so the list shape was lost before the SQL was built.

- Keep a lone `{{ filters.<key> }}` reference as its native list so it reaches the engine as a list → `IN ('a', 'b')` (escaped by the engine). Templates with surrounding text or a `| join` pipe still render to a string.
- Drop a filter whose referenced multi-select is empty (in either `value` or `expression`) so it applies no constraint instead of `IN ()` / `IN ('')`.

Adds tests for filled / empty / scalar and the bare-vs-rendered reference distinction. `gofmt`/`vet` clean; `pkg/server` suite passes.