### PR TITLE
Add pinned columns to dashboard tables

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -815,13 +815,14 @@ Data table with optional column configuration.
 
 If `columns` is omitted, all result columns are shown with their SQL names as headers.
 
-**Conditional formatting.** A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `align` (`left`/`center`/`right` — overrides the type-inferred alignment of the header and body cells, e.g. to right-align a text value like `£177K`), `like`, `hidden`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
+**Conditional formatting.** A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `align` (`left`/`center`/`right` — overrides the type-inferred alignment of the header and body cells, e.g. to right-align a text value like `£177K`), `like`, `hidden`, `frozen`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
 
 - With `if` (+ `value`), the layer styles only the cells that match. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
 - With no `if`, the layer styles every cell — a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put it last as the fallback.
 - Styles on any layer: `backgroundColor`, `textColor`, `bold`, `italic`, `underline`, `strikethrough`.
 - `like`: mirror another column's coloring, driven by that column's per-row value, while keeping this column's own `number`.
 - `hidden: true`: keep the column in the result but don't render it. Optional. Coloring reads a column whether or not it's shown, so hide only to drop it from the display, e.g. a `like` source you must declare but don't want visible.
+- `frozen: true`: freeze the column to the left so it stays visible while scrolling. Optional. Frozen columns render first, in their listed order (plain tables only; not `pivot_table`).
 
 Each layer is a YAML object, so `- { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }` and the same keys written as an indented block are identical — use whichever reads better.
 

--- a/cmd/skill_templates/create-dashboard/SKILL.md
+++ b/cmd/skill_templates/create-dashboard/SKILL.md
@@ -103,13 +103,14 @@ rows:
 
 Widget types are `metric`, `chart`, `table`, `pivot_table`, `text`, `divider`, and `image`.
 
-A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `align` (`left`/`center`/`right` — overrides the type-inferred alignment of the header and body cells, e.g. to right-align a text value like `£177K`), `like`, `hidden`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
+A `table` column takes `name`, `label`, `number` (value format: `number`, `currency`, or a d3-format string), `align` (`left`/`center`/`right` — overrides the type-inferred alignment of the header and body cells, e.g. to right-align a text value like `£177K`), `like`, `hidden`, `frozen`, and `format`. `format` is an **ordered list of layers**; for each cell the **first layer that matches wins**. A scalar `format` string (e.g. `format: currency`) is also accepted as a legacy alias for `number` — prefer `number` in new dashboards.
 
 - With `if` (+ `value`), the layer styles only the cells that match. `value` is a scalar, `[low, high]` for `is_between`/`is_not_between`, `{ column: <name> }` to compare against another column in the same row, or omitted for empty checks. Operators: `is_empty`, `is_not_empty`, `text_contains`/`text_does_not_contain`/`text_starts_with`/`text_ends_with`/`text_is_exactly`, `date_is`/`date_before`/`date_after` (by day, or exact instant with a time), `greater_than`/`greater_than_or_equal`/`less_than`/`less_than_or_equal`, `is_equal_to`/`is_not_equal_to`, `is_between`/`is_not_between`.
 - With no `if`, the layer styles every cell — a **gradient** (`backgroundColor` is a list of 2+ colors; optional `range` list + `unit` = `absolute`/`percent`/`percentile`, omit `range` for auto min/max) or a **flat fill** (`backgroundColor` is a string). Put it last as the fallback.
 - Styles on any layer: `backgroundColor`, `textColor`, `bold`, `italic`, `underline`, `strikethrough`.
 - `like`: mirror another column's coloring, driven by that column's per-row value, while keeping this column's own `number`.
 - `hidden: true`: keep the column in the result but don't render it. Optional. Coloring reads a column whether or not it's shown, so hide only to drop it from the display, e.g. a `like` source you must declare but don't want visible.
