### PR TITLE
Use border wording for column group borders

### DIFF
--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -369,7 +369,7 @@ Table column fields:
 | `name` | string | Result column name (must match the SQL output) |
 | `label` | string | Display header (defaults to `name`) |
 | `align` | string | Text alignment override: `left`, `center`, or `right`. Applies to the column header and its body cells. Use it to right-align a text value like `£177K` that isn't detected as numeric. |
-| `border` | string | Non-colour vertical divider on this column's `left`, `right`, or `both` edge, to separate column groups (plain tables only; not `pivot_table`). |
+| `border` | string | Non-colour vertical border on this column's `left`, `right`, or `both` edge, to separate column groups (plain tables only; not `pivot_table`). |
 | `hidden` | boolean | Keep the column in the result but don't render it, see [Hidden columns](#hidden-columns) |
 | `format` | string \| object | Value display and conditional coloring, see below |
 
@@ -447,7 +447,7 @@ the condition; without `if`, the layer styles every cell.
 |-----|--------------|
 | `number` | Value display: `currency`, `number`, or a d3-format string. |
 | `align` | Text alignment: `left`, `center`, or `right` (aligns the header and body cells). |
-| `border` | Non-colour vertical divider on the column's `left`, `right`, or `both` edge, to separate column groups (plain tables only; not `pivot_table`). |
+| `border` | Non-colour vertical border on the column's `left`, `right`, or `both` edge, to separate column groups (plain tables only; not `pivot_table`). |
 | `like` | Mirror another column's coloring, driven by that column's per-row value (keeps own `number`). |
 | `hidden` | Keep the column in the result (so it can drive cross-column rules or be a `like` source) but don't render it. |
 | `format` | Ordered list of style layers; first match wins. |

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -22,7 +22,7 @@ interface TableColumn {
   label: string;
   number?: string; // value display (currency | number | d3-format)
   align?: "left" | "center" | "right"; // text-alignment override (header + body)
-  border?: "left" | "right" | "both"; // non-colour vertical group divider on this edge
+  border?: "left" | "right" | "both"; // non-colour vertical group border on this edge
   format?: FormatLayer[]; // effective layers (own, or the mirrored column's if `like`)
   idx: number; // own data index (drives the displayed value)
   colorIdx: number; // data index whose value drives coloring (own, or `like` source)
@@ -110,7 +110,7 @@ export function TableWidget({ widget, data }: Props) {
       .filter((c) => !c.hidden);
   }, [widget.columns, effData?.columns]);
 
-  // Per-column `border: left|right|both` group-divider classes, de-duping an
+  // Per-column `border: left|right|both` group-border classes, de-duping an
   // adjacent right+left pair into one line (border-separate would draw two).
   // Plain tables only — pivots reject `border` (see validator).
   const borderClasses = useMemo(() => {

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -147,7 +147,7 @@ export interface TableColumn {
   hidden?: boolean;
   /** Text alignment override — applies to the header and body cells. */
   align?: 'left' | 'center' | 'right';
-  /** Non-colour vertical divider on this column's edge, to separate column groups. */
+  /** Non-colour vertical border on this column's edge, to separate column groups. */
   border?: 'left' | 'right' | 'both';
   /** Ordered style layers; the first layer that matches a cell wins. */
   format?: FormatLayer[];

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -227,7 +227,7 @@ type TableColumn struct {
 	Like   string        `yaml:"like,omitempty" json:"like,omitempty"`     // mirror another column's coloring + per-row value
 	Hidden bool          `yaml:"hidden,omitempty" json:"hidden,omitempty"` // keep the column in the result (for cross-column rules / like) but don't render it
 	Align  string        `yaml:"align,omitempty" json:"align,omitempty"`   // text alignment override: left | center | right (applies to the header and body cells)
-	Border string        `yaml:"border,omitempty" json:"border,omitempty"` // non-colour vertical group divider on this column's edge: left | right | both
+	Border string        `yaml:"border,omitempty" json:"border,omitempty"` // non-colour vertical group border on this column's edge: left | right | both
 	Format []FormatLayer `yaml:"format,omitempty" json:"format,omitempty"` // ordered conditional-format style layers; first match wins
 }
 


### PR DESCRIPTION
Renames the leftover 'divider' wording for the table column `border` property to 'border' across the schema docs, Go model comment, and frontend, so it reads consistently and doesn't clash with the separate divider widget type.