### PR TITLE
Add table column border divider option

### DIFF
--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -369,6 +369,7 @@ Table column fields:
 | `name` | string | Result column name (must match the SQL output) |
 | `label` | string | Display header (defaults to `name`) |
 | `align` | string | Text alignment override: `left`, `center`, or `right`. Applies to the column header and its body cells. Use it to right-align a text value like `£177K` that isn't detected as numeric. |
+| `border` | string | Non-colour vertical divider on this column's `left`, `right`, or `both` edge, to separate column groups. |
 | `hidden` | boolean | Keep the column in the result but don't render it, see [Hidden columns](#hidden-columns) |
 | `format` | string \| object | Value display and conditional coloring, see below |
 
@@ -446,6 +447,7 @@ the condition; without `if`, the layer styles every cell.
 |-----|--------------|
 | `number` | Value display: `currency`, `number`, or a d3-format string. |
 | `align` | Text alignment: `left`, `center`, or `right` (aligns the header and body cells). |
+| `border` | Non-colour vertical divider on the column's `left`, `right`, or `both` edge, to separate column groups. |
 | `like` | Mirror another column's coloring, driven by that column's per-row value (keeps own `number`). |
 | `hidden` | Keep the column in the result (so it can drive cross-column rules or be a `like` source) but don't render it. |
 | `format` | Ordered list of style layers; first match wins. |

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -369,7 +369,7 @@ Table column fields:
 | `name` | string | Result column name (must match the SQL output) |
 | `label` | string | Display header (defaults to `name`) |
 | `align` | string | Text alignment override: `left`, `center`, or `right`. Applies to the column header and its body cells. Use it to right-align a text value like `£177K` that isn't detected as numeric. |
-| `border` | string | Non-colour vertical divider on this column's `left`, `right`, or `both` edge, to separate column groups. |
+| `border` | string | Non-colour vertical divider on this column's `left`, `right`, or `both` edge, to separate column groups (plain tables only; not `pivot_table`). |
 | `hidden` | boolean | Keep the column in the result but don't render it, see [Hidden columns](#hidden-columns) |
 | `format` | string \| object | Value display and conditional coloring, see below |
 
@@ -447,7 +447,7 @@ the condition; without `if`, the layer styles every cell.
 |-----|--------------|
 | `number` | Value display: `currency`, `number`, or a d3-format string. |
 | `align` | Text alignment: `left`, `center`, or `right` (aligns the header and body cells). |