+- `frozen: true`: freeze the column to the left so it stays visible while scrolling. Optional. Frozen columns render first, in their listed order (plain tables only; not `pivot_table`).
 
 Each layer is a YAML object, so `- { backgroundColor: [red, white, green], range: [-25, 0, 25], unit: absolute }` and the same keys written as an indented block are identical — use whichever reads better.
 

--- a/docs/dashboards/widgets.md
+++ b/docs/dashboards/widgets.md
@@ -371,6 +371,7 @@ Table column fields:
 | `align` | string | Text alignment override: `left`, `center`, or `right`. Applies to the column header and its body cells. Use it to right-align a text value like `£177K` that isn't detected as numeric. |
 | `border` | string | Non-colour vertical border on this column's `left`, `right`, or `both` edge, to separate column groups (plain tables only; not `pivot_table`). |
 | `hidden` | boolean | Keep the column in the result but don't render it, see [Hidden columns](#hidden-columns) |
+| `frozen` | boolean | Freeze the column to the left so it stays visible while scrolling. Frozen columns render first, in their listed order (plain tables only; not `pivot_table`). |
 | `format` | string \| object | Value display and conditional coloring, see below |
 
 ### Pivot tables

--- a/frontend/src/components/widgets/TableWidget.tsx
+++ b/frontend/src/components/widgets/TableWidget.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type CSSProperties } from "react";
+import { useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { format as d3Format } from "d3-format";
 import type { FormatLayer, Widget, WidgetData } from "../../types/dashboard";
 import { useTokens } from "../../themes/TemplateProvider";
@@ -23,6 +23,7 @@ interface TableColumn {
   number?: string; // value display (currency | number | d3-format)
   align?: "left" | "center" | "right"; // text-alignment override (header + body)
   border?: "left" | "right" | "both"; // non-colour vertical group border on this edge
+  frozen?: boolean; // freeze to the left; frozen columns render first
   format?: FormatLayer[]; // effective layers (own, or the mirrored column's if `like`)
   idx: number; // own data index (drives the displayed value)
   colorIdx: number; // data index whose value drives coloring (own, or `like` source)
@@ -69,6 +70,7 @@ export function TableWidget({ widget, data }: Props) {
               border: m?.border,
               like: m?.like,
               hidden: m?.hidden ?? false,
+              frozen: m?.frozen ?? false,
               format: m?.format,
               idx,
             };
@@ -81,6 +83,7 @@ export function TableWidget({ widget, data }: Props) {
             border: col.border,
             like: col.like,
             hidden: col.hidden ?? false,
+            frozen: col.frozen ?? false,
             format: col.format,
             idx: effData.columns.findIndex((c) => c.name === col.name),
           }));
@@ -99,7 +102,7 @@ export function TableWidget({ widget, data }: Props) {
       return src?.like ? undefined : src;
     };
 
-    return raw
+    const resolved = raw
       .map((c) => {
         const src = c.like ? likeSource(c) : undefined;
         if (src) {
@@ -108,7 +111,12 @@ export function TableWidget({ widget, data }: Props) {
         return { ...c, colorIdx: c.idx };
       })
       .filter((c) => !c.hidden);
-  }, [widget.columns, effData?.columns]);
+
+    // Frozen columns render first, in listed order; not supported on pivots.
+    if (pivot) return resolved;
+    const frozen = resolved.filter((c) => c.frozen);
+    return frozen.length ? [...frozen, ...resolved.filter((c) => !c.frozen)] : resolved;
+  }, [widget.columns, effData?.columns, pivot]);
 
   // Per-column `border: left|right|both` group-border classes, de-duping an
   // adjacent right+left pair into one line (border-separate would draw two).
@@ -130,6 +138,53 @@ export function TableWidget({ widget, data }: Props) {
   }, [columns, pivot]);
 
   const rows = effData?.rows ?? [];
+
+  // Frozen columns render first and stick to the left; 0 on pivots.
+  const frozenCount = useMemo(() => (pivot ? 0 : columns.filter((c) => c.frozen).length), [columns, pivot]);
+  const headerRowRef = useRef<HTMLTableRowElement>(null);
+  const [frozenOffsets, setFrozenOffsets] = useState<number[]>([]);
+  useLayoutEffect(() => {
+    if (!frozenCount) {
+      setFrozenOffsets([]);
+      return;
+    }
+    let cancelled = false;
+    const recompute = () => {
+      const ths = headerRowRef.current?.children;
+      if (cancelled || !ths) return;
+      const offsets: number[] = [];
+      let acc = 0;
+      for (let i = 0; i < frozenCount; i++) {
+        offsets[i] = acc;
+        acc += (ths[i] as HTMLElement)?.getBoundingClientRect().width ?? 0; // no gap, so no seam bleeds
+      }
+      setFrozenOffsets(offsets);
+    };
+    recompute();
+    // Observe each cell, not the row: a w-full table can reflow (e.g. font load)
+    // without the row's box changing.
+    const ths = headerRowRef.current?.children;
+    let ro: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== "undefined" && ths) {
+      ro = new ResizeObserver(recompute);
+      for (let i = 0; i < ths.length; i++) ro.observe(ths[i]);
+    }
+    document.fonts?.ready.then(recompute).catch(() => {});
+    return () => {
+      cancelled = true;
+      ro?.disconnect();
+    };
+  }, [frozenCount, columns, rows]);
+
+  // Sticky position for a frozen cell; its opaque background is class-based (below).
+  const frozenStyle = (ci: number, header: boolean): CSSProperties | undefined => {
+    if (ci >= frozenCount) return undefined;
+    return { position: "sticky", left: frozenOffsets[ci] ?? 0, zIndex: header ? 2 : 1 };
+  };
+  // Opaque background for a frozen cell that still tracks row hover; a
+  // conditional-format colour (inline) still wins.
+  const frozenBgClass = (ci: number) =>
+    ci < frozenCount ? "bg-[var(--dac-background)] group-hover:bg-[var(--dac-surface)]" : "";
 
   // All data columns by name → index, so cross-column rules can reference any
   // column (even ones not shown).