-| `border` | Non-colour vertical divider on the column's `left`, `right`, or `both` edge, to separate column groups. |
+| `border` | Non-colour vertical divider on the column's `left`, `right`, or `both` edge, to separate column groups (plain tables only; not `pivot_table`). |
 | `like` | Mirror another column's coloring, driven by that column's per-row value (keeps own `number`). |
 | `hidden` | Keep the column in the result (so it can drive cross-column rules or be a `like` source) but don't render it. |
 | `format` | Ordered list of style layers; first match wins. |

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -112,9 +112,7 @@ export function TableWidget({ widget, data }: Props) {
 
   // Per-column `border: left|right|both` group-divider classes, de-duping an
   // adjacent right+left pair into one line (border-separate would draw two).
-  // Plain tables only — a pivot draws its own dividers.
   const borderClasses = useMemo(() => {
-    if (pivot) return columns.map(() => "");
     const want = columns.map((c) => ({
       left: c.border === "left" || c.border === "both",
       right: c.border === "right" || c.border === "both",
@@ -127,7 +125,7 @@ export function TableWidget({ widget, data }: Props) {
         .filter(Boolean)
         .join(" "),
     );
-  }, [columns, pivot]);
+  }, [columns]);
 
   const rows = effData?.rows ?? [];
 

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -112,7 +112,9 @@ export function TableWidget({ widget, data }: Props) {
 
   // Per-column `border: left|right|both` group-divider classes, de-duping an
   // adjacent right+left pair into one line (border-separate would draw two).
+  // Plain tables only — pivots reject `border` (see validator).
   const borderClasses = useMemo(() => {
+    if (pivot) return columns.map(() => "");
     const want = columns.map((c) => ({
       left: c.border === "left" || c.border === "both",
       right: c.border === "right" || c.border === "both",
@@ -125,7 +127,7 @@ export function TableWidget({ widget, data }: Props) {
         .filter(Boolean)
         .join(" "),
     );
-  }, [columns]);
+  }, [columns, pivot]);
 
   const rows = effData?.rows ?? [];
 

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -22,6 +22,7 @@ interface TableColumn {
   label: string;
   number?: string; // value display (currency | number | d3-format)
   align?: "left" | "center" | "right"; // text-alignment override (header + body)
+  border?: "left" | "right" | "both"; // non-colour vertical group divider on this edge
   format?: FormatLayer[]; // effective layers (own, or the mirrored column's if `like`)
   idx: number; // own data index (drives the displayed value)
   colorIdx: number; // data index whose value drives coloring (own, or `like` source)
@@ -65,6 +66,7 @@ export function TableWidget({ widget, data }: Props) {
               label: m?.label || col.name,
               number: m?.number,
               align: m?.align,
+              border: m?.border,
               like: m?.like,
               hidden: m?.hidden ?? false,
               format: m?.format,
@@ -76,6 +78,7 @@ export function TableWidget({ widget, data }: Props) {
             label: col.label || col.name,
             number: col.number,
             align: col.align,
+            border: col.border,
             like: col.like,
             hidden: col.hidden ?? false,
             format: col.format,
@@ -106,6 +109,25 @@ export function TableWidget({ widget, data }: Props) {
       })
       .filter((c) => !c.hidden);
   }, [widget.columns, effData?.columns]);
+
+  // Per-column `border: left|right|both` group-divider classes, de-duping an
+  // adjacent right+left pair into one line (border-separate would draw two).
+  // Plain tables only — a pivot draws its own dividers.
+  const borderClasses = useMemo(() => {
+    if (pivot) return columns.map(() => "");
+    const want = columns.map((c) => ({
+      left: c.border === "left" || c.border === "both",
+      right: c.border === "right" || c.border === "both",
+    }));
+    for (let i = 0; i < want.length - 1; i++) {
+      if (want[i].right && want[i + 1].left) want[i].right = false;
+    }
+    return want.map((w) =>
+      [w.left ? "border-l-2 border-[var(--dac-border)]" : "", w.right ? "border-r-2 border-[var(--dac-border)]" : ""]
+        .filter(Boolean)
+        .join(" "),
+    );
+  }, [columns, pivot]);
 
   const rows = effData?.rows ?? [];
 
@@ -245,7 +267,7 @@ export function TableWidget({ widget, data }: Props) {
       <table className="w-full text-[13px] min-w-[400px] border-separate [border-spacing:1px_1px]">
         <thead>
           <tr className="bg-[var(--dac-surface)]">
-            {columns.map((col) => {
+            {columns.map((col, ci) => {
               const numeric = col.number != null;
               const active = sort?.column === col.name;
               const alignCls = alignClasses(col.align, numeric);
@@ -259,7 +281,7 @@ export function TableWidget({ widget, data }: Props) {
                         : "descending"
                       : "none"
                   }
-                  className={`py-0 px-0 whitespace-nowrap ${alignCls.text}`}
+                  className={`py-0 px-0 whitespace-nowrap ${alignCls.text} ${borderClasses[ci]}`}
                 >
                   <button
                     type="button"
@@ -284,7 +306,7 @@ export function TableWidget({ widget, data }: Props) {
               key={i}
               className={`transition-colors duration-75 ${totalRow ? "bg-[var(--dac-surface)]" : subtotalRow ? "bg-[var(--dac-surface)]/60" : "hover:bg-[var(--dac-surface)]"}`}
             >
-              {columns.map((col) => {
+              {columns.map((col, ci) => {
                 const numeric = col.number != null;
                 const alignCls = alignClasses(col.align, numeric);
                 const raw = col.idx >= 0 ? row[col.idx] : null; // displayed value (own column)
@@ -307,7 +329,7 @@ export function TableWidget({ widget, data }: Props) {
                     key={col.name}
                     className={`py-1.5 px-4 whitespace-nowrap align-middle rounded-none ${alignCls.text} ${
                       numeric ? "tabular-nums text-[12px]" : ""
-                    } ${totalRow || colIsTotal(col.idx) ? "font-bold" : ""}`}
+                    } ${totalRow || colIsTotal(col.idx) ? "font-bold" : ""} ${borderClasses[ci]}`}
                     style={Object.keys(style).length ? style : undefined}
                   >
                     {formatCell(raw, col.number, numberFormatters.get(col.name))}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -147,6 +147,8 @@ export interface TableColumn {
   hidden?: boolean;
   /** Text alignment override — applies to the header and body cells. */
   align?: 'left' | 'center' | 'right';
+  /** Non-colour vertical divider on this column's edge, to separate column groups. */
+  border?: 'left' | 'right' | 'both';
   /** Ordered style layers; the first layer that matches a cell wins. */
   format?: FormatLayer[];
 }

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -1000,6 +1000,7 @@ func asTableColumns(v interface{}) []TableColumn {
 				Label:  asString(m["label"]),
 				Number: asString(m["number"]),
 				Align:  asString(m["align"]),
+				Border: asString(m["border"]),
 				Like:   asString(m["like"]),
 				Hidden: asBool(m["hidden"]),
 			}

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -359,7 +359,7 @@ export default (
         sql="SELECT * FROM orders"
         columns={[
           { name: "id", label: "Order ID" },
-          { name: "amount", label: "Amount", number: "currency" },
+          { name: "amount", label: "Amount", number: "currency", border: "left" },
           { name: "target", hidden: true },
         ]} />
     </Row>
@@ -378,6 +378,9 @@ export default (
 	}
 	if w.Columns[1].Number != "currency" {
 		t.Errorf("expected number %q, got %+v", "currency", w.Columns[1].Number)
+	}
+	if w.Columns[1].Border != "left" {
+		t.Errorf("expected border %q, got %+v", "left", w.Columns[1].Border)
 	}
 	if !w.Columns[2].Hidden {
 		t.Errorf("expected target column to be hidden, got %+v", w.Columns[2])

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -227,6 +227,7 @@ type TableColumn struct {
 	Like   string        `yaml:"like,omitempty" json:"like,omitempty"`     // mirror another column's coloring + per-row value
 	Hidden bool          `yaml:"hidden,omitempty" json:"hidden,omitempty"` // keep the column in the result (for cross-column rules / like) but don't render it
 	Align  string        `yaml:"align,omitempty" json:"align,omitempty"`   // text alignment override: left | center | right (applies to the header and body cells)
+	Border string        `yaml:"border,omitempty" json:"border,omitempty"` // non-colour vertical group divider on this column's edge: left | right | both
 	Format []FormatLayer `yaml:"format,omitempty" json:"format,omitempty"` // ordered conditional-format style layers; first match wins
 }
 
@@ -269,12 +270,13 @@ func (c *TableColumn) UnmarshalYAML(node *yaml.Node) error {
 		Like   string    `yaml:"like,omitempty"`
 		Hidden bool      `yaml:"hidden,omitempty"`
 		Align  string    `yaml:"align,omitempty"`
+		Border string    `yaml:"border,omitempty"`
 		Format yaml.Node `yaml:"format,omitempty"`
 	}
 	if err := node.Decode(&tmp); err != nil {
 		return err
 	}
-	*c = TableColumn{Name: tmp.Name, Label: tmp.Label, Number: tmp.Number, Like: tmp.Like, Hidden: tmp.Hidden, Align: tmp.Align}
+	*c = TableColumn{Name: tmp.Name, Label: tmp.Label, Number: tmp.Number, Like: tmp.Like, Hidden: tmp.Hidden, Align: tmp.Align, Border: tmp.Border}
 
 	// Follow a YAML alias to its target, then: a scalar is the legacy value-display
 	// shorthand (folds into `number`); a list is the style layers.

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -771,8 +771,12 @@ func validateTableColumns(prefix string, w *Widget, errs *[]string) {
 		if c.Align != "" && c.Align != "left" && c.Align != "center" && c.Align != "right" {
 			*errs = append(*errs, fmt.Sprintf("%s.align: must be left, center, or right", cp))
 		}
-		if c.Border != "" && c.Border != "left" && c.Border != "right" && c.Border != "both" {
-			*errs = append(*errs, fmt.Sprintf("%s.border: must be left, right, or both", cp))
+		if c.Border != "" {
+			if w.Type == WidgetTypePivotTable {
+				*errs = append(*errs, cp+".border: not supported on pivot tables")
+			} else if c.Border != "left" && c.Border != "right" && c.Border != "both" {
+				*errs = append(*errs, fmt.Sprintf("%s.border: must be left, right, or both", cp))
+			}
 		}
 		for i, layer := range c.Format {
 			validateFormatLayer(fmt.Sprintf("%s.format[%d]", cp, i), layer, false, errs)

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -771,6 +771,9 @@ func validateTableColumns(prefix string, w *Widget, errs *[]string) {
 		if c.Align != "" && c.Align != "left" && c.Align != "center" && c.Align != "right" {
 			*errs = append(*errs, fmt.Sprintf("%s.align: must be left, center, or right", cp))
 		}
+		if c.Border != "" && c.Border != "left" && c.Border != "right" && c.Border != "both" {
+			*errs = append(*errs, fmt.Sprintf("%s.border: must be left, right, or both", cp))
+		}
 		for i, layer := range c.Format {
 			validateFormatLayer(fmt.Sprintf("%s.format[%d]", cp, i), layer, false, errs)
 		}

--- a/pkg/dashboard/validator_test.go
+++ b/pkg/dashboard/validator_test.go
@@ -473,6 +473,19 @@ func TestValidate_PivotScaleBy(t *testing.T) {
 	assertValidationContains(t, Validate(tbl), "scaleBy: only valid on pivot value formats")
 }
 
+func TestValidate_TableColumnBorder(t *testing.T) {
+	tbl := func(border string) *Dashboard {
+		return &Dashboard{Name: "test", Rows: []Row{{Widgets: []Widget{{
+			Name: "w", Type: WidgetTypeTable, SQL: "SELECT sales FROM orders",
+			Columns: []TableColumn{{Name: "sales", Border: border}},
+		}}}}}
+	}
+	for _, v := range []string{"left", "right", "both"} {
+		assertNoErr(t, Validate(tbl(v)))
+	}
+	assertValidationContains(t, Validate(tbl("top")), "border: must be left, right, or both")
+}
+
 func TestValidate_PivotOnlyOnTables(t *testing.T) {
 	d := &Dashboard{
 		Name: "test",

--- a/pkg/dashboard/validator_test.go
+++ b/pkg/dashboard/validator_test.go
@@ -484,6 +484,14 @@ func TestValidate_TableColumnBorder(t *testing.T) {
 		assertNoErr(t, Validate(tbl(v)))
 	}
 	assertValidationContains(t, Validate(tbl("top")), "border: must be left, right, or both")
+
+	// border is table-only — rejected on pivot_table widgets.
+	pivot := &Dashboard{Name: "test", Rows: []Row{{Widgets: []Widget{{
+		Name: "w", Type: WidgetTypePivotTable, SQL: "SELECT region, sales FROM orders",
+		Pivot:   &PivotConfig{Rows: []PivotField{{Field: "region"}}, Values: []PivotValue{{Field: "sales"}}},
+		Columns: []TableColumn{{Name: "sales", Border: "left"}},
+	}}}}}
+	assertValidationContains(t, Validate(pivot), "border: not supported on pivot tables")
 }
 
 func TestValidate_PivotOnlyOnTables(t *testing.T) {

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -503,6 +503,9 @@
         "align": {
           "enum": ["left", "center", "right"]
         },
+        "border": {
+          "enum": ["left", "right", "both"]
+        },
         "format": {
           "oneOf": [
             { "type": "string" },


### PR DESCRIPTION
Adds an optional `border: left|right|both` field to dashboard table columns, drawing a non-colour vertical divider on that edge to separate column groups. Covers the schema, model, validator, TSX/JSX loader, and docs.