@@ -266,7 +321,7 @@ export function TableWidget({ widget, data }: Props) {
     <div className="overflow-x-auto">
       <table className="w-full text-[13px] min-w-[400px] border-separate [border-spacing:1px_1px]">
         <thead>
-          <tr className="bg-[var(--dac-surface)]">
+          <tr ref={headerRowRef} className="bg-[var(--dac-surface)]">
             {columns.map((col, ci) => {
               const numeric = col.number != null;
               const active = sort?.column === col.name;
@@ -281,7 +336,8 @@ export function TableWidget({ widget, data }: Props) {
                         : "descending"
                       : "none"
                   }
-                  className={`py-0 px-0 whitespace-nowrap ${alignCls.text} ${borderClasses[ci]}`}
+                  className={`py-0 px-0 whitespace-nowrap ${alignCls.text} ${ci < frozenCount ? "bg-[var(--dac-surface)]" : ""} ${borderClasses[ci]}`}
+                  style={frozenStyle(ci, true)}
                 >
                   <button
                     type="button"
@@ -304,7 +360,7 @@ export function TableWidget({ widget, data }: Props) {
             return (
             <tr
               key={i}
-              className={`transition-colors duration-75 ${totalRow ? "bg-[var(--dac-surface)]" : subtotalRow ? "bg-[var(--dac-surface)]/60" : "hover:bg-[var(--dac-surface)]"}`}
+              className={`group transition-colors duration-75 ${totalRow ? "bg-[var(--dac-surface)]" : subtotalRow ? "bg-[var(--dac-surface)]/60" : "hover:bg-[var(--dac-surface)]"}`}
             >
               {columns.map((col, ci) => {
                 const numeric = col.number != null;
@@ -324,13 +380,16 @@ export function TableWidget({ widget, data }: Props) {
                   const colorRaw = col.colorIdx >= 0 ? row[col.colorIdx] : null;
                   Object.assign(style, cellStyle(col.format, scales.get(col.name) ?? [], colorRaw, tokens, lookup));
                 }
+                // Sticky position merges under conditional-format style so the cell colour wins.
+                const frozen = frozenStyle(ci, false);
+                const tdStyle = frozen ? { ...frozen, ...style } : Object.keys(style).length ? style : undefined;
                 return (
                   <td
                     key={col.name}
                     className={`py-1.5 px-4 whitespace-nowrap align-middle rounded-none ${alignCls.text} ${
                       numeric ? "tabular-nums text-[12px]" : ""
-                    } ${totalRow || colIsTotal(col.idx) ? "font-bold" : ""} ${borderClasses[ci]}`}
-                    style={Object.keys(style).length ? style : undefined}
+                    } ${totalRow || colIsTotal(col.idx) ? "font-bold" : ""} ${frozenBgClass(ci)} ${borderClasses[ci]}`}
+                    style={tdStyle}
                   >
                     {formatCell(raw, col.number, numberFormatters.get(col.name))}
                   </td>

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -149,6 +149,8 @@ export interface TableColumn {
   align?: 'left' | 'center' | 'right';
   /** Non-colour vertical border on this column's edge, to separate column groups. */
   border?: 'left' | 'right' | 'both';
+  /** Freeze the column to the left so it stays visible while scrolling. */
+  frozen?: boolean;
   /** Ordered style layers; the first layer that matches a cell wins. */
   format?: FormatLayer[];
 }

--- a/pkg/dashboard/jsloader.go
+++ b/pkg/dashboard/jsloader.go
@@ -1003,6 +1003,7 @@ func asTableColumns(v interface{}) []TableColumn {
 				Border: asString(m["border"]),
 				Like:   asString(m["like"]),
 				Hidden: asBool(m["hidden"]),
+				Frozen: asBool(m["frozen"]),
 			}
 			// `format` is polymorphic: a string is the legacy value-display
 			// shorthand (== `number`), a list is the style layers.

--- a/pkg/dashboard/jsloader_test.go
+++ b/pkg/dashboard/jsloader_test.go
@@ -358,7 +358,7 @@ export default (
       <Table name="Orders" col={12}
         sql="SELECT * FROM orders"
         columns={[
-          { name: "id", label: "Order ID" },
+          { name: "id", label: "Order ID", frozen: true },
           { name: "amount", label: "Amount", number: "currency", border: "left" },
           { name: "target", hidden: true },
         ]} />
@@ -375,6 +375,9 @@ export default (
 	}
 	if w.Columns[0].Name != "id" || w.Columns[0].Label != "Order ID" {
 		t.Errorf("unexpected column 0: %+v", w.Columns[0])
+	}
+	if !w.Columns[0].Frozen {
+		t.Errorf("expected id column to be frozen, got %+v", w.Columns[0])
 	}
 	if w.Columns[1].Number != "currency" {
 		t.Errorf("expected number %q, got %+v", "currency", w.Columns[1].Number)

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -228,6 +228,7 @@ type TableColumn struct {
 	Hidden bool          `yaml:"hidden,omitempty" json:"hidden,omitempty"` // keep the column in the result (for cross-column rules / like) but don't render it
 	Align  string        `yaml:"align,omitempty" json:"align,omitempty"`   // text alignment override: left | center | right (applies to the header and body cells)
 	Border string        `yaml:"border,omitempty" json:"border,omitempty"` // non-colour vertical group border on this column's edge: left | right | both
+	Frozen bool          `yaml:"frozen,omitempty" json:"frozen,omitempty"` // freeze the column to the left so it stays visible while scrolling
 	Format []FormatLayer `yaml:"format,omitempty" json:"format,omitempty"` // ordered conditional-format style layers; first match wins
 }
 
@@ -271,12 +272,13 @@ func (c *TableColumn) UnmarshalYAML(node *yaml.Node) error {
 		Hidden bool      `yaml:"hidden,omitempty"`
 		Align  string    `yaml:"align,omitempty"`
 		Border string    `yaml:"border,omitempty"`
+		Frozen bool      `yaml:"frozen,omitempty"`
 		Format yaml.Node `yaml:"format,omitempty"`
 	}
 	if err := node.Decode(&tmp); err != nil {
 		return err
 	}
-	*c = TableColumn{Name: tmp.Name, Label: tmp.Label, Number: tmp.Number, Like: tmp.Like, Hidden: tmp.Hidden, Align: tmp.Align, Border: tmp.Border}
+	*c = TableColumn{Name: tmp.Name, Label: tmp.Label, Number: tmp.Number, Like: tmp.Like, Hidden: tmp.Hidden, Align: tmp.Align, Border: tmp.Border, Frozen: tmp.Frozen}
 
 	// Follow a YAML alias to its target, then: a scalar is the legacy value-display
 	// shorthand (folds into `number`); a list is the style layers.

--- a/pkg/dashboard/validator.go
+++ b/pkg/dashboard/validator.go
@@ -778,6 +778,9 @@ func validateTableColumns(prefix string, w *Widget, errs *[]string) {
 				*errs = append(*errs, fmt.Sprintf("%s.border: must be left, right, or both", cp))
 			}
 		}
+		if c.Frozen && w.Type == WidgetTypePivotTable {
+			*errs = append(*errs, cp+".frozen: not supported on pivot tables")
+		}
 		for i, layer := range c.Format {
 			validateFormatLayer(fmt.Sprintf("%s.format[%d]", cp, i), layer, false, errs)
 		}

--- a/pkg/dashboard/validator_test.go
+++ b/pkg/dashboard/validator_test.go
@@ -494,6 +494,23 @@ func TestValidate_TableColumnBorder(t *testing.T) {
 	assertValidationContains(t, Validate(pivot), "border: not supported on pivot tables")
 }
 
+func TestValidate_TableColumnFrozen(t *testing.T) {
+	// frozen is accepted on plain tables.
+	tbl := &Dashboard{Name: "test", Rows: []Row{{Widgets: []Widget{{
+		Name: "w", Type: WidgetTypeTable, SQL: "SELECT sales FROM orders",
+		Columns: []TableColumn{{Name: "sales", Frozen: true}},
+	}}}}}
+	assertNoErr(t, Validate(tbl))
+
+	// frozen is table-only — rejected on pivot_table widgets.
+	pivot := &Dashboard{Name: "test", Rows: []Row{{Widgets: []Widget{{
+		Name: "w", Type: WidgetTypePivotTable, SQL: "SELECT region, sales FROM orders",
+		Pivot:   &PivotConfig{Rows: []PivotField{{Field: "region"}}, Values: []PivotValue{{Field: "sales"}}},
+		Columns: []TableColumn{{Name: "sales", Frozen: true}},
+	}}}}}
+	assertValidationContains(t, Validate(pivot), "frozen: not supported on pivot tables")
+}
+
 func TestValidate_PivotOnlyOnTables(t *testing.T) {
 	d := &Dashboard{
 		Name: "test",

--- a/schemas/dac/dashboard/v1/schema.json
+++ b/schemas/dac/dashboard/v1/schema.json
@@ -506,6 +506,9 @@
         "border": {
           "enum": ["left", "right", "both"]
         },
+        "frozen": {
+          "type": "boolean"
+        },
         "format": {
           "oneOf": [
             { "type": "string" },


### PR DESCRIPTION
Adds a per-column `pinned` boolean to table widgets that freezes the column to the left while scrolling. Pinned columns render first in the preview. Rejected on pivot tables (mirrors the existing `border` rule). Threaded through the schema, model, JS loader, and validator, with docs and tests.